### PR TITLE
[Feat] 커뮤니티 - 게시물 수정 기능 구현

### DIFF
--- a/src/main/java/org/sopt/bofit/domain/post/controller/PostController.java
+++ b/src/main/java/org/sopt/bofit/domain/post/controller/PostController.java
@@ -34,4 +34,16 @@ public class PostController {
         return BaseResponse.ok(postService.createPost(userId, request.title(), request.content()),"게시물 생성 완료");
     }
 
+    @Tag(name = "Community", description = "커뮤니티 관련 API")
+    @Operation(summary = "게시물 수정", description = "커뮤니티에서 글을 수정합니다.")
+    @CustomExceptionDescription(UPDATE_POST)
+    @PutMapping("{postId}")
+    public BaseResponse<PostResponse> updatePost(
+            @RequestBody @Valid PostRequest request,
+            @Parameter(hidden = true) @LoginUserId Long userId,
+            @PathVariable Long postId
+    ){
+        return BaseResponse.ok(postService.updatePost(userId,postId,request.title(), request.content()),"게시물 수정 완료");
+    }
+
 }

--- a/src/main/java/org/sopt/bofit/domain/post/entity/Post.java
+++ b/src/main/java/org/sopt/bofit/domain/post/entity/Post.java
@@ -41,4 +41,9 @@ public class Post extends BaseEntity {
                 .build();
     }
 
+    public void updatePost(String title, String content){
+        this.title = title;
+        this.content = content;
+    }
+
 }

--- a/src/main/java/org/sopt/bofit/domain/post/service/PostService.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/PostService.java
@@ -36,7 +36,7 @@ public class PostService {
     public PostResponse updatePost (Long userId, Long postId, String title, String content) {
         User user = userReadService.findUserById(userId);
         Post post = postRepository.findById(postId).orElseThrow(() -> new NotFoundException(POST_NOT_FOUND));
-        
+
         post.updatePost(title, content);
         return PostResponse.from(post.getId());
     }

--- a/src/main/java/org/sopt/bofit/domain/post/service/PostService.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/PostService.java
@@ -5,15 +5,13 @@ import org.sopt.bofit.domain.post.dto.response.PostResponse;
 import org.sopt.bofit.domain.post.entity.Post;
 import org.sopt.bofit.domain.post.repository.PostRepository;
 import org.sopt.bofit.domain.user.entity.User;
-import org.sopt.bofit.domain.user.repository.UserRepository;
 import org.sopt.bofit.domain.user.service.UserReadService;
-import org.sopt.bofit.global.exception.constant.PostErrorCode;
+import org.sopt.bofit.global.exception.custom_exception.ForbiddenException;
 import org.sopt.bofit.global.exception.custom_exception.NotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import static org.sopt.bofit.global.exception.constant.PostErrorCode.*;
-import static org.sopt.bofit.global.exception.constant.UserErrorCode.*;
 
 @Service
 @RequiredArgsConstructor
@@ -36,6 +34,10 @@ public class PostService {
     public PostResponse updatePost (Long userId, Long postId, String title, String content) {
         User user = userReadService.findUserById(userId);
         Post post = postRepository.findById(postId).orElseThrow(() -> new NotFoundException(POST_NOT_FOUND));
+
+        if(!post.getUser().getId().equals(userId)) {
+            throw new ForbiddenException(POST_UNAUTHORIZED);
+        }
 
         post.updatePost(title, content);
         return PostResponse.from(post.getId());

--- a/src/main/java/org/sopt/bofit/domain/post/service/PostService.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/PostService.java
@@ -7,9 +7,12 @@ import org.sopt.bofit.domain.post.repository.PostRepository;
 import org.sopt.bofit.domain.user.entity.User;
 import org.sopt.bofit.domain.user.repository.UserRepository;
 import org.sopt.bofit.domain.user.service.UserReadService;
+import org.sopt.bofit.global.exception.constant.PostErrorCode;
 import org.sopt.bofit.global.exception.custom_exception.NotFoundException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import static org.sopt.bofit.global.exception.constant.PostErrorCode.*;
 import static org.sopt.bofit.global.exception.constant.UserErrorCode.*;
 
 @Service
@@ -28,5 +31,15 @@ public class PostService {
         postRepository.save(newPost);
         return PostResponse.from(newPost.getId());
     }
+
+    @Transactional
+    public PostResponse updatePost (Long userId, Long postId, String title, String content) {
+        User user = userReadService.findUserById(userId);
+        Post post = postRepository.findById(postId).orElseThrow(() -> new NotFoundException(POST_NOT_FOUND));
+        
+        post.updatePost(title, content);
+        return PostResponse.from(post.getId());
+    }
+
 
 }

--- a/src/main/java/org/sopt/bofit/global/config/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/org/sopt/bofit/global/config/swagger/SwaggerResponseDescription.java
@@ -36,6 +36,15 @@ public enum SwaggerResponseDescription {
             POST_TITLE_BLANK,
             POST_CONTENT_LONG,
             POST_TITLE_LONG
+    ))),
+    UPDATE_POST(new LinkedHashSet<>(Set.of(
+            USER_NOT_FOUND,
+            POST_NOT_FOUND,
+            POST_UNAUTHORIZED,
+            POST_CONTENT_BLANK,
+            POST_TITLE_BLANK,
+            POST_CONTENT_LONG,
+            POST_TITLE_LONG
     )))
     ;
     private final Set<ErrorCode> errorCodeList;

