### PR TITLE
[Chore] 유저 정보 응답 DTO 수정

### DIFF
--- a/src/main/java/org/sopt/bofit/domain/user/dto/response/UserProfileResponse.java
+++ b/src/main/java/org/sopt/bofit/domain/user/dto/response/UserProfileResponse.java
@@ -6,9 +6,6 @@ public record UserProfileResponse(
         @Schema(description = "유저 PK", example = "1")
         Long userId,
 
-        @Schema(description = "유저 이름", example = "이정연")
-        String userName,
-
         @Schema(description = "유저 닉네임", example = "장정훈")
         String nickname,
 
@@ -19,8 +16,8 @@ public record UserProfileResponse(
         boolean isRecommendInsurance
 ) {
 
-    public static UserProfileResponse of(Long userId, String userName, String nickname, String profileImageUrl, boolean isRecommendInsurance) {
-        return new UserProfileResponse(userId, userName, nickname, profileImageUrl, isRecommendInsurance);
+    public static UserProfileResponse of(Long userId, String nickname, String profileImageUrl, boolean isRecommendInsurance) {
+        return new UserProfileResponse(userId, nickname, profileImageUrl, isRecommendInsurance);
     }
 
 }

--- a/src/main/java/org/sopt/bofit/domain/user/service/UserReadService.java
+++ b/src/main/java/org/sopt/bofit/domain/user/service/UserReadService.java
@@ -29,7 +29,7 @@ public class UserReadService {
 
         User user = findUserById(userId);
 
-        return UserProfileResponse.of(userId, user.getName(), user.getNickname(), user.getProfileImage(), user.isRecommendInsurance());
+        return UserProfileResponse.of(userId, user.getNickname(), user.getProfileImage(), user.isRecommendInsurance());
 
     }
 


### PR DESCRIPTION
## Related issue 🛠
- closed #37
  


## Work Description 📝
- 카카오 API에서 받아오는 값이 변함에 따라 마이페이지에서 유저 정보 조회 시 실명 정보를 제외했습니다.
