### PR TITLE
[Mod] 카카오 로그인 로직 수정

### DIFF
--- a/src/main/java/org/sopt/bofit/domain/user/entity/User.java
+++ b/src/main/java/org/sopt/bofit/domain/user/entity/User.java
@@ -66,28 +66,5 @@ public class User extends BaseEntity {
     @Column(nullable = false)
     private UserStatus status = UserStatus.ACTIVE;
 
-    public static User create(
-            LoginProvider loginProvider,
-            String oauthId,
-            String name,
-            String nickname,
-            String profileImage,
-            Gender gender,
-            int birthDay,
-            int birthYear
-    ) {
-        return User.builder()
-                .loginProvider(loginProvider)
-                .oauthId(oauthId)
-                .name(name)
-                .nickname(nickname)
-                .profileImage(profileImage)
-                .gender(gender)
-                .birthDay(birthDay)
-                .birthYear(birthYear)
-                .isRegistered(false)
-                .status(UserStatus.ACTIVE)
-                .build();
-    }
 
 }

--- a/src/main/java/org/sopt/bofit/domain/user/entity/User.java
+++ b/src/main/java/org/sopt/bofit/domain/user/entity/User.java
@@ -64,6 +64,7 @@ public class User extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
+    @Builder.Default
     private UserStatus status = UserStatus.ACTIVE;
 
 

--- a/src/main/java/org/sopt/bofit/global/oauth/dto/KaKaoTokenResponse.java
+++ b/src/main/java/org/sopt/bofit/global/oauth/dto/KaKaoTokenResponse.java
@@ -7,22 +7,27 @@ import lombok.Getter;
 
 public record KaKaoTokenResponse(
         @Schema(description = "액세스 토큰")
-        String access_token,
+        @JsonProperty("access_token")
+        String accessToken,
 
         @Schema(description = "토큰 타입", example = "bearer")
-        String token_type,
+        @JsonProperty("token_type")
+        String tokenType,
 
         @Schema(description = "리프레쉬 토큰")
-        String refresh_token,
+        @JsonProperty("refresh_token")
+        String refreshToken,
 
         @Schema(description = "토큰 만료일", example = "43199")
-        int expires_in,
+        @JsonProperty("expires_in")
+        int expiresIn,
 
         @Schema(description = "유저 정보 scope", example = "account_email profile")
         String scope,
 
         @Schema(description = "리프레쉬 토큰 만료일", example = "5184000")
-        int refresh_token_expires_in
+        @JsonProperty("refresh_token_expires_in")
+        int refreshTokenExpiresIn
 
 ) {
 

--- a/src/main/java/org/sopt/bofit/global/oauth/dto/KakaoUserResponse.java
+++ b/src/main/java/org/sopt/bofit/global/oauth/dto/KakaoUserResponse.java
@@ -24,10 +24,12 @@ public record KakaoUserResponse(
                 String nickname,
 
                 @Schema(description = "프로필 사진 이미지 url", example = "https://")
-                String profile_image_url,
+                @JsonProperty("profile_image_url")
+                String profileImageUrl,
 
                 @Schema(description = "유저 기본 프로필 여부")
-                boolean is_default_image
+                @JsonProperty("is_default_image")
+                boolean isDefaultImage
         ) {}
     }
 }

--- a/src/main/java/org/sopt/bofit/global/oauth/dto/KakaoUserResponse.java
+++ b/src/main/java/org/sopt/bofit/global/oauth/dto/KakaoUserResponse.java
@@ -24,7 +24,10 @@ public record KakaoUserResponse(
                 String nickname,
 
                 @Schema(description = "프로필 사진 이미지 url", example = "https://")
-                String profile_image_url
+                String profile_image_url,
+
+                @Schema(description = "유저 기본 프로필 여부")
+                boolean is_default_image
         ) {}
     }
 }

