### PR TITLE
[Feat] 댓글 작성 API 구현

### DIFF
--- a/src/main/java/org/sopt/bofit/domain/comment/constant/CommentConstant.java
+++ b/src/main/java/org/sopt/bofit/domain/comment/constant/CommentConstant.java
@@ -1,0 +1,9 @@
+package org.sopt.bofit.domain.comment.constant;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class CommentConstant {
+	public static final int COMMENT_CONTENT_MAX_SIZE = 30;
+}

--- a/src/main/java/org/sopt/bofit/domain/comment/dto/request/CommentCreateRequest.java
+++ b/src/main/java/org/sopt/bofit/domain/comment/dto/request/CommentCreateRequest.java
@@ -1,0 +1,16 @@
+package org.sopt.bofit.domain.comment.dto.request;
+
+import static org.sopt.bofit.domain.comment.constant.CommentConstant.*;
+
+import org.hibernate.validator.constraints.Length;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+public record CommentCreateRequest (
+	@Schema(description = "댓글 내용", example = "좋은 글이네요")
+	@NotBlank(message = "content 는 필수 항목입니다.")
+	@Length(max = COMMENT_CONTENT_MAX_SIZE, message = "content 의 최대 길이인 {max}을 초과했습니다.")
+	String content
+) {
+}

--- a/src/main/java/org/sopt/bofit/domain/comment/entity/Comment.java
+++ b/src/main/java/org/sopt/bofit/domain/comment/entity/Comment.java
@@ -3,6 +3,7 @@ package org.sopt.bofit.domain.comment.entity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.sopt.bofit.domain.post.entity.Post;
@@ -17,6 +18,7 @@ public class Comment extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "comment_id")
     private Long id;
 
     @Column(nullable = false, length = 300)

--- a/src/main/java/org/sopt/bofit/domain/comment/entity/Comment.java
+++ b/src/main/java/org/sopt/bofit/domain/comment/entity/Comment.java
@@ -12,7 +12,6 @@ import org.sopt.bofit.global.entity.BaseEntity;
 
 @Entity
 @Getter
