### PR TITLE
[Feat] 보험 추천 리포트 상세 조회 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,6 @@ dependencies {
 
 	//Spring Boot
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
 	//Lombok
 	compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/org/sopt/bofit/domain/insurance/controller/InsuranceController.java
+++ b/src/main/java/org/sopt/bofit/domain/insurance/controller/InsuranceController.java
@@ -2,15 +2,19 @@ package org.sopt.bofit.domain.insurance.controller;
 
 import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.*;
 
+import java.util.UUID;
+
 import org.sopt.bofit.domain.insurancereport.dto.request.InsuranceReportRequest;
 import org.sopt.bofit.domain.insurancereport.dto.response.InsuranceReportDetailResponse;
+import org.sopt.bofit.domain.insurancereport.dto.response.IssueInsuranceReportResponse;
 import org.sopt.bofit.domain.insurancereport.service.InsuranceReportService;
-import org.sopt.bofit.domain.user.dto.response.UserProfileResponse;
 import org.sopt.bofit.domain.user.entity.User;
 import org.sopt.bofit.domain.user.service.UserService;
 import org.sopt.bofit.global.annotation.CustomExceptionDescription;
 import org.sopt.bofit.global.annotation.LoginUserId;
 import org.sopt.bofit.global.response.BaseResponse;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -31,16 +35,27 @@ public class InsuranceController {
 	private final UserService userService;
 
 	@Tag(name = "Insurance", description = "보험 관련 API")
-	@CustomExceptionDescription(INSURANCE_REPORT)
+	@CustomExceptionDescription(ISSUE_INSURANCE_REPORT)
 	@Operation(summary = "보험 상품 추천", description = "보험 상품을 추천 받습니다.")
 	@PostMapping("/reports")
-	public BaseResponse<InsuranceReportDetailResponse> report(
+	public BaseResponse<IssueInsuranceReportResponse> issueReport(
 		@Parameter(hidden = true) @LoginUserId Long userId,
 		@Valid @RequestBody InsuranceReportRequest request){
 		User user = userService.userUpdate(userId, request.toUserUpdate());
-
-		InsuranceReportDetailResponse response = insuranceReportService.recommend(user, request.toUserInfo(user));
+		IssueInsuranceReportResponse response = insuranceReportService.recommend(user, request.toUserInfo(user));
 		return BaseResponse.ok(response, "보험 추천 리포트 발급 성공");
+	}
+
+	@Tag(name = "Insurance", description = "보험 관련 API")
+	@CustomExceptionDescription(GET_INSURANCE_REPORT)
+	@Operation(summary = "보험 상품 상세 조회", description = "보험 상품을 상세 조회합니다.")
+	@GetMapping("/reports/{insurance-report-id}")
+	public BaseResponse<InsuranceReportDetailResponse> getReport(
+		@Parameter(hidden = true) @LoginUserId Long userId,
+		@PathVariable(name = "insurance-report-id") UUID insuranceReportId){
+		InsuranceReportDetailResponse response =
+			insuranceReportService.findInsuranceReportDetailById(insuranceReportId);
+		return BaseResponse.ok(response, "보험 추천 리포트 상세 조회 성공");
 	}
 
 }

--- a/src/main/java/org/sopt/bofit/domain/insurancereport/constant/AdditionalInfo.java
+++ b/src/main/java/org/sopt/bofit/domain/insurancereport/constant/AdditionalInfo.java
@@ -1,0 +1,23 @@
+package org.sopt.bofit.domain.insurancereport.constant;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum AdditionalInfo {
+
+	MAJOR_DISEASE("큰병", "3대 중증질환(암, 뇌혈관, 심장)은 발병률이 높고, 치료비 부담도 커요. 진단 즉시 목돈(진단비)이 지급돼 경제적 부담을 줄여줘요."),
+	CANCER("암", "일반암(위암, 폐암 등)과 소액암(갑상선암, 전립선암 등)으로 나뉘며, 치료비가 저렴하고 완치가 쉽기 때문에 보장금액이 낮게 설정돼요."),
+
+	CEREBROVASCULAR("뇌혈관질환", "뇌출혈→뇌경색→뇌혈관질환 순으로 보장 범위가 넓어져요. 범위가 넓을수록 더 다양한 질환을 보장받을 수 있어요."),
+	HEART_DISEASE("심장질환", " 심근경색보다 허혈성심장질환(협심증, 급성심근경색 포함)이 더 넓은 보장이에요. 확대심장질환과 심부전, 부정맥 특약도 고려해볼 수 있어요."),
+	SURGERY("수술", "예상치 못한 수술에 대비해 수술비를 보장해요. 종수술비는 수술 종류에 따라 금액이 달라지며, 숫자가 클수록 위험도가 높고 보장도 커져요."),
+	HOSPITALIZATION("입원", "입원 시 하루당 일정 금액이 지급돼 병원비와 소득 손실 부담을 덜어줘요. 대부분 연간 180일, 1회 입원당 120일 한도가 있으니 꼭 확인하세요."),
+	DISABILITY("장해", "질병이나 사고로 인한 영구적 신체 손상을 보장해요. 보통 장해지급률 3% 이상부터 해당하며, 3%는 시력 상실, 10%는 손가락 절단 등이 포함돼요."),
+	DEATH("사망", "사망 시 가족에게 지급되는 보장금으로, 생활비와 장례비에 도움이 돼요. 질병사망과 상해사망으로 구분되며, 상해사망은 사고 위험을 반영해 보장 금액이 더 높아요.")
+	;
+
+	private final String description;
+	private final String information;
+}
+
+

--- a/src/main/java/org/sopt/bofit/domain/insurancereport/constant/AdditionalInfo.java
+++ b/src/main/java/org/sopt/bofit/domain/insurancereport/constant/AdditionalInfo.java
@@ -1,7 +1,9 @@
 package org.sopt.bofit.domain.insurancereport.constant;
 
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+@Getter
 @RequiredArgsConstructor
 public enum AdditionalInfo {
 

--- a/src/main/java/org/sopt/bofit/domain/insurancereport/dto/response/InsuranceReportDetailResponse.java
+++ b/src/main/java/org/sopt/bofit/domain/insurancereport/dto/response/InsuranceReportDetailResponse.java
@@ -45,4 +45,23 @@ public record InsuranceReportDetailResponse (
 		);
 	}
 
+	public static InsuranceReportDetailResponse from(
+		InsuranceReport report
+	){
+		InsuranceProduct product = report.getProduct();
+		InsuranceStatistic statistic = report.getStatistic();
+		return new InsuranceReportDetailResponse(
+			report.getId(),
+			product.getId(),
+			product.getBasicInformation(),
+			report.getReportRationale(),
+			MajorDiseaseTotalSection.of(report, product, statistic),
+			SurgeryTotalSection.of(report, product, statistic),
+			DailyHospitalizationTotalSection.of(report, product, statistic),
+			DisabilityTotalSection.of(report, product, statistic),
+			DeathTotalSection.of(report, product, statistic)
+		);
+	}
+
+
 }

--- a/src/main/java/org/sopt/bofit/domain/insurancereport/dto/response/IssueInsuranceReportResponse.java
+++ b/src/main/java/org/sopt/bofit/domain/insurancereport/dto/response/IssueInsuranceReportResponse.java
@@ -1,0 +1,8 @@
+package org.sopt.bofit.domain.insurancereport.dto.response;
+
+import java.util.UUID;
+
+public record IssueInsuranceReportResponse (
+	UUID insuranceReportId
+) {
+}

--- a/src/main/java/org/sopt/bofit/domain/insurancereport/dto/response/dailyHospitalization/DailyHospitalizationTotalSection.java
+++ b/src/main/java/org/sopt/bofit/domain/insurancereport/dto/response/dailyHospitalization/DailyHospitalizationTotalSection.java
@@ -3,9 +3,13 @@ package org.sopt.bofit.domain.insurancereport.dto.response.dailyHospitalization;
 import org.sopt.bofit.domain.insurance.entity.benefit.DailyHospitalization;
 import org.sopt.bofit.domain.insurance.entity.benefit.InsuranceBenefit;
 import org.sopt.bofit.domain.insurance.entity.product.InsuranceProduct;
+import org.sopt.bofit.domain.insurancereport.constant.AdditionalInfo;
 import org.sopt.bofit.domain.insurancereport.entity.InsuranceReport;
 
+import com.sun.source.doctree.SeeTree;
+
 public record DailyHospitalizationTotalSection(
+	String additionalInfo,
 	String coverageStatus,
 	DailyHospitalizationSection diseaseDailyHospitalization,
 	DailyHospitalizationSection injuryDailyHospitalization
@@ -18,6 +22,7 @@ public record DailyHospitalizationTotalSection(
 		DailyHospitalization productDailyHospitalization = product.getDailyHospitalization();
 		DailyHospitalization averageDailyHospitalization = average.getDailyHospitalization();
 		return new DailyHospitalizationTotalSection(
+			AdditionalInfo.HOSPITALIZATION.getInformation(),
 			report.getDailyHospitalization().getDescription(),
 			DailyHospitalizationSection.of(report.getDiseaseDailyHospitalization(),
 				productDailyHospitalization.getDisease(), averageDailyHospitalization.getDisease()),

--- a/src/main/java/org/sopt/bofit/domain/insurancereport/dto/response/death/DeathTotalSection.java
+++ b/src/main/java/org/sopt/bofit/domain/insurancereport/dto/response/death/DeathTotalSection.java
@@ -3,9 +3,11 @@ package org.sopt.bofit.domain.insurancereport.dto.response.death;
 import org.sopt.bofit.domain.insurance.entity.benefit.Death;
 import org.sopt.bofit.domain.insurance.entity.benefit.InsuranceBenefit;
 import org.sopt.bofit.domain.insurance.entity.product.InsuranceProduct;
+import org.sopt.bofit.domain.insurancereport.constant.AdditionalInfo;
 import org.sopt.bofit.domain.insurancereport.entity.InsuranceReport;
 
 public record DeathTotalSection(
+	String additionalInfo,
 	String coverageStatus,
 	DeathSection disease,
 	DeathSection injury
@@ -13,11 +15,13 @@ public record DeathTotalSection(
 	public static DeathTotalSection of(
 		InsuranceReport report,
 		InsuranceProduct product,
-		InsuranceBenefit average){
+		InsuranceBenefit average
+	){
 		Death productDeath = product.getDeath();
 		Death averageDeath = average.getDeath();
 
 		return new DeathTotalSection(
+			AdditionalInfo.DEATH.getInformation(),
 			report.getDeath().getDescription(),
 			DeathSection.of(report.getDiseaseDeath(), productDeath.getDisease(), averageDeath.getDisease()),
 			DeathSection.of(report.getInjuryDeath(), productDeath.getInjury(), averageDeath.getInjury())

--- a/src/main/java/org/sopt/bofit/domain/insurancereport/dto/response/disability/DisabilityTotalSection.java
+++ b/src/main/java/org/sopt/bofit/domain/insurancereport/dto/response/disability/DisabilityTotalSection.java
@@ -3,9 +3,11 @@ package org.sopt.bofit.domain.insurancereport.dto.response.disability;
 import org.sopt.bofit.domain.insurance.entity.benefit.Disability;
 import org.sopt.bofit.domain.insurance.entity.benefit.InsuranceBenefit;
 import org.sopt.bofit.domain.insurance.entity.product.InsuranceProduct;
+import org.sopt.bofit.domain.insurancereport.constant.AdditionalInfo;
 import org.sopt.bofit.domain.insurancereport.entity.InsuranceReport;
 
 public record DisabilityTotalSection(
+	String additionalInfo,
 	String coverageStatus,
 	DisabilitySection disease,
 	DisabilitySection injury
@@ -18,6 +20,7 @@ public record DisabilityTotalSection(
 		Disability productDisability = product.getDisability();
 		Disability averageDisability = average.getDisability();
 		return new DisabilityTotalSection(
+			AdditionalInfo.DISABILITY.getInformation(),
 			report.getDisability().getDescription(),
 			DisabilitySection.of(report.getDiseaseDisability() ,
 				productDisability.getDiseaseGE3PCT(), averageDisability.getDiseaseGE3PCT()),

--- a/src/main/java/org/sopt/bofit/domain/insurancereport/dto/response/majordisease/CancerSection.java
+++ b/src/main/java/org/sopt/bofit/domain/insurancereport/dto/response/majordisease/CancerSection.java
@@ -3,9 +3,11 @@ package org.sopt.bofit.domain.insurancereport.dto.response.majordisease;
 import org.sopt.bofit.domain.insurance.entity.benefit.Cancer;
 import org.sopt.bofit.domain.insurance.entity.benefit.InsuranceBenefit;
 import org.sopt.bofit.domain.insurance.entity.product.InsuranceProduct;
+import org.sopt.bofit.domain.insurancereport.constant.AdditionalInfo;
 import org.sopt.bofit.domain.insurancereport.entity.constant.CoverageStatus;
 
 public record CancerSection(
+	String additionalInfo,
 	String coverageStatus,
 	MajorDiseaseSubSection general,
 	MajorDiseaseSubSection atypical
@@ -13,7 +15,9 @@ public record CancerSection(
 	public static CancerSection of(CoverageStatus status, InsuranceProduct product, InsuranceBenefit average){
 		Cancer productCancer = product.getMajorDisease().getCancer();
 		Cancer averageCancer = average.getMajorDisease().getCancer();
-		return new CancerSection(status.getDescription(),
+		return new CancerSection(
+			AdditionalInfo.CANCER.getInformation(),
+			status.getDescription(),
 			MajorDiseaseSubSection.of(productCancer.getGeneralDiagnosis(), averageCancer.getGeneralDiagnosis(),
 				productCancer.getGeneralSurgery(), averageCancer.getGeneralSurgery()),
 			MajorDiseaseSubSection.of(productCancer.getAtypicalDiagnosis(), averageCancer.getAtypicalDiagnosis(),

--- a/src/main/java/org/sopt/bofit/domain/insurancereport/dto/response/majordisease/CerebrovascularSection.java
+++ b/src/main/java/org/sopt/bofit/domain/insurancereport/dto/response/majordisease/CerebrovascularSection.java
@@ -3,9 +3,11 @@ package org.sopt.bofit.domain.insurancereport.dto.response.majordisease;
 import org.sopt.bofit.domain.insurance.entity.benefit.Cerebrovascular;
 import org.sopt.bofit.domain.insurance.entity.benefit.InsuranceBenefit;
 import org.sopt.bofit.domain.insurance.entity.product.InsuranceProduct;
+import org.sopt.bofit.domain.insurancereport.constant.AdditionalInfo;
 import org.sopt.bofit.domain.insurancereport.entity.constant.CoverageStatus;
 
 public record CerebrovascularSection(
+	String additionalInfo,
 	String coverageStatus,
 	MajorDiseaseSubSection hemorrhage,
 	MajorDiseaseSubSection infarction,
@@ -16,7 +18,9 @@ public record CerebrovascularSection(
 		Cerebrovascular productCerebrovascular = product.getMajorDisease().getCerebrovascular();
 		Cerebrovascular averageCerebrovascular = average.getMajorDisease().getCerebrovascular();
 
-		return new CerebrovascularSection(status.getDescription(),
+		return new CerebrovascularSection(
+			AdditionalInfo.CEREBROVASCULAR.getInformation(),
+			status.getDescription(),
 			MajorDiseaseSubSection.of(
 				productCerebrovascular.getHemorrhageDiagnosis(), averageCerebrovascular.getHemorrhageDiagnosis(),
 				productCerebrovascular.getHemorrhageSurgery(), averageCerebrovascular.getHemorrhageSurgery()),

--- a/src/main/java/org/sopt/bofit/domain/insurancereport/dto/response/majordisease/HeartSection.java
+++ b/src/main/java/org/sopt/bofit/domain/insurancereport/dto/response/majordisease/HeartSection.java
@@ -3,9 +3,11 @@ package org.sopt.bofit.domain.insurancereport.dto.response.majordisease;
 import org.sopt.bofit.domain.insurance.entity.benefit.Heart;
 import org.sopt.bofit.domain.insurance.entity.benefit.InsuranceBenefit;
 import org.sopt.bofit.domain.insurance.entity.product.InsuranceProduct;
+import org.sopt.bofit.domain.insurancereport.constant.AdditionalInfo;
 import org.sopt.bofit.domain.insurancereport.entity.constant.CoverageStatus;
 
 public record HeartSection(
+	String additionalInfo,
 	String coverageStatus,
 	MajorDiseaseSubSection acuteMyocardialInfarction,
 	MajorDiseaseSubSection ischemic,
@@ -16,7 +18,9 @@ public record HeartSection(
 		Heart productHeart = product.getMajorDisease().getHeart();
 		Heart averageHeart = average.getMajorDisease().getHeart();
 
-		return new HeartSection(status.getDescription(),
+		return new HeartSection(
+			AdditionalInfo.HEART_DISEASE.getInformation(),
+			status.getDescription(),
 			MajorDiseaseSubSection.of(
 				productHeart.getAcuteMyocardialInfarctionDiagnosis(), averageHeart.getAcuteMyocardialInfarctionDiagnosis(),
 				productHeart.getAcuteMyocardialInfarctionSurgery(), averageHeart.getAcuteMyocardialInfarctionSurgery()),

--- a/src/main/java/org/sopt/bofit/domain/insurancereport/dto/response/majordisease/MajorDiseaseTotalSection.java
+++ b/src/main/java/org/sopt/bofit/domain/insurancereport/dto/response/majordisease/MajorDiseaseTotalSection.java
@@ -2,17 +2,20 @@ package org.sopt.bofit.domain.insurancereport.dto.response.majordisease;
 
 import org.sopt.bofit.domain.insurance.entity.product.InsuranceProduct;
 import org.sopt.bofit.domain.insurance.entity.statistic.InsuranceStatistic;
+import org.sopt.bofit.domain.insurancereport.constant.AdditionalInfo;
 import org.sopt.bofit.domain.insurancereport.entity.InsuranceReport;
 
 public record MajorDiseaseTotalSection(
+	String additionalInfo,
 	String coverageStatus,
 	CancerSection cancerSection,
 	CerebrovascularSection cerebrovascularSection,
 	HeartSection heartSection
-
 ) {
 	public static MajorDiseaseTotalSection of (InsuranceReport report, InsuranceProduct product, InsuranceStatistic average){
-		return new MajorDiseaseTotalSection(report.getMajorDisease().getDescription(),
+		return new MajorDiseaseTotalSection(
+			AdditionalInfo.MAJOR_DISEASE.getInformation(),
+			report.getMajorDisease().getDescription(),
 			CancerSection.of(report.getCancer(), product, average),
 			CerebrovascularSection.of(report.getCerebrovascular(), product, average),
 			HeartSection.of(report.getHeartDisease(), product, average));

--- a/src/main/java/org/sopt/bofit/domain/insurancereport/dto/response/surgery/SurgeryTotalSection.java
+++ b/src/main/java/org/sopt/bofit/domain/insurancereport/dto/response/surgery/SurgeryTotalSection.java
@@ -15,19 +15,19 @@ public record SurgeryTotalSection(
 ) {
 	public static SurgeryTotalSection of(InsuranceReport report, InsuranceProduct product, InsuranceStatistic average){
 		Surgery productSurgery = product.getSurgery();
-		Surgery averagesurgery = average.getSurgery();
+		Surgery averageSurgery = average.getSurgery();
 
 		return new SurgeryTotalSection(
 			report.getSurgery().getDescription(),
 			SurgerySection.of(report.getDiseaseSurgery(),
-				productSurgery.getDiseaseSurgery(), averagesurgery.getInjurySurgery()),
+				productSurgery.getDiseaseSurgery(), averageSurgery.getInjurySurgery()),
 			SurgeryTypeSection.of(report.getDiseaseSurgery(),
-				productSurgery.getDiseaseSurgery(), averagesurgery.getDiseaseSurgery()),
+				productSurgery.getDiseaseSurgery(), averageSurgery.getDiseaseSurgery()),
 
 			SurgerySection.of(report.getInjurySurgery(),
-				productSurgery.getInjurySurgery(), productSurgery.getInjurySurgery()),
+				productSurgery.getInjurySurgery(), averageSurgery.getInjurySurgery()),
 			SurgeryTypeSection.of(report.getInjuryTypeSurgery(),
-				productSurgery.getInjurySurgery(), averagesurgery.getInjurySurgery())
+				productSurgery.getInjurySurgery(), averageSurgery.getInjurySurgery())
 		);
 	}
 

--- a/src/main/java/org/sopt/bofit/domain/insurancereport/errorcode/InsuranceReportErrorCode.java
+++ b/src/main/java/org/sopt/bofit/domain/insurancereport/errorcode/InsuranceReportErrorCode.java
@@ -1,0 +1,26 @@
+package org.sopt.bofit.domain.insurancereport.errorcode;
+
+import org.sopt.bofit.global.exception.constant.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum InsuranceReportErrorCode implements ErrorCode {
+
+	NOT_FOUND_INSURANCE_REPORT(HttpStatus.NOT_FOUND.value(), "보험 추천 리포트를 찾을 수 없습니다.")
+	;
+
+	private final int httpStatus;
+	private final String message;
+
+	@Override
+	public int getHttpStatus() {
+		return httpStatus;
+	}
+
+	@Override
+	public String getMessage() {
+		return message;
+	}
+}

--- a/src/main/java/org/sopt/bofit/domain/insurancereport/repository/InsuranceReportRepository.java
+++ b/src/main/java/org/sopt/bofit/domain/insurancereport/repository/InsuranceReportRepository.java
@@ -1,11 +1,23 @@
 package org.sopt.bofit.domain.insurancereport.repository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 import org.sopt.bofit.domain.insurancereport.entity.InsuranceReport;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface InsuranceReportRepository extends JpaRepository<InsuranceReport, UUID> {
+
+	@Query("select ir "
+		+ "from InsuranceReport ir "
+		+ "left join fetch InsuranceProduct "
+		+ "left join fetch InsuranceStatistic "
+		+ "where ir.id = :id")
+	Optional<InsuranceReport> findByIdWithProductAndStatistic(@Param("id") UUID id);
+
+
 }

--- a/src/main/java/org/sopt/bofit/domain/insurancereport/repository/InsuranceReportRepository.java
+++ b/src/main/java/org/sopt/bofit/domain/insurancereport/repository/InsuranceReportRepository.java
@@ -14,10 +14,9 @@ public interface InsuranceReportRepository extends JpaRepository<InsuranceReport
 
 	@Query("select ir "
 		+ "from InsuranceReport ir "
-		+ "left join fetch InsuranceProduct "
-		+ "left join fetch InsuranceStatistic "
+		+ "left join fetch ir.product ip "
+		+ "left join fetch ir.statistic is "
 		+ "where ir.id = :id")
 	Optional<InsuranceReport> findByIdWithProductAndStatistic(@Param("id") UUID id);
-
 
 }

--- a/src/main/java/org/sopt/bofit/domain/insurancereport/service/InsuranceReportReader.java
+++ b/src/main/java/org/sopt/bofit/domain/insurancereport/service/InsuranceReportReader.java
@@ -23,7 +23,7 @@ public class InsuranceReportReader {
 	}
 
 	public InsuranceReport findByIdWithRelatedEntity(UUID insuranceReportId){
-		return insuranceReportRepository.findById(insuranceReportId).orElseThrow(() ->
+		return insuranceReportRepository.findByIdWithProductAndStatistic(insuranceReportId).orElseThrow(() ->
 			new NotFoundException(InsuranceReportErrorCode.NOT_FOUND_INSURANCE_REPORT));
 	}
 }

--- a/src/main/java/org/sopt/bofit/domain/insurancereport/service/InsuranceReportReader.java
+++ b/src/main/java/org/sopt/bofit/domain/insurancereport/service/InsuranceReportReader.java
@@ -1,7 +1,13 @@
 package org.sopt.bofit.domain.insurancereport.service;
 
+import java.util.UUID;
+
 import org.sopt.bofit.domain.insurance.entity.product.InsuranceProduct;
+import org.sopt.bofit.domain.insurancereport.entity.InsuranceReport;
+import org.sopt.bofit.domain.insurancereport.errorcode.InsuranceReportErrorCode;
 import org.sopt.bofit.domain.insurancereport.repository.InsuranceReportRepository;
+import org.sopt.bofit.global.exception.constant.InsuranceErrorCode;
+import org.sopt.bofit.global.exception.custom_exception.NotFoundException;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
@@ -10,4 +16,14 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class InsuranceReportReader {
 	private final InsuranceReportRepository insuranceReportRepository;
+
+	public InsuranceReport findById(UUID insuranceReportId){
+		return insuranceReportRepository.findById(insuranceReportId).orElseThrow(() ->
+			new NotFoundException(InsuranceReportErrorCode.NOT_FOUND_INSURANCE_REPORT));
+	}
+
+	public InsuranceReport findByIdWithRelatedEntity(UUID insuranceReportId){
+		return insuranceReportRepository.findById(insuranceReportId).orElseThrow(() ->
+			new NotFoundException(InsuranceReportErrorCode.NOT_FOUND_INSURANCE_REPORT));
+	}
 }

--- a/src/main/java/org/sopt/bofit/domain/insurancereport/service/InsuranceReportService.java
+++ b/src/main/java/org/sopt/bofit/domain/insurancereport/service/InsuranceReportService.java
@@ -1,12 +1,14 @@
 package org.sopt.bofit.domain.insurancereport.service;
 
 import java.util.List;
+import java.util.UUID;
 
 import org.sopt.bofit.domain.insurance.entity.product.InsuranceProduct;
 import org.sopt.bofit.domain.insurance.entity.statistic.InsuranceStatistic;
 import org.sopt.bofit.domain.insurance.service.InsuranceProductReader;
 import org.sopt.bofit.domain.insurance.service.InsuranceStatisticReader;
 import org.sopt.bofit.domain.insurancereport.dto.response.InsuranceReportDetailResponse;
+import org.sopt.bofit.domain.insurancereport.dto.response.IssueInsuranceReportResponse;
 import org.sopt.bofit.domain.insurancereport.entity.InsuranceReport;
 import org.sopt.bofit.domain.user.entity.User;
 import org.sopt.bofit.domain.user.entity.UserInfo;
@@ -25,8 +27,7 @@ public class InsuranceReportService {
 
 	private final InsuranceStatisticReader insuranceStatisticReader;
 
-
-	public InsuranceReportDetailResponse recommend(User user, UserInfo userInfo){
+	public IssueInsuranceReportResponse recommend(User user, UserInfo userInfo){
 		int age = UserUtil.convertInternationalAge(user.getBirthDate());
 
 		List<InsuranceProduct> products
@@ -41,6 +42,11 @@ public class InsuranceReportService {
 			totalAverage, recommendedProduct, user, userInfo, age);
 		user.recommendedInsurance();
 
-		return InsuranceReportDetailResponse.of(insuranceReport, recommendedProduct, totalAverage);
+		return new IssueInsuranceReportResponse(insuranceReport.getId());
+	}
+
+	public InsuranceReportDetailResponse findInsuranceReportDetailById(UUID insuranceReportId){
+		return InsuranceReportDetailResponse.from(
+			insuranceReportReader.findByIdWithRelatedEntity(insuranceReportId));
 	}
 }

--- a/src/main/java/org/sopt/bofit/domain/insurancereport/template/ReportPromptTemplate.java
+++ b/src/main/java/org/sopt/bofit/domain/insurancereport/template/ReportPromptTemplate.java
@@ -26,6 +26,13 @@ public class ReportPromptTemplate {
 	){
 		return OpenAiPromptTemplate.createDefaultMessage(
     """
+	각 bullet은 반드시 한 문장으로만 작성.
+	문장 길이는 짧고 명확하되, 의미가 부족하지 않도록 구성 (30-35자 내외)
+	각 문장은 반드시 사용자 정보 기반의 '이유 + 설계 방향'을 포함할 것
+	말하듯 자연스럽고 부드럽게, 그러나 단정하고 신뢰감 있는 톤으로 작성할 것
+	다음과 같은 표현은 사용하지 말 것: “꼼꼼히 설계했어요”, “든든하게 준비했어요”, “필요할 것 같아요”, “~같아서”, “보장을 담았어요”처럼 뭉뚱그리거나 확신 없는 표현
+	각 문장은 bullet로 구분해 총 3~4개 작성
+    
     reasons max size < 5, keywordChips max size < 3
     reasons example: "운전이 잦아 상해 위험 대비가 필요해요", "미혼인 점을 참고해 실제 치료비 중심으로 구성했어요", "근골격계 이력으로 병원비 보장을 강화했어요"
     keywordChips example: "중대 질환 든든 보장", "합리적인 보험료"

--- a/src/main/java/org/sopt/bofit/global/config/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/org/sopt/bofit/global/config/swagger/SwaggerResponseDescription.java
@@ -1,13 +1,14 @@
 package org.sopt.bofit.global.config.swagger;
 
 import lombok.Getter;
-import org.sopt.bofit.global.exception.constant.*;
+
 import org.sopt.bofit.global.exception.constant.ErrorCode;
 import org.sopt.bofit.global.exception.constant.GlobalErrorCode;
 
 import java.util.LinkedHashSet;
 import java.util.Set;
 
+import static org.sopt.bofit.domain.insurancereport.errorcode.InsuranceReportErrorCode.*;
 import static org.sopt.bofit.global.exception.constant.InsuranceErrorCode.*;
 import static org.sopt.bofit.global.exception.constant.OAuthErrorCode.*;
 import static org.sopt.bofit.global.exception.constant.PostErrorCode.*;
@@ -54,9 +55,12 @@ public enum SwaggerResponseDescription {
             POST_NOT_FOUND,
             POST_UNAUTHORIZED
     ))),
-    INSURANCE_REPORT(new LinkedHashSet<>(Set.of(
+    ISSUE_INSURANCE_REPORT(new LinkedHashSet<>(Set.of(
         NOT_FOUND_INSURANCE_TOTAL_AVERAGE,
         NOT_FOUND_RECOMMENDED_STATUS_INSURANCE
+    ))),
+    GET_INSURANCE_REPORT(new LinkedHashSet<>(Set.of(
+        NOT_FOUND_INSURANCE_REPORT
     )))
     ;
     private final Set<ErrorCode> errorCodeList;


### PR DESCRIPTION
## Related issue 🛠
- closed #42 
  

## Work Description 📝
- 보험 추천 리포트 상세 조회 구현
- 보험 추천 조회 시 additionalInfo 를 함께 제세하도록 추가 
- AdditionalInfo를 enum 으로 사용한 이유는
1. 해당 데이터는 고정 데이터이므로 정보가 변화할 일이 적음. 클라이언트에서 내려주는 형태 불가능한 상황이어서 부득이하게 서버에서 해당 방식을 사용해서 처리함. 캐싱을 사용하더라도 주기적으로 데이터를 긁어와야할텐데 수정이 너무 드물기 때문에 캐싱의 TTL이 길어질 것 같았고 그럴 바에는 상수로 저장하고 사용하는 방식이 좋았을 것 같다고 판단됨
2. 범위가 넓지 않지만 리포트 상세 조회 시 자주 사용되는 고정값이며 내용의 크기가 크지 않기 때문에 상수로 처리함.

## Uncompleted Tasks 😅

## To Reviewers 📢