--- a/src/main/java/org/sopt/bofit/global/exception/constant/PostErrorCode.java
+++ b/src/main/java/org/sopt/bofit/global/exception/constant/PostErrorCode.java
@@ -8,7 +8,8 @@ public enum PostErrorCode implements ErrorCode {
     POST_TITLE_BLANK(HttpStatus.BAD_REQUEST.value(), "제목은 비어있을 수 없습니다."),
     POST_CONTENT_BLANK(HttpStatus.BAD_REQUEST.value(), "본문은 비어있을 수 없습니다."),
     POST_TITLE_LONG(HttpStatus.BAD_REQUEST.value(), "제목은 30자 미만으로 입력해주세요."),
-    POST_CONTENT_LONG(HttpStatus.BAD_REQUEST.value(), "내용은 3000자 미만으로 작성해주세요")
+    POST_CONTENT_LONG(HttpStatus.BAD_REQUEST.value(), "내용은 3000자 미만으로 작성해주세요"),
+    POST_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "존재하지 않는 게시글입니다."),
 
     ;
     private final int httpStatus;

--- a/src/main/java/org/sopt/bofit/global/exception/constant/PostErrorCode.java
+++ b/src/main/java/org/sopt/bofit/global/exception/constant/PostErrorCode.java
@@ -10,6 +10,7 @@ public enum PostErrorCode implements ErrorCode {
     POST_TITLE_LONG(HttpStatus.BAD_REQUEST.value(), "제목은 30자 미만으로 입력해주세요."),
     POST_CONTENT_LONG(HttpStatus.BAD_REQUEST.value(), "내용은 3000자 미만으로 작성해주세요"),
     POST_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "존재하지 않는 게시글입니다."),
+    POST_UNAUTHORIZED(HttpStatus.FORBIDDEN.value(), "본인의 게시글만 삭제할 수 있습니다.")
 
     ;
     private final int httpStatus;

--- a/src/main/java/org/sopt/bofit/global/exception/custom_exception/ForbiddenException.java
+++ b/src/main/java/org/sopt/bofit/global/exception/custom_exception/ForbiddenException.java
@@ -1,0 +1,13 @@
+package org.sopt.bofit.global.exception.custom_exception;
+
+import org.sopt.bofit.global.exception.constant.ErrorCode;
+
+public class ForbiddenException extends CustomException{
+    public ForbiddenException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public ForbiddenException(ErrorCode errorCode, String messageDetail) {
+        super(errorCode, messageDetail);
+    }
+}


### PR DESCRIPTION
## Related issue 🛠
- closed #32
 

## Work Description 📝
- [x] 게시물 수정 기능 구현

## To Reviewers 📢
게시물 수정 기능을 구현하였습니다. Request와 Response는 게시물 작성과 동일하여 DTO를 재사용했습니다. 게시물의 userId와 LoginUserId를 비교하여 본인의 게시물만 수정할 수 있도록 구현했습니다.