### PR TITLE
[Chore] 로그인 응답 DTO 수정

### DIFF
--- a/src/main/java/org/sopt/bofit/domain/user/entity/User.java
+++ b/src/main/java/org/sopt/bofit/domain/user/entity/User.java
@@ -56,9 +56,6 @@ public class User extends BaseEntity {
     @Column(name = "has_child")
     private boolean hasChild;
 
-    @Column(name = "is_registered")
-    private boolean isRegistered;
-
     @Column(name = "is_recommend_insurance")
     private boolean isRecommendInsurance;
 

--- a/src/main/java/org/sopt/bofit/global/oauth/dto/KaKaoLoginResponse.java
+++ b/src/main/java/org/sopt/bofit/global/oauth/dto/KaKaoLoginResponse.java
@@ -7,9 +7,6 @@ public record KaKaoLoginResponse(
         @Schema(description = "유저 PK", example = "1")
         Long userId,
 
-        @Schema(description = "첫 접속 여부(서비스 고지사항 노출용)", example = "true")
-        boolean isRegistered,
-
         @Schema(description = "액세스 토큰")
         String accessToken,
 
@@ -17,7 +14,7 @@ public record KaKaoLoginResponse(
         String refreshToken
 )
 {
-    public static KaKaoLoginResponse of(Long userId, boolean isRegistered, String accessToken, String refreshToken) {
-        return new KaKaoLoginResponse(userId, isRegistered, accessToken, refreshToken);
+    public static KaKaoLoginResponse of(Long userId, String accessToken, String refreshToken) {
+        return new KaKaoLoginResponse(userId, accessToken, refreshToken);
     }
 }

--- a/src/main/java/org/sopt/bofit/global/oauth/service/OAuthService.java
+++ b/src/main/java/org/sopt/bofit/global/oauth/service/OAuthService.java
@@ -133,7 +133,6 @@ public class OAuthService {
                                             );
                                     return KaKaoLoginResponse.of(
                                             user.getId(),
-                                            user.isRegistered(),
                                             accessToken,
                                             refreshToken
                                     );


### PR DESCRIPTION
## Related issue 🛠
- closed #37
  
## Work Description 📝
- 로그인 후에 노출되는 서비스 고지사항 노출 여부를 결정하는 것이 클라이언트의 로컬 스토리지에 저장하는 방식으로 변경됨에 따라 isRegistered 필드를 삭제했습니다.