--- a/src/main/java/org/sopt/bofit/global/oauth/dto/KakaoUserResponse.java
+++ b/src/main/java/org/sopt/bofit/global/oauth/dto/KakaoUserResponse.java
@@ -16,18 +16,6 @@ public record KakaoUserResponse(
 ) {
     public record KakaoAccount(
 
-            @Schema(description = "이름", example = "이정연")
-            String name,
-
-            @Schema(description = "성별", example = "male")
-            String gender,
-
-            @Schema(description = "생일", example = "1112")
-            String birthday,
-
-            @Schema(description = "출생연도", example = "2000")
-            String birthyear,
-
             @Schema(description = "유저 프로필 정보")
             UserProfile profile
     ) {

--- a/src/main/java/org/sopt/bofit/global/oauth/service/OAuthService.java
+++ b/src/main/java/org/sopt/bofit/global/oauth/service/OAuthService.java
@@ -101,16 +101,12 @@ public class OAuthService {
                             .subscribeOn(Schedulers.boundedElastic())
                             .flatMap(optionalUser ->
                                     optionalUser.map(Mono::just).orElseGet(() -> {
-                                        User newUser = User.create(
-                                                LoginProvider.KAKAO,
-                                                String.valueOf(kakaoUser.oauthId()),
-                                                account.name(),
-                                                profile.nickname(),
-                                                profile.profile_image_url(),
-                                                parseGender(account.gender()).orElse(null),
-                                                parseBirth(account.birthday()),
-                                                parseBirth(account.birthyear())
-                                        );
+                                        User newUser = User.builder()
+                                                .loginProvider(LoginProvider.KAKAO)
+                                                .oauthId(String.valueOf(kakaoUser.oauthId()))
+                                                .nickname(profile.nickname())
+                                                .profileImage(profile.profile_image_url())
+                                                .build();
                                         return Mono.fromCallable(() -> userRepository.save(newUser))
                                                 .subscribeOn(Schedulers.boundedElastic());
                                     })

--- a/src/main/java/org/sopt/bofit/global/oauth/service/OAuthService.java
+++ b/src/main/java/org/sopt/bofit/global/oauth/service/OAuthService.java
@@ -94,8 +94,8 @@ public class OAuthService {
                         return Mono.error(new BadRequestException(KAKAO_USER_INFO_REQUEST_FAILED));
                     }
                     UserProfile profile = account.profile();
-                    boolean isDefault = account.profile().is_default_image();
-                    String userProfileImage = isDefault ? null : account.profile().profile_image_url();
+                    boolean isDefault = account.profile().isDefaultImage();
+                    String userProfileImage = isDefault ? null : account.profile().profileImageUrl();
 
                     return Mono.fromCallable(() ->
                                     userRepository.findByOauthId(String.valueOf(kakaoUser.oauthId()))
@@ -120,7 +120,7 @@ public class OAuthService {
     public Mono<KaKaoLoginResponse> login(String code) {
         return requestToken(code)
                 .flatMap(token ->
-                        registerOrLogin(token.access_token())
+                        registerOrLogin(token.accessToken())
                                 .publishOn(Schedulers.boundedElastic())
                                 .map(user -> {
                                     String accessToken = jwtProvider.generateAccessToken(user.getId());

--- a/src/main/java/org/sopt/bofit/global/oauth/service/OAuthService.java
+++ b/src/main/java/org/sopt/bofit/global/oauth/service/OAuthService.java
@@ -94,6 +94,8 @@ public class OAuthService {
                         return Mono.error(new BadRequestException(KAKAO_USER_INFO_REQUEST_FAILED));
                     }
                     UserProfile profile = account.profile();
+                    boolean isDefault = account.profile().is_default_image();
+                    String userProfileImage = isDefault ? null : account.profile().profile_image_url();
 
                     return Mono.fromCallable(() ->
                                     userRepository.findByOauthId(String.valueOf(kakaoUser.oauthId()))
@@ -105,7 +107,7 @@ public class OAuthService {
                                                 .loginProvider(LoginProvider.KAKAO)
                                                 .oauthId(String.valueOf(kakaoUser.oauthId()))
                                                 .nickname(profile.nickname())
-                                                .profileImage(profile.profile_image_url())
+                                                .profileImage(userProfileImage)
                                                 .build();
                                         return Mono.fromCallable(() -> userRepository.save(newUser))
                                                 .subscribeOn(Schedulers.boundedElastic());


### PR DESCRIPTION
## Related issue 🛠
- closed #19
  


## Work Description 📝
- [x] 이름, 성별 , 생일은 카카오 API를 통해 받아오지 않도록 수정 
- [x] 사용자 프로필 사진이 기본 이미지인 경우 필드값 null로 지정

## To Reviewers 📢
User에 있던 생성 메서드를 삭제하고, 빌더 패턴을 사용하도록 수정했습니다. 필드가 변경되면 도메인 단에서 메서드도 수정해야 하고, 서비스 단에서도 파라미터를 수정해야 하기도 하고, 변수가 많아짐에 따라 빌더 패턴 적용이 더 유리할 것이라고 판단했기 때문입니다.