### PR TITLE
[Feat] 내가 쓴 댓글 조회 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,15 @@ dependencies {
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
+def generated = "build/generated/querydsl"
 
+sourceSets {
+	main.java.srcDirs += [generated]
+}
+
+tasks.withType(JavaCompile).configureEach {
+	options.annotationProcessorGeneratedSourcesDirectory = file(generated)
+}
 
 
 tasks.named('test') {

--- a/src/main/java/org/sopt/bofit/domain/comment/repository/CommentCustomRepository.java
+++ b/src/main/java/org/sopt/bofit/domain/comment/repository/CommentCustomRepository.java
@@ -1,8 +1,8 @@
 package org.sopt.bofit.domain.comment.repository;
 
-import org.sopt.bofit.domain.user.dto.response.MyCommentsResponse;
+import org.sopt.bofit.domain.user.dto.response.CommentSummaryResponse;
 import org.springframework.data.domain.Slice;
 
 public interface CommentCustomRepository {
-    Slice<MyCommentsResponse> findCommentsByCursorId(Long userId, Long cursorId, int size);
+    Slice<CommentSummaryResponse> findCommentsByCursorId(Long userId, Long cursorId, int size);
 }

--- a/src/main/java/org/sopt/bofit/domain/comment/repository/CommentCustomRepository.java
+++ b/src/main/java/org/sopt/bofit/domain/comment/repository/CommentCustomRepository.java
@@ -1,0 +1,8 @@
+package org.sopt.bofit.domain.comment.repository;
+
+import org.sopt.bofit.domain.user.dto.response.MyCommentsResponse;
+import org.springframework.data.domain.Slice;
+
+public interface CommentCustomRepository {
+    Slice<MyCommentsResponse> findCommentsByCursorId(Long userId, Long cursorId, int size);
+}

--- a/src/main/java/org/sopt/bofit/domain/comment/repository/CommentCustomRepositoryImpl.java
+++ b/src/main/java/org/sopt/bofit/domain/comment/repository/CommentCustomRepositoryImpl.java
@@ -4,7 +4,7 @@ import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.sopt.bofit.domain.comment.entity.CommentStatus;
-import org.sopt.bofit.domain.user.dto.response.MyCommentsResponse;
+import org.sopt.bofit.domain.user.dto.response.CommentSummaryResponse;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
@@ -20,11 +20,11 @@ public class CommentCustomRepositoryImpl implements CommentCustomRepository {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Slice<MyCommentsResponse> findCommentsByCursorId(Long userId, Long cursorId, int size) {
+    public Slice<CommentSummaryResponse> findCommentsByCursorId(Long userId, Long cursorId, int size) {
         QComment comment = QComment.comment;
 
-        List<MyCommentsResponse> content = queryFactory
-                .select(Projections.constructor(MyCommentsResponse.class,
+        List<CommentSummaryResponse> content = queryFactory
+                .select(Projections.constructor(CommentSummaryResponse.class,
                         comment.id,
                         comment.post.id,
                         comment.content,

--- a/src/main/java/org/sopt/bofit/domain/comment/repository/CommentCustomRepositoryImpl.java
+++ b/src/main/java/org/sopt/bofit/domain/comment/repository/CommentCustomRepositoryImpl.java
@@ -1,11 +1,48 @@
 package org.sopt.bofit.domain.comment.repository;
 
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.sopt.bofit.domain.comment.entity.CommentStatus;
 import org.sopt.bofit.domain.user.dto.response.MyCommentsResponse;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.stereotype.Repository;
+import org.sopt.bofit.domain.comment.entity.QComment;
 
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
 public class CommentCustomRepositoryImpl implements CommentCustomRepository {
+
+    private final JPAQueryFactory queryFactory;
+
     @Override
     public Slice<MyCommentsResponse> findCommentsByCursorId(Long userId, Long cursorId, int size) {
-        return null;
+        QComment comment = QComment.comment;
+
+        List<MyCommentsResponse> content = queryFactory
+                .select(Projections.constructor(MyCommentsResponse.class,
+                        comment.id,
+                        comment.content,
+                        comment.createdAt
+                ))
+                .from(comment)
+                .where(
+                        comment.user.id.eq(userId),
+                        comment.status.eq(CommentStatus.ACTIVE),
+                        cursorId != null ? comment.id.lt(cursorId) : null
+                )
+                .groupBy(comment.id)
+                .orderBy(comment.id.desc())
+                .limit(size + 1)
+                .fetch();
+
+        boolean hasNext = content.size() > size;
+        if (hasNext) content.remove(size);
+
+        return new SliceImpl<>(content, PageRequest.of(0, size), hasNext);
     }
 }

--- a/src/main/java/org/sopt/bofit/domain/comment/repository/CommentCustomRepositoryImpl.java
+++ b/src/main/java/org/sopt/bofit/domain/comment/repository/CommentCustomRepositoryImpl.java
@@ -1,0 +1,11 @@
+package org.sopt.bofit.domain.comment.repository;
+
+import org.sopt.bofit.domain.user.dto.response.MyCommentsResponse;
+import org.springframework.data.domain.Slice;
+
+public class CommentCustomRepositoryImpl implements CommentCustomRepository {
+    @Override
+    public Slice<MyCommentsResponse> findCommentsByCursorId(Long userId, Long cursorId, int size) {
+        return null;
+    }
+}

--- a/src/main/java/org/sopt/bofit/domain/comment/repository/CommentCustomRepositoryImpl.java
+++ b/src/main/java/org/sopt/bofit/domain/comment/repository/CommentCustomRepositoryImpl.java
@@ -26,6 +26,7 @@ public class CommentCustomRepositoryImpl implements CommentCustomRepository {
         List<MyCommentsResponse> content = queryFactory
                 .select(Projections.constructor(MyCommentsResponse.class,
                         comment.id,
+                        comment.post.id,
                         comment.content,
                         comment.createdAt
                 ))

--- a/src/main/java/org/sopt/bofit/domain/post/repository/PostCustomRepository.java
+++ b/src/main/java/org/sopt/bofit/domain/post/repository/PostCustomRepository.java
@@ -1,8 +1,8 @@
 package org.sopt.bofit.domain.post.repository;
 
-import org.sopt.bofit.domain.user.dto.response.MyPostsResponse;
+import org.sopt.bofit.domain.user.dto.response.PostSummaryResponse;
 import org.springframework.data.domain.Slice;
 
 public interface PostCustomRepository {
-    Slice<MyPostsResponse> findPostsByCursorId(Long userId, Long cursorId, int size);
+    Slice<PostSummaryResponse> findPostsByCursorId(Long userId, Long cursorId, int size);
 }

--- a/src/main/java/org/sopt/bofit/domain/post/repository/PostCustomRepositoryImpl.java
+++ b/src/main/java/org/sopt/bofit/domain/post/repository/PostCustomRepositoryImpl.java
@@ -5,19 +5,15 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.sopt.bofit.domain.comment.entity.CommentStatus;
 import org.sopt.bofit.domain.comment.entity.QComment;
-import org.sopt.bofit.domain.post.entity.Post;
 import org.sopt.bofit.domain.post.entity.QPost;
 import org.sopt.bofit.domain.post.entity.constant.PostStatus;
-import org.sopt.bofit.domain.user.dto.response.MyPostsResponse;
+import org.sopt.bofit.domain.user.dto.response.PostSummaryResponse;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
-
-import static org.sopt.bofit.domain.post.entity.QPost.post;
 
 
 @Repository
@@ -27,12 +23,12 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Slice<MyPostsResponse> findPostsByCursorId(Long userId, Long cursorId, int size) {
+    public Slice<PostSummaryResponse> findPostsByCursorId(Long userId, Long cursorId, int size) {
         QPost post = QPost.post;
         QComment comment = QComment.comment;
 
-        List<MyPostsResponse> content = queryFactory
-                .select(Projections.constructor(MyPostsResponse.class,
+        List<PostSummaryResponse> content = queryFactory
+                .select(Projections.constructor(PostSummaryResponse.class,
                         post.id,
                         post.title,
                         post.content,

--- a/src/main/java/org/sopt/bofit/domain/post/service/PostService.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/PostService.java
@@ -1,12 +1,7 @@
 package org.sopt.bofit.domain.post.service;
 
 import lombok.RequiredArgsConstructor;
-import org.sopt.bofit.domain.post.repository.PostCustomRepositoryImpl;
 import org.sopt.bofit.domain.post.repository.PostRepository;
-import org.sopt.bofit.domain.user.dto.response.MyPostsResponse;
-import org.sopt.bofit.domain.user.dto.response.SliceResponse;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 
 @Service

--- a/src/main/java/org/sopt/bofit/domain/user/controller/UserController.java
+++ b/src/main/java/org/sopt/bofit/domain/user/controller/UserController.java
@@ -4,8 +4,8 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.sopt.bofit.domain.user.dto.response.MyCommentsResponse;
-import org.sopt.bofit.domain.user.dto.response.MyPostsResponse;
+import org.sopt.bofit.domain.user.dto.response.CommentSummaryResponse;
+import org.sopt.bofit.domain.user.dto.response.PostSummaryResponse;
 import org.sopt.bofit.domain.user.dto.response.SliceResponse;
 import org.sopt.bofit.domain.user.dto.response.UserProfileResponse;
 import org.sopt.bofit.domain.user.service.UserReadService;
@@ -13,7 +13,6 @@ import org.sopt.bofit.domain.user.service.UserWriteService;
 import org.sopt.bofit.global.annotation.CustomExceptionDescription;
 import org.sopt.bofit.global.annotation.LoginUserId;
 import org.sopt.bofit.global.response.BaseResponse;
-import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -44,7 +43,7 @@ public class UserController {
     @CustomExceptionDescription(MY_POSTS)
     @Operation(summary = "내가 쓴 글 조회", description = "마이페이지에서 내가 쓴 글을 조회합니다.")
     @GetMapping("me/posts")
-    public BaseResponse<SliceResponse<MyPostsResponse>> getMyPosts(
+    public BaseResponse<SliceResponse<PostSummaryResponse>> getMyPosts(
             @Parameter(hidden = true) @LoginUserId Long userId,
             @RequestParam(required = false) Long cursorId,
             @RequestParam(defaultValue = "10") int size
@@ -56,7 +55,7 @@ public class UserController {
     @CustomExceptionDescription(MY_COMMENTS)
     @Operation(summary = "내가 쓴 댓글 조회", description = "마이페이지에서 내가 쓴 댓글을 조회합니다.")
     @GetMapping("me/comments")
-    public BaseResponse<SliceResponse<MyCommentsResponse>> getMyComments(
+    public BaseResponse<SliceResponse<CommentSummaryResponse>> getMyComments(
             @Parameter(hidden = true) @LoginUserId Long userId,
             @RequestParam(required = false) Long cursorId,
             @RequestParam(defaultValue = "10") int size

--- a/src/main/java/org/sopt/bofit/domain/user/controller/UserController.java
+++ b/src/main/java/org/sopt/bofit/domain/user/controller/UserController.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.sopt.bofit.domain.user.dto.response.MyCommentsResponse;
 import org.sopt.bofit.domain.user.dto.response.MyPostsResponse;
 import org.sopt.bofit.domain.user.dto.response.SliceResponse;
 import org.sopt.bofit.domain.user.dto.response.UserProfileResponse;
@@ -49,6 +50,18 @@ public class UserController {
             @RequestParam(defaultValue = "10") int size
     ){
         return BaseResponse.ok(userReadService.getMyPosts(userId, cursorId, size), "내가 쓴 글 조회 성공");
+    }
+
+    @Tag(name = "My Page", description = "마이페이지 관련 API")
+    @CustomExceptionDescription(MY_COMMENTS)
+    @Operation(summary = "내가 쓴 댓글 조회", description = "마이페이지에서 내가 쓴 댓글을 조회합니다.")
+    @GetMapping("me/comments")
+    public BaseResponse<SliceResponse<MyCommentsResponse>> getMyComments(
+            @Parameter(hidden = true) @LoginUserId Long userId,
+            @RequestParam(required = false) Long cursorId,
+            @RequestParam(defaultValue = "10") int size
+    ){
+        return BaseResponse.ok(userReadService.getMyComments(userId, cursorId, size), "내가 쓴 댓글 조회 성공");
     }
 
 }

--- a/src/main/java/org/sopt/bofit/domain/user/dto/response/CommentSummaryResponse.java
+++ b/src/main/java/org/sopt/bofit/domain/user/dto/response/CommentSummaryResponse.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 
-public record MyCommentsResponse(
+public record CommentSummaryResponse(
 
         @Schema(description = "댓글 ID")
         Long commentId,
@@ -18,7 +18,7 @@ public record MyCommentsResponse(
         @Schema(description = "작성 시간")
         LocalDateTime createdAt
 ) {
-    public static MyCommentsResponse of(Long commentId, Long postId, String content, LocalDateTime createdAt) {
-        return new MyCommentsResponse(commentId, postId, content, createdAt);
+    public static CommentSummaryResponse of(Long commentId, Long postId, String content, LocalDateTime createdAt) {
+        return new CommentSummaryResponse(commentId, postId, content, createdAt);
     }
 }

--- a/src/main/java/org/sopt/bofit/domain/user/dto/response/MyCommentsResponse.java
+++ b/src/main/java/org/sopt/bofit/domain/user/dto/response/MyCommentsResponse.java
@@ -9,13 +9,16 @@ public record MyCommentsResponse(
         @Schema(description = "댓글 ID")
         Long commentId,
 
+        @Schema(description = "댓글을 작성한 게시글 ID")
+        Long postId,
+
         @Schema(description = "댓글 내용", example = "저도요")
         String content,
 
         @Schema(description = "작성 시간")
         LocalDateTime createdAt
 ) {
-    public static MyCommentsResponse of(Long commentId, String content, LocalDateTime createdAt) {
-        return new MyCommentsResponse(commentId, content, createdAt);
+    public static MyCommentsResponse of(Long commentId, Long postId, String content, LocalDateTime createdAt) {
+        return new MyCommentsResponse(commentId, postId, content, createdAt);
     }
 }

--- a/src/main/java/org/sopt/bofit/domain/user/dto/response/MyCommentsResponse.java
+++ b/src/main/java/org/sopt/bofit/domain/user/dto/response/MyCommentsResponse.java
@@ -1,0 +1,18 @@
+package org.sopt.bofit.domain.user.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+public record MyCommentsResponse(
+
+        @Schema(description = "댓글 내용", example = "저도요")
+        String content,
+
+        @Schema(description = "작성 시간")
+        LocalDateTime createdAt
+) {
+    public static MyCommentsResponse of(String content, LocalDateTime createdAt) {
+        return new MyCommentsResponse(content, createdAt);
+    }
+}

--- a/src/main/java/org/sopt/bofit/domain/user/dto/response/MyCommentsResponse.java
+++ b/src/main/java/org/sopt/bofit/domain/user/dto/response/MyCommentsResponse.java
@@ -6,13 +6,16 @@ import java.time.LocalDateTime;
 
 public record MyCommentsResponse(
 
+        @Schema(description = "댓글 ID")
+        Long commentId,
+
         @Schema(description = "댓글 내용", example = "저도요")
         String content,
 
         @Schema(description = "작성 시간")
         LocalDateTime createdAt
 ) {
-    public static MyCommentsResponse of(String content, LocalDateTime createdAt) {
-        return new MyCommentsResponse(content, createdAt);
+    public static MyCommentsResponse of(Long commentId, String content, LocalDateTime createdAt) {
+        return new MyCommentsResponse(commentId, content, createdAt);
     }
 }

--- a/src/main/java/org/sopt/bofit/domain/user/dto/response/PostSummaryResponse.java
+++ b/src/main/java/org/sopt/bofit/domain/user/dto/response/PostSummaryResponse.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 
-public record MyPostsResponse(
+public record PostSummaryResponse(
 
         @Schema(description = "게시글 ID")
         Long postId,
@@ -22,7 +22,7 @@ public record MyPostsResponse(
         LocalDateTime createdAt
 ){
 
-    public static MyPostsResponse of(Long postId, String title, String content, int commentCount, LocalDateTime createdAt){
-        return new MyPostsResponse(postId, title, content, commentCount, createdAt);
+    public static PostSummaryResponse of(Long postId, String title, String content, int commentCount, LocalDateTime createdAt){
+        return new PostSummaryResponse(postId, title, content, commentCount, createdAt);
     }
 }

--- a/src/main/java/org/sopt/bofit/domain/user/dto/response/SliceResponse.java
+++ b/src/main/java/org/sopt/bofit/domain/user/dto/response/SliceResponse.java
@@ -16,10 +16,10 @@ public record SliceResponse<T>(
 
         if (!slice.isLast() && !content.isEmpty()) {
             Object lastElement = content.get(content.size() - 1);
-            if (lastElement instanceof MyPostsResponse lastPost) {
+            if (lastElement instanceof PostSummaryResponse lastPost) {
                 nextCursorId = lastPost.postId();
             }
-            else if (lastElement instanceof MyCommentsResponse lastComment) {
+            else if (lastElement instanceof CommentSummaryResponse lastComment) {
                 nextCursorId = lastComment.commentId();
             }
         }

--- a/src/main/java/org/sopt/bofit/domain/user/dto/response/SliceResponse.java
+++ b/src/main/java/org/sopt/bofit/domain/user/dto/response/SliceResponse.java
@@ -19,6 +19,9 @@ public record SliceResponse<T>(
             if (lastElement instanceof MyPostsResponse lastPost) {
                 nextCursorId = lastPost.postId();
             }
+            else if (lastElement instanceof MyCommentsResponse lastComment) {
+                nextCursorId = lastComment.commentId();
+            }
         }
 
         return new SliceResponse<>(content, nextCursorId, slice.isLast());

--- a/src/main/java/org/sopt/bofit/domain/user/service/UserReadService.java
+++ b/src/main/java/org/sopt/bofit/domain/user/service/UserReadService.java
@@ -1,7 +1,9 @@
 package org.sopt.bofit.domain.user.service;
 
 import lombok.RequiredArgsConstructor;
+import org.sopt.bofit.domain.comment.repository.CommentCustomRepositoryImpl;
 import org.sopt.bofit.domain.post.repository.PostCustomRepositoryImpl;
+import org.sopt.bofit.domain.user.dto.response.MyCommentsResponse;
 import org.sopt.bofit.domain.user.dto.response.MyPostsResponse;
 import org.sopt.bofit.domain.user.dto.response.SliceResponse;
 import org.sopt.bofit.domain.user.dto.response.UserProfileResponse;
@@ -20,6 +22,8 @@ public class UserReadService {
     private final UserRepository userRepository;
 
     private final PostCustomRepositoryImpl postCustomRepositoryImpl;
+
+    private final CommentCustomRepositoryImpl commentCustomRepositoryImpl;
 
     public UserProfileResponse getUserInfo(Long userId){
 
@@ -40,5 +44,14 @@ public class UserReadService {
 
     private User findUserById(Long userId) {
         return userRepository.findById(userId).orElseThrow(() -> new NotFoundException(USER_NOT_FOUND));
+    }
+
+    public SliceResponse<MyCommentsResponse> getMyComments(Long userId, Long cursorId, int size) {
+
+        findUserById(userId);
+
+        Slice<MyCommentsResponse> comments = commentCustomRepositoryImpl.findCommentsByCursorId(userId, cursorId, size);
+
+        return SliceResponse.of(comments);
     }
 }

--- a/src/main/java/org/sopt/bofit/domain/user/service/UserReadService.java
+++ b/src/main/java/org/sopt/bofit/domain/user/service/UserReadService.java
@@ -3,8 +3,8 @@ package org.sopt.bofit.domain.user.service;
 import lombok.RequiredArgsConstructor;
 import org.sopt.bofit.domain.comment.repository.CommentCustomRepositoryImpl;
 import org.sopt.bofit.domain.post.repository.PostCustomRepositoryImpl;
-import org.sopt.bofit.domain.user.dto.response.MyCommentsResponse;
-import org.sopt.bofit.domain.user.dto.response.MyPostsResponse;
+import org.sopt.bofit.domain.user.dto.response.CommentSummaryResponse;
+import org.sopt.bofit.domain.user.dto.response.PostSummaryResponse;
 import org.sopt.bofit.domain.user.dto.response.SliceResponse;
 import org.sopt.bofit.domain.user.dto.response.UserProfileResponse;
 import org.sopt.bofit.domain.user.entity.User;
@@ -33,11 +33,11 @@ public class UserReadService {
 
     }
 
-    public SliceResponse<MyPostsResponse> getMyPosts(Long userId, Long cursorId, int size) {
+    public SliceResponse<PostSummaryResponse> getMyPosts(Long userId, Long cursorId, int size) {
 
         findUserById(userId);
 
-        Slice<MyPostsResponse> posts = postCustomRepositoryImpl.findPostsByCursorId(userId, cursorId, size);
+        Slice<PostSummaryResponse> posts = postCustomRepositoryImpl.findPostsByCursorId(userId, cursorId, size);
 
         return SliceResponse.of(posts);
     }
@@ -46,11 +46,11 @@ public class UserReadService {
         return userRepository.findById(userId).orElseThrow(() -> new NotFoundException(USER_NOT_FOUND));
     }
 
-    public SliceResponse<MyCommentsResponse> getMyComments(Long userId, Long cursorId, int size) {
+    public SliceResponse<CommentSummaryResponse> getMyComments(Long userId, Long cursorId, int size) {
 
         findUserById(userId);
 
-        Slice<MyCommentsResponse> comments = commentCustomRepositoryImpl.findCommentsByCursorId(userId, cursorId, size);
+        Slice<CommentSummaryResponse> comments = commentCustomRepositoryImpl.findCommentsByCursorId(userId, cursorId, size);
 
         return SliceResponse.of(comments);
     }

--- a/src/main/java/org/sopt/bofit/global/config/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/org/sopt/bofit/global/config/swagger/SwaggerResponseDescription.java
@@ -28,6 +28,9 @@ public enum SwaggerResponseDescription {
     ))),
     MY_POSTS(new LinkedHashSet<>(Set.of(
             USER_NOT_FOUND
+    ))),
+    MY_COMMENTS(new LinkedHashSet<>(Set.of(
+            USER_NOT_FOUND
     )))
     ;
     private final Set<ErrorCode> errorCodeList;


### PR DESCRIPTION
``## Related issue 🛠
- closed #28
  


## Work Description 📝
- [x] 내가 쓴 댓글 조회

## To Reviewers 📢
내가 작성한 글 조회 API를 구현할 때와 동일하게 QueryDSL과 Slice를 통해 구현했습니다. 내 글 조회 기능 구현 시에 만들어 두었던 SliceResponse를 제네릭 타입으로 선언해두었기 때문에 재사용했습니다. 따라서 추후에 다른 무한 스크롤 기능이 추가되어도 그대로 사용할 수 있을 것 같습니다. 확장성이 존재하기는 하는데, 궁금한 점이 생겼습니다. 
``` if (!slice.isLast() && !content.isEmpty()) {
            Object lastElement = content.get(content.size() - 1);
            if (lastElement instanceof MyPostsResponse lastPost) {
                nextCursorId = lastPost.postId();
            }
            else if (lastElement instanceof MyCommentsResponse lastComment) {
                nextCursorId = lastComment.commentId();
            }
        }
```
 

 SliceResponse 생성 메서드 내부에서 사용되는 로직인데, 현재는 instanceof를 통해 객체를 판단하여 nextCursorId를 지정하는 형태인데, 만약 무한 스크롤 기능이 여러 곳에서 쓰이게 된다면 이 분기 처리가 많아져 가독성이나 여러 방면에서 문제가 생길 것 같은데, 이를 보완할 수 있는 방법을 고민해보고 있습니다.