### PR TITLE
[Feat] User 도메인 설계

### DIFF
--- a/src/main/java/org/sopt/bofit/BofitApplication.java
+++ b/src/main/java/org/sopt/bofit/BofitApplication.java
@@ -2,7 +2,9 @@ package org.sopt.bofit;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class BofitApplication {
 

--- a/src/main/java/org/sopt/bofit/domain/user/entity/User.java
+++ b/src/main/java/org/sopt/bofit/domain/user/entity/User.java
@@ -28,6 +28,8 @@ public class User extends BaseEntity {
 
     private String name;
 
+    private String nickname;
+
     @Column(unique = true)
     private String email;
 

--- a/src/main/java/org/sopt/bofit/domain/user/entity/User.java
+++ b/src/main/java/org/sopt/bofit/domain/user/entity/User.java
@@ -67,6 +67,4 @@ public class User extends BaseEntity {
     @Column(nullable = false)
     private UserStatus status = UserStatus.ACTIVE;
 
-
-
 }

--- a/src/main/java/org/sopt/bofit/domain/user/entity/User.java
+++ b/src/main/java/org/sopt/bofit/domain/user/entity/User.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.sopt.bofit.domain.user.entity.constant.Gender;
 import org.sopt.bofit.domain.user.entity.constant.Job;
+import org.sopt.bofit.domain.user.entity.constant.UserStatus;
 import org.sopt.bofit.global.entity.BaseEntity;
 
 @Entity
@@ -55,7 +56,9 @@ public class User extends BaseEntity {
     @Column(name = "is_registered")
     private boolean isRegistered;
 
-    private String status;
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private UserStatus status = UserStatus.ACTIVE;
 
 
 

--- a/src/main/java/org/sopt/bofit/domain/user/entity/User.java
+++ b/src/main/java/org/sopt/bofit/domain/user/entity/User.java
@@ -1,0 +1,58 @@
+package org.sopt.bofit.domain.user.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.sopt.bofit.global.entity.BaseEntity;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
+    private Long id;
+
+    @Column(unique = true, nullable = false)
+    private Long kakaoId;
+
+    private String name;
+
+    @Column(unique = true)
+    private String email;
+
+    @Column(name = "profile_image")
+    private String profileImage;
+
+    private String gender;
+
+    @Column(name = "birth_day")
+    private String birthDay;
+
+    @Column(name = "birth_year")
+    private String birthYear;
+
+    @Column(name = "phone_number")
+    private String phoneNumber;
+
+    private String job;
+
+    @Column(name = "is_married")
+    private boolean isMarried;
+
+    @Column(name = "is_driver")
+    private boolean isDriver;
+
+    @Column(name = "has_child")
+    private boolean hasChild;
+
+    @Column(name = "is_registered")
+    private boolean isRegistered;
+
+    private String status;
+
+
+
+}

--- a/src/main/java/org/sopt/bofit/domain/user/entity/User.java
+++ b/src/main/java/org/sopt/bofit/domain/user/entity/User.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.sopt.bofit.domain.user.entity.constant.Gender;
 import org.sopt.bofit.domain.user.entity.constant.Job;
+import org.sopt.bofit.domain.user.entity.constant.LoginProvider;
 import org.sopt.bofit.domain.user.entity.constant.UserStatus;
 import org.sopt.bofit.global.entity.BaseEntity;
 
@@ -18,8 +19,12 @@ public class User extends BaseEntity {
     @Column(name = "user_id")
     private Long id;
 
-    @Column(unique = true, nullable = false)
-    private Long kakaoId;
+    @Enumerated(EnumType.STRING)
+    @Column(name = "login_provider", nullable = false)
+    private LoginProvider loginProvider;
+
+    @Column(unique = true, nullable = false, name = "oauth_id")
+    private String oauthId;
 
     private String name;
 

--- a/src/main/java/org/sopt/bofit/domain/user/entity/User.java
+++ b/src/main/java/org/sopt/bofit/domain/user/entity/User.java
@@ -47,9 +47,6 @@ public class User extends BaseEntity {
     @Column(name = "birth_year")
     private int birthYear;
 
-    @Column(name = "phone_number")
-    private String phoneNumber;
-
     @Enumerated(EnumType.STRING)
     private Job job;
 

--- a/src/main/java/org/sopt/bofit/domain/user/entity/User.java
+++ b/src/main/java/org/sopt/bofit/domain/user/entity/User.java
@@ -2,6 +2,7 @@ package org.sopt.bofit.domain.user.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.sopt.bofit.domain.user.entity.constant.Gender;
 import org.sopt.bofit.global.entity.BaseEntity;
 
 @Entity
@@ -26,7 +27,8 @@ public class User extends BaseEntity {
     @Column(name = "profile_image")
     private String profileImage;
 
-    private String gender;
+    @Enumerated(EnumType.STRING)
+    private Gender gender;
 
     @Column(name = "birth_day")
     private String birthDay;

--- a/src/main/java/org/sopt/bofit/domain/user/entity/User.java
+++ b/src/main/java/org/sopt/bofit/domain/user/entity/User.java
@@ -8,6 +8,8 @@ import org.sopt.bofit.domain.user.entity.constant.LoginProvider;
 import org.sopt.bofit.domain.user.entity.constant.UserStatus;
 import org.sopt.bofit.global.entity.BaseEntity;
 
+import java.time.MonthDay;
+
 @Entity
 @Getter
 @Builder
@@ -40,10 +42,10 @@ public class User extends BaseEntity {
     private Gender gender;
 
     @Column(name = "birth_day")
-    private String birthDay;
+    private MonthDay birthDay;
 
     @Column(name = "birth_year")
-    private String birthYear;
+    private int birthYear;
 
     @Column(name = "phone_number")
     private String phoneNumber;

--- a/src/main/java/org/sopt/bofit/domain/user/entity/User.java
+++ b/src/main/java/org/sopt/bofit/domain/user/entity/User.java
@@ -3,6 +3,7 @@ package org.sopt.bofit.domain.user.entity;
 import jakarta.persistence.*;
 import lombok.*;
 import org.sopt.bofit.domain.user.entity.constant.Gender;
+import org.sopt.bofit.domain.user.entity.constant.Job;
 import org.sopt.bofit.global.entity.BaseEntity;
 
 @Entity
@@ -39,7 +40,8 @@ public class User extends BaseEntity {
     @Column(name = "phone_number")
     private String phoneNumber;
 
-    private String job;
+    @Enumerated(EnumType.STRING)
+    private Job job;
 
     @Column(name = "is_married")
     private boolean isMarried;

--- a/src/main/java/org/sopt/bofit/domain/user/entity/UserInfo.java
+++ b/src/main/java/org/sopt/bofit/domain/user/entity/UserInfo.java
@@ -1,0 +1,46 @@
+package org.sopt.bofit.domain.user.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.sopt.bofit.domain.user.entity.constant.ConveragePreference;
+import org.sopt.bofit.domain.user.entity.constant.DiagnosedDisease;
+import org.sopt.bofit.global.converter.CoveragePreferenceMapConverter;
+import org.sopt.bofit.global.converter.DiseaseEnumListJsonConverter;
+import org.sopt.bofit.global.entity.BaseEntity;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Entity
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@Table(name = "user_info")
+public class UserInfo extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    private int minPrice;
+
+    private int maxPrice;
+
+    @Convert(converter = DiseaseEnumListJsonConverter.class)
+    @Column(name = "diagnosed_diseases", columnDefinition = "JSON")
+    private List<DiagnosedDisease> diagnosedDiseases = new ArrayList<>();
+
+    @Convert(converter = DiseaseEnumListJsonConverter.class)
+    @Column(name = "family_history", columnDefinition = "JSON")
+    private List<DiagnosedDisease> familyHistory = new ArrayList<>();
+
+    @Convert(converter = CoveragePreferenceMapConverter.class)
+    @Column(name = "coverage_preference", columnDefinition = "JSON")
+    private Map<ConveragePreference, Integer> coveragePreferences = new LinkedHashMap<>();
+}

--- a/src/main/java/org/sopt/bofit/domain/user/entity/constant/ConveragePreference.java
+++ b/src/main/java/org/sopt/bofit/domain/user/entity/constant/ConveragePreference.java
@@ -1,0 +1,19 @@
+package org.sopt.bofit.domain.user.entity.constant;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ConveragePreference {
+    SERIOUS_DISEASE("암, 심장질환같은 큰 병에 대비"),
+    FAMILY_SUPPORT("가족에게 경제적 도움이 되는 보장"),
+    ESSENTIAL_ONLY("꼭 필요한 보장만 챙기고 싶음"),
+    ACCIDENT_PREDICTION("예기치 못한 사고에 대비"),
+    SURGERY_CONVERAGE("수술할 일이 생겼을 때 보장"),
+    MAXIMUM_CONVERAGE("폭넓은 보장을 받고 싶다"),
+    RECOMMENDED_OPTION("많이 선택하는 걸로 설정")
+    ;
+
+    private final String description;
+}

--- a/src/main/java/org/sopt/bofit/domain/user/entity/constant/DiagnosedDisease.java
+++ b/src/main/java/org/sopt/bofit/domain/user/entity/constant/DiagnosedDisease.java
@@ -1,0 +1,23 @@
+package org.sopt.bofit.domain.user.entity.constant;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum DiagnosedDisease {
+    CANCER("암",null),
+    CEREBROVASCULAR("뇌혈관질환","뇌출혈, 뇌경색"),
+    HEART("심장질환",null),
+    RESPIRATORY("호흡기질환", null),
+    RIVER("간질환", null),
+    KIDNEY("신장질환", null),
+    MENTAL("정신질환", null),
+    CHRONIC("만성질환", "고혈압, 당뇨 등"),
+    NONE("해당 없음", null)
+    ;
+
+
+    private final String diseaseName;
+    private final String description;
+}

--- a/src/main/java/org/sopt/bofit/domain/user/entity/constant/Gender.java
+++ b/src/main/java/org/sopt/bofit/domain/user/entity/constant/Gender.java
@@ -1,0 +1,8 @@
+package org.sopt.bofit.domain.user.entity.constant;
+
+import lombok.Getter;
+
+@Getter
+public enum Gender {
+    MALE, FEMALE;
+}

--- a/src/main/java/org/sopt/bofit/domain/user/entity/constant/Job.java
+++ b/src/main/java/org/sopt/bofit/domain/user/entity/constant/Job.java
@@ -1,0 +1,22 @@
+package org.sopt.bofit.domain.user.entity.constant;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Job {
+    OFFICE_WORK("사무직"),
+    SERVICE_SALES("서비스·영업직"),
+    PROFESSIONAL("전문직"),
+    SELF_EMPLOYED("자영업"),
+    PRODUCTION_SITE("생산·현장직"),
+    DRIVER_DELIVERY("운전·배달직"),
+    HOMEMAKER("주부"),
+    STUDENT("학생"),
+    UNEMPLOYED("무직"),
+    FREELANCER("프리랜서"),
+    ETC("기타");
+
+    private final String displayName;
+}

--- a/src/main/java/org/sopt/bofit/domain/user/entity/constant/LoginProvider.java
+++ b/src/main/java/org/sopt/bofit/domain/user/entity/constant/LoginProvider.java
@@ -1,0 +1,10 @@
+package org.sopt.bofit.domain.user.entity.constant;
+
+import lombok.Getter;
+
+@Getter
+public enum LoginProvider {
+    KAKAO,
+    GOOGLE,
+    NAVER
+}

--- a/src/main/java/org/sopt/bofit/domain/user/entity/constant/UserStatus.java
+++ b/src/main/java/org/sopt/bofit/domain/user/entity/constant/UserStatus.java
@@ -1,0 +1,8 @@
+package org.sopt.bofit.domain.user.entity.constant;
+
+import lombok.Getter;
+
+@Getter
+public enum UserStatus {
+    ACTIVE,INACTIVE;
+}

--- a/src/main/java/org/sopt/bofit/global/converter/CoveragePreferenceMapConverter.java
+++ b/src/main/java/org/sopt/bofit/global/converter/CoveragePreferenceMapConverter.java
@@ -7,7 +7,7 @@ import jakarta.persistence.AttributeConverter;
 import jakarta.persistence.Converter;
 import org.sopt.bofit.domain.user.entity.constant.ConveragePreference;
 import org.sopt.bofit.global.exception.constant.GlobalErrorCode;
-import org.sopt.bofit.global.exception.custom_exception.JsonConvertException;
+import org.sopt.bofit.global.exception.custom_exception.InternalException;
 
 import java.io.IOException;
 import java.util.LinkedHashMap;
@@ -22,7 +22,7 @@ public class CoveragePreferenceMapConverter implements AttributeConverter<Map<Co
         try {
             return mapper.writeValueAsString(attribute);
         } catch (JsonProcessingException e) {
-            throw new JsonConvertException(GlobalErrorCode.JSON_SERIALIZATION_ERROR);
+            throw new InternalException(GlobalErrorCode.JSON_SERIALIZATION_ERROR);
         }
     }
 
@@ -31,7 +31,7 @@ public class CoveragePreferenceMapConverter implements AttributeConverter<Map<Co
         try {
             return mapper.readValue(dbData, new TypeReference<LinkedHashMap<ConveragePreference, Integer>>() {});
         } catch (IOException e) {
-            throw new JsonConvertException(GlobalErrorCode.JSON_DESERIALIZATION_ERROR);
+            throw new InternalException(GlobalErrorCode.JSON_DESERIALIZATION_ERROR);
         }
     }
 }

--- a/src/main/java/org/sopt/bofit/global/converter/CoveragePreferenceMapConverter.java
+++ b/src/main/java/org/sopt/bofit/global/converter/CoveragePreferenceMapConverter.java
@@ -1,0 +1,37 @@
+package org.sopt.bofit.global.converter;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import org.sopt.bofit.domain.user.entity.constant.ConveragePreference;
+import org.sopt.bofit.global.exception.constant.GlobalErrorCode;
+import org.sopt.bofit.global.exception.custom_exception.JsonConvertException;
+
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@Converter
+public class CoveragePreferenceMapConverter implements AttributeConverter<Map<ConveragePreference,Integer>,String> {
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    @Override
+    public String convertToDatabaseColumn(Map<ConveragePreference, Integer> attribute) {
+        try {
+            return mapper.writeValueAsString(attribute);
+        } catch (JsonProcessingException e) {
+            throw new JsonConvertException(GlobalErrorCode.JSON_SERIALIZATION_ERROR);
+        }
+    }
+
+    @Override
+    public Map<ConveragePreference, Integer> convertToEntityAttribute(String dbData) {
+        try {
+            return mapper.readValue(dbData, new TypeReference<LinkedHashMap<ConveragePreference, Integer>>() {});
+        } catch (IOException e) {
+            throw new JsonConvertException(GlobalErrorCode.JSON_DESERIALIZATION_ERROR);
+        }
+    }
+}

--- a/src/main/java/org/sopt/bofit/global/converter/DiseaseEnumListJsonConverter.java
+++ b/src/main/java/org/sopt/bofit/global/converter/DiseaseEnumListJsonConverter.java
@@ -7,7 +7,7 @@ import jakarta.persistence.AttributeConverter;
 import jakarta.persistence.Converter;
 import org.sopt.bofit.domain.user.entity.constant.DiagnosedDisease;
 import org.sopt.bofit.global.exception.constant.GlobalErrorCode;
-import org.sopt.bofit.global.exception.custom_exception.JsonConvertException;
+import org.sopt.bofit.global.exception.custom_exception.InternalException;
 
 import java.io.IOException;
 import java.util.List;
@@ -21,7 +21,7 @@ public class DiseaseEnumListJsonConverter implements AttributeConverter<List<Dia
         try {
             return mapper.writeValueAsString(attribute);
         } catch (JsonProcessingException e) {
-            throw new JsonConvertException(GlobalErrorCode.JSON_SERIALIZATION_ERROR);
+            throw new InternalException(GlobalErrorCode.JSON_SERIALIZATION_ERROR);
         }
     }
 
@@ -30,7 +30,7 @@ public class DiseaseEnumListJsonConverter implements AttributeConverter<List<Dia
         try {
             return mapper.readValue(dbData, new TypeReference<>() {});
         } catch (IOException e) {
-            throw new JsonConvertException(GlobalErrorCode.JSON_DESERIALIZATION_ERROR);
+            throw new InternalException(GlobalErrorCode.JSON_DESERIALIZATION_ERROR);
         }
     }
 }