-@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Comment extends BaseEntity {
 
@@ -21,13 +20,6 @@ public class Comment extends BaseEntity {
     @Column(name = "comment_id")
     private Long id;
 
-    @Column(nullable = false, length = 300)
-    private String content;
-
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
-    private CommentStatus status;
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
@@ -35,4 +27,28 @@ public class Comment extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id")
     private Post post;
+
+    @Column(nullable = false, length = 300)
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private CommentStatus status;
+
+    public static Comment create(Post post, User user, String content){
+        return Comment.builder()
+            .content(content)
+            .post(post)
+            .status(CommentStatus.ACTIVE)
+            .user(user)
+            .build();
+    }
+
+    @Builder
+    private Comment(String content, CommentStatus status, User user, Post post) {
+        this.content = content;
+        this.status = status;
+        this.user = user;
+        this.post = post;
+    }
 }

--- a/src/main/java/org/sopt/bofit/domain/comment/repository/CommentJpaRepository.java
+++ b/src/main/java/org/sopt/bofit/domain/comment/repository/CommentJpaRepository.java
@@ -1,0 +1,11 @@
+package org.sopt.bofit.domain.comment.repository;
+
+import java.util.List;
+
+import org.sopt.bofit.domain.comment.entity.Comment;
+import org.sopt.bofit.domain.comment.entity.CommentStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentJpaRepository extends JpaRepository<Comment, Long> {
+	List<Comment> findAllByPostIdAndStatus(Long postId, CommentStatus status);
+}

--- a/src/main/java/org/sopt/bofit/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/org/sopt/bofit/domain/comment/repository/CommentRepository.java
@@ -1,12 +1,9 @@
 package org.sopt.bofit.domain.comment.repository;
 
-import org.sopt.bofit.domain.comment.entity.Comment;
-import org.sopt.bofit.domain.comment.entity.CommentStatus;
-import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
-import java.util.List;
 
-public interface CommentRepository extends JpaRepository<Comment, Long> {
+@Repository
+public interface CommentRepository extends CommentCustomRepository, CommentJpaRepository {
 
-    List<Comment> findAllByPostIdAndStatus(Long postId, CommentStatus status);
 }

--- a/src/main/java/org/sopt/bofit/domain/comment/service/CommentReader.java
+++ b/src/main/java/org/sopt/bofit/domain/comment/service/CommentReader.java
@@ -1,0 +1,12 @@
+package org.sopt.bofit.domain.comment.service;
+
+import org.sopt.bofit.domain.comment.repository.CommentRepository;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class CommentReader {
+	private final CommentRepository commentRepository;
+}

--- a/src/main/java/org/sopt/bofit/domain/comment/service/CommentService.java
+++ b/src/main/java/org/sopt/bofit/domain/comment/service/CommentService.java
@@ -1,12 +1,32 @@
 package org.sopt.bofit.domain.comment.service;
 
-import lombok.RequiredArgsConstructor;
+import org.sopt.bofit.domain.comment.dto.request.CommentCreateRequest;
+import org.sopt.bofit.domain.comment.entity.Comment;
 import org.sopt.bofit.domain.comment.repository.CommentRepository;
+import org.sopt.bofit.domain.post.entity.Post;
+import org.sopt.bofit.domain.post.service.PostReader;
+import org.sopt.bofit.domain.user.entity.User;
+import org.sopt.bofit.domain.user.service.UserReader;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
 public class CommentService {
+	private final CommentReader commentReader;
+	private final CommentWriter commentWriter;
 
-    private final CommentRepository commentRepository;
+	private final PostReader postReader;
+
+	private final UserReader userReader;
+
+	@Transactional
+	public void createComment(Long userId, Long postId, CommentCreateRequest request){
+		Post post = postReader.findById(postId);
+		User user = userReader.findById(userId);
+
+		Comment comment = commentWriter.createComment(post, user, request.content());
+	}
 }

--- a/src/main/java/org/sopt/bofit/domain/comment/service/CommentWriter.java
+++ b/src/main/java/org/sopt/bofit/domain/comment/service/CommentWriter.java
@@ -1,0 +1,23 @@
+package org.sopt.bofit.domain.comment.service;
+
+import org.sopt.bofit.domain.comment.entity.Comment;
+import org.sopt.bofit.domain.comment.repository.CommentRepository;
+import org.sopt.bofit.domain.post.entity.Post;
+import org.sopt.bofit.domain.user.entity.User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class CommentWriter {
+	private final CommentRepository commentRepository;
+
+	@Transactional
+	public Comment createComment(Post post, User user, String content){
+		Comment comment = Comment.create(post, user, content);
+
+		return commentRepository.save(comment);
+	}
+}

--- a/src/main/java/org/sopt/bofit/domain/post/controller/PostController.java
+++ b/src/main/java/org/sopt/bofit/domain/post/controller/PostController.java
@@ -5,6 +5,9 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+
+import org.sopt.bofit.domain.comment.dto.request.CommentCreateRequest;
+import org.sopt.bofit.domain.comment.service.CommentService;
 import org.sopt.bofit.domain.post.dto.request.PostCreateRequest;
 import org.sopt.bofit.domain.post.dto.response.PostCreateResponse;
 import org.sopt.bofit.domain.post.dto.response.PostDetailResponse;
@@ -24,6 +27,7 @@ import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.*;
 public class PostController {
 
     private final PostService postService;
+    private final CommentService commentService;
 
     @Tag(name = "Community", description = "커뮤니티 관련 API")
     @Operation(summary = "게시물 작성", description = "커뮤니티에 글을 작성합니다.")
@@ -77,5 +81,18 @@ public class PostController {
             @PathVariable Long postId
     ){
         return BaseResponse.ok(postService.getPostDetail(postId),"글 상세 조회 성공");
+    }
+
+    @Tag(name = "Community", description = "커뮤니티 관련 API")
+    @Operation(summary = "댓글 작성", description = "커뮤니티 게시글에 댓글을 작성합니다.")
+    @CustomExceptionDescription(CREATE_POST)
+    @PostMapping("/{post-id}/comments")
+    public BaseResponse<PostCreateResponse> createComment(
+        @RequestBody @Valid CommentCreateRequest request,
+        @PathVariable(name = "post-id") Long postId,
+        @Parameter(hidden = true) @LoginUserId Long userId
+    ){
+        commentService.createComment(userId, postId, request);
+        return BaseResponse.ok("댓글 생성 성공");
     }
 }

--- a/src/main/java/org/sopt/bofit/domain/post/entity/Post.java
+++ b/src/main/java/org/sopt/bofit/domain/post/entity/Post.java
@@ -16,6 +16,7 @@ public class Post extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "post_id")
     private Long id;
 
     @Column(nullable = false, length = 30)

--- a/src/main/java/org/sopt/bofit/domain/post/repository/PostJpaRepository.java
+++ b/src/main/java/org/sopt/bofit/domain/post/repository/PostJpaRepository.java
@@ -2,8 +2,6 @@ package org.sopt.bofit.domain.post.repository;
 
 import org.sopt.bofit.domain.post.entity.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
-@Repository
-public interface PostRepository extends PostJpaRepository, PostCustomRepository{
+public interface PostJpaRepository extends JpaRepository<Post, Long> {
 }

--- a/src/main/java/org/sopt/bofit/domain/post/service/PostReader.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/PostReader.java
@@ -26,13 +26,11 @@ import static org.sopt.bofit.global.exception.constant.PostErrorCode.POST_NOT_FO
 public class PostReader {
     private final PostRepository postRepository;
 
-    private final PostCustomRepositoryImpl postCustomRepositoryImpl;
-
     private final CommentRepository commentRepository;
 
     public SliceResponse<PostSummaryResponse> getAllPosts(Long cursorId, int size){
 
-        Slice<PostSummaryResponse> postList = postCustomRepositoryImpl.findAllByCursorId(cursorId, size);
+        Slice<PostSummaryResponse> postList = postRepository.findAllByCursorId(cursorId, size);
 
         return SliceResponse.of(postList);
     }

--- a/src/main/java/org/sopt/bofit/domain/post/service/PostWriter.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/PostWriter.java
@@ -21,11 +21,10 @@ public class PostWriter {
 
     private final UserReader userReader;
 
-    private final PostRepository postRepository;
-
     private final PostReader postReader;
 
-    private final PostCustomRepositoryImpl postCustomRepositoryImpl;
+    private final PostRepository postRepository;
+
 
     public PostCreateResponse createPost(Long userId, String title, String content) {
         User user = userReader.findById(userId);
@@ -61,6 +60,6 @@ public class PostWriter {
         Post post = postReader.findById(postId);
         checkUserIsOwner(userId, post);
 
-        postCustomRepositoryImpl.deletePostByPostId(postId);
+        postRepository.deletePostByPostId(postId);
     }
 }

--- a/src/main/java/org/sopt/bofit/domain/user/service/UserReader.java
+++ b/src/main/java/org/sopt/bofit/domain/user/service/UserReader.java
@@ -2,6 +2,7 @@ package org.sopt.bofit.domain.user.service;
 
 import lombok.RequiredArgsConstructor;
 
+import org.sopt.bofit.domain.comment.repository.CommentRepository;
 import org.sopt.bofit.domain.user.dto.response.DiagnosedDiseaseResponses;
 import org.sopt.bofit.domain.comment.repository.CommentCustomRepositoryImpl;
 import org.sopt.bofit.domain.post.repository.PostCustomRepositoryImpl;
@@ -28,7 +29,7 @@ public class UserReader {
 
     private final PostCustomRepositoryImpl postCustomRepositoryImpl;
 
-    private final CommentCustomRepositoryImpl commentCustomRepositoryImpl;
+    private final CommentRepository commentRepository;
     
     public UserProfileResponse getUserInfo(Long userId){
 
@@ -60,7 +61,7 @@ public class UserReader {
 
         findById(userId);
 
-        Slice<MyCommentSummaryResponse> comments = commentCustomRepositoryImpl.findCommentsByCursorId(userId, cursorId, size);
+        Slice<MyCommentSummaryResponse> comments = commentRepository.findCommentsByCursorId(userId, cursorId, size);
 
         return SliceResponse.of(comments);
     }

--- a/src/main/java/org/sopt/bofit/domain/user/service/UserReader.java
+++ b/src/main/java/org/sopt/bofit/domain/user/service/UserReader.java
@@ -3,6 +3,7 @@ package org.sopt.bofit.domain.user.service;
 import lombok.RequiredArgsConstructor;
 
 import org.sopt.bofit.domain.comment.repository.CommentRepository;
+import org.sopt.bofit.domain.post.repository.PostRepository;
 import org.sopt.bofit.domain.user.dto.response.DiagnosedDiseaseResponses;
 import org.sopt.bofit.domain.comment.repository.CommentCustomRepositoryImpl;
 import org.sopt.bofit.domain.post.repository.PostCustomRepositoryImpl;
@@ -27,7 +28,7 @@ public class UserReader {
 
     private final UserRepository userRepository;
 
-    private final PostCustomRepositoryImpl postCustomRepositoryImpl;
+    private final PostRepository postRepository;
 
     private final CommentRepository commentRepository;
     
@@ -43,7 +44,7 @@ public class UserReader {
 
         findById(userId);
 
-        Slice<MyPostSummaryResponse> posts = postCustomRepositoryImpl.findPostsByCursorId(userId, cursorId, size);
+        Slice<MyPostSummaryResponse> posts = postRepository.findPostsByCursorId(userId, cursorId, size);
 
         return SliceResponse.of(posts);
     }

--- a/src/main/java/org/sopt/bofit/global/config/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/org/sopt/bofit/global/config/swagger/SwaggerResponseDescription.java
@@ -69,6 +69,10 @@ public enum SwaggerResponseDescription {
     ))),
     GET_MY_LAST_INSURANCE_REPORT_SUMMARY(new LinkedHashSet<>(Set.of(
         NOT_FOUND_INSURANCE_REPORT
+    ))),
+    POST_COMMENT(new LinkedHashSet<>(Set.of(
+        USER_NOT_FOUND,
+        POST_NOT_FOUND
     )))
     ;
     private final Set<ErrorCode> errorCodeList;


### PR DESCRIPTION
## Related issue 🛠
- closed #54
  

## Work Description 📝
- 댓글 작성 api 구현 
- 댓글 및 게시글의 id 칼럼명 수정
- 댓글 서비스 레이어를 2 단계로 분리
- 댓글 및 게시글  레포지토리 구조 수정
  - Repository 인터페이스만을 사용하도록 수정. queryDSL 를 사용하기 위한 구현체 클래스를 직접 의존하는 것이 아니라 PostRepository 인터페이스를 사용하도록 하여 결합도를 낮춤.

## Uncompleted Tasks 😅

## To Reviewers 📢
