### PR TITLE
[Feat] 보장 상황 선택지 조회 API 구현

### DIFF
--- a/src/main/java/org/sopt/bofit/domain/post/dto/response/PostDetailResponse.java
+++ b/src/main/java/org/sopt/bofit/domain/post/dto/response/PostDetailResponse.java
@@ -15,7 +15,7 @@ public record PostDetailResponse(
         String nickname,
 
         @Schema(description = "프로필 사진 url")
-        String profileImageUrl,
+        String profileImage,
 
         @Schema(description = "게시물 제목")
         String title,

--- a/src/main/java/org/sopt/bofit/domain/post/dto/response/PostDetailResponse.java
+++ b/src/main/java/org/sopt/bofit/domain/post/dto/response/PostDetailResponse.java
@@ -24,7 +24,10 @@ public record PostDetailResponse(
         String content,
 
         @Schema(description = "댓글 수 ", example = "8")
-        long commentCount
+        long commentCount,
+
+        @Schema(description = "생성 시간")
+        LocalDateTime createdAt
 ) {
 
 }

--- a/src/main/java/org/sopt/bofit/domain/post/service/PostReader.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/PostReader.java
@@ -45,7 +45,7 @@ public class PostReader {
         return builder()
                 .writerId(writer.getId())
                 .nickname(writer.getNickname())
-                .profileImageUrl(writer.getProfileImage())
+                .profileImage(writer.getProfileImage())
                 .title(post.getTitle())
                 .content(post.getContent())
                 .commentCount(postCommentCount)

--- a/src/main/java/org/sopt/bofit/domain/user/controller/UserController.java
+++ b/src/main/java/org/sopt/bofit/domain/user/controller/UserController.java
@@ -42,13 +42,6 @@ public class UserController {
         return BaseResponse.ok(userService.getUserInfo(userId), "유저 프로필 조회 성공");
     }
 
-    @Tag(name = "Users", description = "유저 관련 API")
-    @Operation(summary = "직업 목록 조회", description = "선택 가능한 직업 목록을 조회합니다.")
-    @GetMapping("/jobs")
-    public BaseResponse<JobResponses> getJobs() {
-        return BaseResponse.ok(userService.getJobs(), "선택 가능한 직업 목록 조회 성공");
-    }
-
     @Tag(name = "My Page", description = "마이페이지 관련 API")
     @CustomExceptionDescription(MY_POSTS)
     @Operation(summary = "내가 쓴 글 조회", description = "마이페이지에서 내가 쓴 글을 조회합니다.")
@@ -73,13 +66,6 @@ public class UserController {
         return BaseResponse.ok(userService.getMyComments(userId, cursorId, size), "내가 쓴 댓글 조회 성공");
     }
 
-    @Tag(name = "UserInfo", description = "유저 정보 관련 API")
-    @Operation(summary = "진단 받은 질병 목록 조회", description = "선택 가능한 진단 받았던 질병 목록을 조회합니다.")
-    @GetMapping("/diagnosed-disease")
-    public BaseResponse<DiagnosedDiseaseResponses> getDiagnosedDisease() {
-        return BaseResponse.ok(userService.getDiagnosedDiseaseNames(), "진단 받은 질병 목록 조회 성공");
-    }
-
     @Tag(name = "Insurance", description = "보험 관련 API")
     @CustomExceptionDescription(GET_MY_LAST_INSURANCE_REPORT_SUMMARY)
     @Operation(summary = "최근 추천 리포트 요약 조회", description = "가장 최근에 추천 받은 보험 리포트의 요약 내용을 조회합니다.")
@@ -91,6 +77,5 @@ public class UserController {
             = insuranceReportService.findUsersLastReportSummary(userId);
         return BaseResponse.ok(response, "최근 추천 리포트 요약 조회");
     }
-
 
 }

--- a/src/main/java/org/sopt/bofit/domain/user/controller/UserInfoController.java
+++ b/src/main/java/org/sopt/bofit/domain/user/controller/UserInfoController.java
@@ -23,7 +23,7 @@ import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/user-info")
+@RequestMapping("/user-infos")
 public class UserInfoController {
 
 	private final UserService userService;

--- a/src/main/java/org/sopt/bofit/domain/user/controller/UserInfoController.java
+++ b/src/main/java/org/sopt/bofit/domain/user/controller/UserInfoController.java
@@ -1,0 +1,54 @@
+package org.sopt.bofit.domain.user.controller;
+
+import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.*;
+
+import org.sopt.bofit.domain.user.dto.response.CoveragePreferenceResponses;
+import org.sopt.bofit.domain.user.dto.response.DiagnosedDiseaseResponses;
+import org.sopt.bofit.domain.user.dto.response.JobResponses;
+import org.sopt.bofit.domain.user.dto.response.MyPostSummaryResponse;
+import org.sopt.bofit.domain.user.service.UserService;
+import org.sopt.bofit.global.annotation.CustomExceptionDescription;
+import org.sopt.bofit.global.annotation.LoginUserId;
+import org.sopt.bofit.global.dto.response.BaseResponse;
+import org.sopt.bofit.global.dto.response.SliceResponse;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/user-info")
+public class UserInfoController {
+
+	private final UserService userService;
+
+	@Tag(name = "UserInfo", description = "유저 정보 관련 API")
+	@Operation(summary = "직업 목록 조회", description = "선택 가능한 직업 목록을 조회합니다.")
+	@GetMapping("/jobs")
+	public BaseResponse<JobResponses> getJobs() {
+		return BaseResponse.ok(userService.getJobs(), "선택 가능한 직업 목록 조회 성공");
+	}
+
+	@Tag(name = "UserInfo", description = "유저 정보 관련 API")
+	@Operation(summary = "진단 받은 질병 목록 조회", description = "선택 가능한 진단 받았던 질병 목록을 조회합니다.")
+	@GetMapping("/diagnosed-disease")
+	public BaseResponse<DiagnosedDiseaseResponses> getDiagnosedDisease() {
+		return BaseResponse.ok(userService.getDiagnosedDiseaseNames(), "진단 받은 질병 목록 조회 성공");
+	}
+
+	@Tag(name = "UserInfo", description = "유저 정보 관련 API")
+	@Operation(summary = "보장 상황 목록 조회", description = "선택 가능한 보장 상황 목록을 조회합니다.")
+	@GetMapping("/coverage-select")
+	public BaseResponse<CoveragePreferenceResponses> getCoverageSelect() {
+		CoveragePreferenceResponses response = userService.getCoveragePreference();
+		return BaseResponse.ok(response, "보장 상황 목록 조회 성공");
+	}
+
+
+}

--- a/src/main/java/org/sopt/bofit/domain/user/dto/response/CoveragePreferenceResponses.java
+++ b/src/main/java/org/sopt/bofit/domain/user/dto/response/CoveragePreferenceResponses.java
@@ -1,0 +1,26 @@
+package org.sopt.bofit.domain.user.dto.response;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.sopt.bofit.domain.user.entity.constant.CoveragePreference;
+
+public record CoveragePreferenceResponses (
+	List<CoveragePreferenceResponse> coveragePreferenceResponses
+){
+
+	public static CoveragePreferenceResponses from(CoveragePreference[] coveragePreferences){
+		return new CoveragePreferenceResponses(Stream.of(coveragePreferences)
+			.map(CoveragePreferenceResponse::create)
+			.toList());
+	}
+
+	private record CoveragePreferenceResponse(
+		CoveragePreference coveragePreference,
+		String description
+	){
+		private static CoveragePreferenceResponse create(CoveragePreference coveragePreference){
+			return new CoveragePreferenceResponse(coveragePreference, coveragePreference.getDescription());
+		}
+	}
+}

--- a/src/main/java/org/sopt/bofit/domain/user/entity/constant/CoveragePreference.java
+++ b/src/main/java/org/sopt/bofit/domain/user/entity/constant/CoveragePreference.java
@@ -6,13 +6,13 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum CoveragePreference {
-    MAJOR_DISEASE("암, 심장질환같은 큰 병에 대비"),
-    DEATH_BENEFIT("가족에게 경제적 도움이 되는 보장"),
-    ESSENTIAL_ONLY("꼭 필요한 보장만 챙기고 싶음"),
-    ACCIDENT_PREDICTION("예기치 못한 사고에 대비"),
-    SURGERY_COVERAGE("수술할 일이 생겼을 때 보장"),
-    MAXIMUM_COVERAGE("폭넓은 보장을 받고 싶다"),
-    RECOMMENDED_OPTION("많이 선택하는 걸로 설정")
+    MAJOR_DISEASE("암, 심장질환같은 큰 병에 대비하고 싶어요"),
+    DEATH_BENEFIT("사망 시 가족에게 경제적 도움이 되는 보장을 원해요"),
+    ESSENTIAL_ONLY("합리적인 보험료로 꼭 필요한 보장만 챙기고 싶어요"),
+    ACCIDENT_PREDICTION("예기치 않은 사고에 대비하고 싶어요"),
+    SURGERY_COVERAGE("수술할 일이 생겼을 때 보장받고 싶어요"),
+    MAXIMUM_COVERAGE("가격이 좀 높아도 폭넓은 보장을 받고 싶어요"),
+    RECOMMENDED_OPTION("잘 모르겠어요. 많이 선택하는 걸로 설정할래요")
     ;
 
     private final String description;

--- a/src/main/java/org/sopt/bofit/domain/user/service/UserReader.java
+++ b/src/main/java/org/sopt/bofit/domain/user/service/UserReader.java
@@ -47,11 +47,6 @@ public class UserReader {
         return SliceResponse.of(posts);
     }
 
-
-    public JobResponses getJobs() {
-        return JobResponses.create(Job.values());
-    }
-
     public User findById(Long userId) {
         return userRepository.findById(userId).orElseThrow(() -> new NotFoundException(USER_NOT_FOUND));
     }
@@ -65,7 +60,4 @@ public class UserReader {
         return SliceResponse.of(comments);
     }
 
-    public DiagnosedDiseaseResponses getDiagnosedDiseaseNames(){
-        return DiagnosedDiseaseResponses.from(DiagnosedDisease.values());
-    }
 }

--- a/src/main/java/org/sopt/bofit/domain/user/service/UserService.java
+++ b/src/main/java/org/sopt/bofit/domain/user/service/UserService.java
@@ -5,6 +5,8 @@ import org.sopt.bofit.domain.user.dto.response.MyCommentSummaryResponse;
 
 import org.sopt.bofit.domain.user.dto.response.MyPostSummaryResponse;
 import org.sopt.bofit.domain.user.entity.constant.CoveragePreference;
+import org.sopt.bofit.domain.user.entity.constant.DiagnosedDisease;
+import org.sopt.bofit.domain.user.entity.constant.Job;
 import org.sopt.bofit.global.dto.response.SliceResponse;
 import org.sopt.bofit.domain.user.dto.response.DiagnosedDiseaseResponses;
 import org.sopt.bofit.domain.user.dto.response.JobResponses;
@@ -28,11 +30,12 @@ public class UserService {
 	}
 
 	public JobResponses getJobs(){
-		return userReader.getJobs();
+		return JobResponses.create(Job.values());
 	}
 
 	public DiagnosedDiseaseResponses getDiagnosedDiseaseNames(){
-		return userReader.getDiagnosedDiseaseNames();
+		return DiagnosedDiseaseResponses.from(DiagnosedDisease.values());
+
 	}
 
 	public CoveragePreferenceResponses  getCoveragePreference(){

--- a/src/main/java/org/sopt/bofit/domain/user/service/UserService.java
+++ b/src/main/java/org/sopt/bofit/domain/user/service/UserService.java
@@ -1,8 +1,10 @@
 package org.sopt.bofit.domain.user.service;
 
+import org.sopt.bofit.domain.user.dto.response.CoveragePreferenceResponses;
 import org.sopt.bofit.domain.user.dto.response.MyCommentSummaryResponse;
 
 import org.sopt.bofit.domain.user.dto.response.MyPostSummaryResponse;
+import org.sopt.bofit.domain.user.entity.constant.CoveragePreference;
 import org.sopt.bofit.global.dto.response.SliceResponse;
 import org.sopt.bofit.domain.user.dto.response.DiagnosedDiseaseResponses;
 import org.sopt.bofit.domain.user.dto.response.JobResponses;
@@ -31,6 +33,10 @@ public class UserService {
 
 	public DiagnosedDiseaseResponses getDiagnosedDiseaseNames(){
 		return userReader.getDiagnosedDiseaseNames();
+	}
+
+	public CoveragePreferenceResponses  getCoveragePreference(){
+		return CoveragePreferenceResponses.from(CoveragePreference.values());
 	}
 
 	@Transactional


### PR DESCRIPTION
## Related issue 🛠
- closed #62
  

## Work Description 📝
- 보장 상황 선택지 조회 API 구현
- user-info 관련 api들의 path 를 변경함.
- 응집도에 따라 user보다는 insuranceReport에 가깝다고 판단됨. 이는 userInfo가 insuranceReport 에 의존성을 강하게 갖기 때문이기도 함.
- 현재는 질병 종류, 직업 종류, 보장 항목 종류 3가지를 조회하는 url을 user-info 컨트롤러에서 조회하도록 함.

## Uncompleted Tasks 😅

## To Reviewers 📢