--- a/src/main/java/org/sopt/bofit/global/converter/DiseaseEnumListJsonConverter.java
+++ b/src/main/java/org/sopt/bofit/global/converter/DiseaseEnumListJsonConverter.java
@@ -1,0 +1,36 @@
+package org.sopt.bofit.global.converter;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import org.sopt.bofit.domain.user.entity.constant.DiagnosedDisease;
+import org.sopt.bofit.global.exception.constant.GlobalErrorCode;
+import org.sopt.bofit.global.exception.custom_exception.JsonConvertException;
+
+import java.io.IOException;
+import java.util.List;
+
+@Converter
+public class DiseaseEnumListJsonConverter implements AttributeConverter<List<DiagnosedDisease>, String> {
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    @Override
+    public String convertToDatabaseColumn(List<DiagnosedDisease> attribute) {
+        try {
+            return mapper.writeValueAsString(attribute);
+        } catch (JsonProcessingException e) {
+            throw new JsonConvertException(GlobalErrorCode.JSON_SERIALIZATION_ERROR);
+        }
+    }
+
+    @Override
+    public List<DiagnosedDisease> convertToEntityAttribute(String dbData) {
+        try {
+            return mapper.readValue(dbData, new TypeReference<>() {});
+        } catch (IOException e) {
+            throw new JsonConvertException(GlobalErrorCode.JSON_DESERIALIZATION_ERROR);
+        }
+    }
+}

