### PR TITLE
[Feat] 커뮤니티 - 게시물 삭제 기능 구현

### DIFF
--- a/src/main/java/org/sopt/bofit/domain/post/controller/PostController.java
+++ b/src/main/java/org/sopt/bofit/domain/post/controller/PostController.java
@@ -46,4 +46,14 @@ public class PostController {
         return BaseResponse.ok(postService.updatePost(userId,postId,request.title(), request.content()),"게시물 수정 완료");
     }
 
+    @Tag(name = "Community", description = "커뮤니티 관련 API")
+    @Operation(summary = "게시물 삭제", description = "커뮤니티에서 글을 삭제합니다.(소프트 딜리트)")
+    @CustomExceptionDescription(DELETE_POST)
+    @DeleteMapping("{postId}")
+    public BaseResponse<Void> deletePost(
+            @Parameter(hidden = true) @LoginUserId Long userId,
+            @PathVariable Long postId
+    ){
+        return BaseResponse.ok(postService.deletePost(userId,postId), "게시물 삭제 완료");
+    }
 }

--- a/src/main/java/org/sopt/bofit/domain/post/controller/PostController.java
+++ b/src/main/java/org/sopt/bofit/domain/post/controller/PostController.java
@@ -54,6 +54,7 @@ public class PostController {
             @Parameter(hidden = true) @LoginUserId Long userId,
             @PathVariable Long postId
     ){
-        return BaseResponse.ok(postService.deletePost(userId,postId), "게시물 삭제 완료");
+        postService.deletePost(userId,postId);
+        return BaseResponse.ok("게시물 삭제 완료");
     }
 }

--- a/src/main/java/org/sopt/bofit/domain/post/repository/PostCustomRepository.java
+++ b/src/main/java/org/sopt/bofit/domain/post/repository/PostCustomRepository.java
@@ -5,4 +5,6 @@ import org.springframework.data.domain.Slice;
 
 public interface PostCustomRepository {
     Slice<PostSummaryResponse> findPostsByCursorId(Long userId, Long cursorId, int size);
+
+    void deletePostByPostId(Long postId);
 }

--- a/src/main/java/org/sopt/bofit/domain/post/repository/PostCustomRepositoryImpl.java
+++ b/src/main/java/org/sopt/bofit/domain/post/repository/PostCustomRepositoryImpl.java
@@ -52,5 +52,16 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
 
         return new SliceImpl<>(content, PageRequest.of(0, size), hasNext);
     }
+
+    @Override
+    public void deletePostByPostId(Long postId) {
+        QPost post = QPost.post;
+
+        queryFactory
+                .update(post)
+                .set(post.status,PostStatus.INACTIVE)
+                .where(post.id.eq(postId))
+                .execute();
+    }
 }
 

--- a/src/main/java/org/sopt/bofit/domain/post/service/PostService.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/PostService.java
@@ -47,7 +47,7 @@ public class PostService {
     }
 
     @Transactional