--- a/src/main/java/org/sopt/bofit/global/entity/BaseEntity.java
+++ b/src/main/java/org/sopt/bofit/global/entity/BaseEntity.java
@@ -1,0 +1,25 @@
+package org.sopt.bofit.global.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+@Getter
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/org/sopt/bofit/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/sopt/bofit/global/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package org.sopt.bofit.global.exception;
 
 import lombok.extern.slf4j.Slf4j;
+import org.sopt.bofit.global.exception.custom_exception.CustomException;
 import org.sopt.bofit.global.response.BaseErrorResponse;
 import org.springframework.beans.TypeMismatchException;
 import org.springframework.context.support.DefaultMessageSourceResolvable;

--- a/src/main/java/org/sopt/bofit/global/exception/constant/GlobalErrorCode.java
+++ b/src/main/java/org/sopt/bofit/global/exception/constant/GlobalErrorCode.java
@@ -16,7 +16,9 @@ public enum GlobalErrorCode implements ErrorCode {
     INVALID_JSON(HttpStatus.BAD_REQUEST.value(), "JSON 형식이 올바르지 않습니다."),
     MISSING_REQUEST_PARAMETER(HttpStatus.BAD_REQUEST.value(), "필수 요청 파라미터가 누락되었습니다."),
     TYPE_MISMATCH(HttpStatus.BAD_REQUEST.value(), "요청 파라미터 타입이 일치하지 않습니다."),
-    MISSING_PATH_VARIABLE(HttpStatus.BAD_REQUEST.value(), "경로 변수 값이 누락되었습니다.")
+    MISSING_PATH_VARIABLE(HttpStatus.BAD_REQUEST.value(), "경로 변수 값이 누락되었습니다."),
+    JSON_SERIALIZATION_ERROR(HttpStatus.INTERNAL_SERVER_ERROR.value(), "Enum 리스트를 JSON 문자열로 직렬화하는 데 실패했습니다."),
+    JSON_DESERIALIZATION_ERROR(HttpStatus.INTERNAL_SERVER_ERROR.value(), "JSON 문자열을 Enum 리스트로 역직렬화하는 데 실패했습니다.")
     ;
 
 

--- a/src/main/java/org/sopt/bofit/global/exception/custom_exception/CustomException.java
+++ b/src/main/java/org/sopt/bofit/global/exception/custom_exception/CustomException.java
@@ -1,4 +1,4 @@
-package org.sopt.bofit.global.exception;
+package org.sopt.bofit.global.exception.custom_exception;
 
 import lombok.Getter;
 import org.sopt.bofit.global.exception.constant.ErrorCode;

--- a/src/main/java/org/sopt/bofit/global/exception/custom_exception/InternalException.java
+++ b/src/main/java/org/sopt/bofit/global/exception/custom_exception/InternalException.java
@@ -2,12 +2,12 @@ package org.sopt.bofit.global.exception.custom_exception;
 
 import org.sopt.bofit.global.exception.constant.GlobalErrorCode;
 
-public class JsonConvertException extends CustomException {
-    public JsonConvertException(GlobalErrorCode errorCode) {
+public class InternalException extends CustomException {
+    public InternalException(GlobalErrorCode errorCode) {
         super(errorCode);
     }
 
-    public JsonConvertException(GlobalErrorCode errorCode, String messageDetail) {
+    public InternalException(GlobalErrorCode errorCode, String messageDetail) {
         super(errorCode, messageDetail);
     }
 }

--- a/src/main/java/org/sopt/bofit/global/exception/custom_exception/JsonConvertException.java
+++ b/src/main/java/org/sopt/bofit/global/exception/custom_exception/JsonConvertException.java
@@ -1,0 +1,13 @@
+package org.sopt.bofit.global.exception.custom_exception;
+
+import org.sopt.bofit.global.exception.constant.GlobalErrorCode;
+
+public class JsonConvertException extends CustomException {
+    public JsonConvertException(GlobalErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public JsonConvertException(GlobalErrorCode errorCode, String messageDetail) {
+        super(errorCode, messageDetail);
+    }
+}


### PR DESCRIPTION
## Related issue 🛠
- closed #5
  
## Work Description 📝
- [x] User 테이블 설계
- [x] UserInfo 테이블 설계
- [x] BaseEntity 구현

## To Reviewers 📢
ERD 설계 시 논의했던 대로 진단 받은 질병 리스트, 가족력, 보장 우선순위 등은 고정된 항목들이 포함되어 있어 따로 테이블을 분리하지 않고 각각 List, Map 형태로 저장되도록 설계했습니다. User 테이블에서 소셜 로그인을 할 때 받아오는 정보들은 null을 허용했습니다.
CustomException의 경우, 이를 상속 받는 구조를 처음 사용해봐서 이런 식으로 선언하는 게 맞는지 잘 모르겠어여 ..
그리고 socialId의 경우, 처음에 Long으로 선언했다가 추후 확장성을 고려하여 String으로 변경했습니다.