-    public Void deletePost(Long userId, Long postId) {
+    public void deletePost(Long userId, Long postId) {
         User user = userReadService.findUserById(userId);
         Post post = postRepository.findById(postId).orElseThrow(() -> new NotFoundException(POST_NOT_FOUND));
 
@@ -56,7 +56,6 @@ public class PostService {
         }
 
         postCustomRepositoryImpl.deletePostByPostId(postId);
-        return null;
     }
 
 

--- a/src/main/java/org/sopt/bofit/domain/post/service/PostService.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/PostService.java
@@ -3,6 +3,7 @@ package org.sopt.bofit.domain.post.service;
 import lombok.RequiredArgsConstructor;
 import org.sopt.bofit.domain.post.dto.response.PostResponse;
 import org.sopt.bofit.domain.post.entity.Post;
+import org.sopt.bofit.domain.post.repository.PostCustomRepositoryImpl;
 import org.sopt.bofit.domain.post.repository.PostRepository;
 import org.sopt.bofit.domain.user.entity.User;
 import org.sopt.bofit.domain.user.service.UserReadService;
@@ -20,6 +21,8 @@ public class PostService {
     private final PostRepository postRepository;
 
     private final UserReadService userReadService;
+
+    private final PostCustomRepositoryImpl postCustomRepositoryImpl;
 
     public PostResponse createPost(Long userId, String title, String content) {
         User user = userReadService.findUserById(userId);
@@ -41,6 +44,18 @@ public class PostService {
 
         post.updatePost(title, content);
         return PostResponse.from(post.getId());
+    }
+
+    @Transactional
+    public void deletePost(Long userId, Long postId) {
+        User user = userReadService.findUserById(userId);
+        Post post = postRepository.findById(postId).orElseThrow(() -> new NotFoundException(POST_NOT_FOUND));
+
+        if(!post.getUser().getId().equals(userId)) {
+            throw new ForbiddenException(POST_UNAUTHORIZED);
+        }
+        
+        postCustomRepositoryImpl.deletePostByPostId(postId);
     }
 
 

--- a/src/main/java/org/sopt/bofit/domain/post/service/PostService.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/PostService.java
@@ -47,15 +47,16 @@ public class PostService {
     }
 
     @Transactional
-    public void deletePost(Long userId, Long postId) {
+    public Void deletePost(Long userId, Long postId) {
         User user = userReadService.findUserById(userId);
         Post post = postRepository.findById(postId).orElseThrow(() -> new NotFoundException(POST_NOT_FOUND));
 
         if(!post.getUser().getId().equals(userId)) {
             throw new ForbiddenException(POST_UNAUTHORIZED);
         }
-        
+
         postCustomRepositoryImpl.deletePostByPostId(postId);
+        return null;
     }
 
 

--- a/src/main/java/org/sopt/bofit/global/config/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/org/sopt/bofit/global/config/swagger/SwaggerResponseDescription.java
@@ -45,6 +45,11 @@ public enum SwaggerResponseDescription {
             POST_TITLE_BLANK,
             POST_CONTENT_LONG,
             POST_TITLE_LONG
+    ))),
+    DELETE_POST(new LinkedHashSet<>(Set.of(
+            USER_NOT_FOUND,
+            POST_NOT_FOUND,
+            POST_UNAUTHORIZED
     )))
     ;
     private final Set<ErrorCode> errorCodeList;

--- a/src/main/java/org/sopt/bofit/global/exception/constant/PostErrorCode.java
+++ b/src/main/java/org/sopt/bofit/global/exception/constant/PostErrorCode.java
@@ -10,7 +10,7 @@ public enum PostErrorCode implements ErrorCode {
     POST_TITLE_LONG(HttpStatus.BAD_REQUEST.value(), "제목은 30자 미만으로 입력해주세요."),
     POST_CONTENT_LONG(HttpStatus.BAD_REQUEST.value(), "내용은 3000자 미만으로 작성해주세요"),
     POST_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "존재하지 않는 게시글입니다."),
-    POST_UNAUTHORIZED(HttpStatus.FORBIDDEN.value(), "본인의 게시글만 삭제할 수 있습니다.")
+    POST_UNAUTHORIZED(HttpStatus.FORBIDDEN.value(), "본인의 게시글만 수정/삭제할 수 있습니다.")
 
     ;
     private final int httpStatus;

--- a/src/main/java/org/sopt/bofit/global/response/BaseResponse.java
+++ b/src/main/java/org/sopt/bofit/global/response/BaseResponse.java
@@ -23,4 +23,8 @@ public class BaseResponse<T> {
     public static <T> BaseResponse<T> ok(T data, String message) {
         return new BaseResponse<>(data, message);
     }
+
+    public static <T> BaseResponse<T> ok(String message){
+        return new BaseResponse<>(null, message);
+    }
 }


### PR DESCRIPTION
## Related issue 🛠
- closed #34
 

## Work Description 📝
- [x] 게시물 삭제 기능 구현

## To Reviewers 📢
게시물 삭제 기능을 구현했습니다. 전체 회의 때 모든 항목을 소프트 딜리트하자는 의견대로 소프트 딜리트 방식으로 게시물을 삭제하도록 했습니다.
소프트 딜리트의 경우, `@SQLDelete` 어노테이션을 활용하는 방식과, 직접 쿼리를 지정하는 방식이 있는데, 저는 직접 쿼리를 지정하는 방식으로 구현하였습니다. 왜냐하면 현재는 PostStatus가 ACTIVE, INACTIVE로만 되어 있어 `@SQLDelete`를 사용하는 것이 간편하지만, 실무에서는 잘 사용하지 않는 방법이기도 하고, 추후에 신고 기능 등이 생겨난다면 이와 같이 구현하는 것이 좀 더 유리하다고 판단했습니다.

---

```
{
  "code": 200,
  "message": "내가 쓴 글 조회 성공",
  "data": {
    "content": [
      {
        "postId": 10,
        "title": "아니",
        "content": "저희 대상타면 어떡하나요 ㅈㅉ로?",
        "commentCount": 0,
        "createdAt": "2025-07-09T19:06:46.170281"
      },
      {
        "postId": 9,
        "title": "sdsadad",
        "content": "str23123123",
        "commentCount": 0,
        "createdAt": "2025-07-09T01:40:15.409749"
      },
      {
        "postId": 8,
        "title": "sdsadad",
        "content": "string2",
        "commentCount": 0,
        "createdAt": "2025-07-09T01:40:10.210054"
      },
      {
        "postId": 7,
        "title": "sdsadad",
        "content": "string2",
        "commentCount": 0,
        "createdAt": "2025-07-09T01:40:08.441714"
      },
      {
        "postId": 6,
        "title": "string",
        "content": "string2",
        "commentCount": 0,
        "createdAt": "2025-07-09T01:39:59.968345"
      },
      {
        "postId": 5,
        "title": "아니",
        "content": "저희 대상타면 어떡하나요 ㅈㅉ로?",
        "commentCount": 4,
        "createdAt": "2025-07-09T01:39:53.778546"
      }
    ],
    "nextCursorId": null,
    "isLast": true
  }
}
```
이는 postId가 11인 게시물을 삭제, 즉 PostStatus = INACTIVE로 변경하고 전체 글을 조회한 경우 Response입니다. 글 조회 API에서 이미 Status가 ACTIVE인 경우만 조회하도록 해놓았기 때문에 위와 같이 11번 게시물이 조회되지 않은 결과입니다.