### PR TITLE
[Refactor] Security, JWT 관련 로직 리팩토링

### DIFF
--- a/src/main/java/org/sopt/bofit/BofitApplication.java
+++ b/src/main/java/org/sopt/bofit/BofitApplication.java
@@ -1,6 +1,7 @@
 package org.sopt.bofit;
 
 import org.sopt.bofit.global.config.properties.JwtProperties;
+import org.sopt.bofit.global.config.properties.KakaoProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -8,7 +9,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @EnableJpaAuditing
 @SpringBootApplication
-@EnableConfigurationProperties(JwtProperties.class)
+@EnableConfigurationProperties({JwtProperties.class, KakaoProperties.class})
 public class BofitApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/org/sopt/bofit/BofitApplication.java
+++ b/src/main/java/org/sopt/bofit/BofitApplication.java
@@ -1,11 +1,14 @@
 package org.sopt.bofit;
 
+import org.sopt.bofit.global.config.properties.JwtProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @EnableJpaAuditing
 @SpringBootApplication
+@EnableConfigurationProperties(JwtProperties.class)
 public class BofitApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/org/sopt/bofit/domain/post/service/PostWriter.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/PostWriter.java
@@ -3,16 +3,13 @@ package org.sopt.bofit.domain.post.service;
 import lombok.RequiredArgsConstructor;
 import org.sopt.bofit.domain.post.dto.response.PostCreateResponse;
 import org.sopt.bofit.domain.post.entity.Post;
-import org.sopt.bofit.domain.post.repository.PostCustomRepositoryImpl;
 import org.sopt.bofit.domain.post.repository.PostRepository;
 import org.sopt.bofit.domain.user.entity.User;
 import org.sopt.bofit.domain.user.service.UserReader;
 import org.sopt.bofit.global.exception.custom_exception.ForbiddenException;
-import org.sopt.bofit.global.exception.custom_exception.NotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import static org.sopt.bofit.global.exception.constant.PostErrorCode.POST_NOT_FOUND;
 import static org.sopt.bofit.global.exception.constant.PostErrorCode.POST_UNAUTHORIZED;
 
 @Service
@@ -40,9 +37,9 @@ public class PostWriter {
         User user = userReader.findById(userId);
         Post post = postReader.findById(postId);
 
-        checkUserIsOwner(userId, post);
-
+        post.getUser().checkIsWriter(userId, POST_UNAUTHORIZED);
         post.updatePost(title, content);
+
         return PostCreateResponse.from(post.getId());
     }
 
@@ -58,7 +55,7 @@ public class PostWriter {
     public void deletePost(Long userId, Long postId) {
         User user = userReader.findById(userId);
         Post post = postReader.findById(postId);
-        checkUserIsOwner(userId, post);
+        post.getUser().checkIsWriter(userId, POST_UNAUTHORIZED);
 
         postRepository.deletePostByPostId(postId);
     }

--- a/src/main/java/org/sopt/bofit/global/config/SecurityConfig.java
+++ b/src/main/java/org/sopt/bofit/global/config/SecurityConfig.java
@@ -2,7 +2,7 @@ package org.sopt.bofit.global.config;
 
 import lombok.RequiredArgsConstructor;
 import org.sopt.bofit.global.oauth.jwt.CustomAccessDeniedHandler;
-import org.sopt.bofit.global.oauth.jwt.CustomAuthenticationEnrtyPoint;
+import org.sopt.bofit.global.oauth.jwt.CustomAuthenticationEntryPoint;
 import org.sopt.bofit.global.oauth.jwt.JwtAuthenticationFilter;
 import org.sopt.bofit.global.oauth.jwt.JwtUtil;
 import org.springframework.context.annotation.Bean;
@@ -42,7 +42,7 @@ public class SecurityConfig {
                 )
                 .addFilterBefore(new JwtAuthenticationFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class)
                 .exceptionHandling(auth -> auth
-                        .authenticationEntryPoint(new CustomAuthenticationEnrtyPoint())
+                        .authenticationEntryPoint(new CustomAuthenticationEntryPoint())
                         .accessDeniedHandler(new CustomAccessDeniedHandler())
                 );
 

--- a/src/main/java/org/sopt/bofit/global/config/properties/JwtProperties.java
+++ b/src/main/java/org/sopt/bofit/global/config/properties/JwtProperties.java
@@ -1,0 +1,13 @@
+package org.sopt.bofit.global.config.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+
+@ConfigurationProperties(prefix = "jwt")
+public record JwtProperties(
+        String secret,
+        Long accessTokenExpiration,
+        Long refreshTokenExpiration
+) {
+
+}

--- a/src/main/java/org/sopt/bofit/global/config/properties/KakaoProperties.java
+++ b/src/main/java/org/sopt/bofit/global/config/properties/KakaoProperties.java
@@ -1,22 +1,12 @@
 package org.sopt.bofit.global.config.properties;
 
-import lombok.Getter;
-import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.stereotype.Component;
 
-@Setter
-@Getter
-@Component
+
 @ConfigurationProperties(prefix = "kakao")
-public class KakaoProperties {
-
-    private String clientId;
-
-    private String redirectUri;
-
-    private String tokenUri;
-
-    private String userInfoUri;
-
-}
+public record KakaoProperties(
+        String clientId,
+        String redirectUri,
+        String tokenUri,
+        String userInfoUri
+) { }

--- a/src/main/java/org/sopt/bofit/global/config/properties/KakaoProperties.java
+++ b/src/main/java/org/sopt/bofit/global/config/properties/KakaoProperties.java
@@ -1,4 +1,4 @@
-package org.sopt.bofit.global.config;
+package org.sopt.bofit.global.config.properties;
 
 import lombok.Getter;
 import lombok.Setter;

--- a/src/main/java/org/sopt/bofit/global/oauth/constant/HttpHeaderConstants.java
+++ b/src/main/java/org/sopt/bofit/global/oauth/constant/HttpHeaderConstants.java
@@ -1,0 +1,10 @@
+package org.sopt.bofit.global.oauth.constant;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class HttpHeaderConstants {
+    public static final String AUTHORIZATION = "authorization";
+    public static final String BEARER_PREFIX = "Bearer ";
+}

--- a/src/main/java/org/sopt/bofit/global/oauth/constant/JwtExceptionConstants.java
+++ b/src/main/java/org/sopt/bofit/global/oauth/constant/JwtExceptionConstants.java
@@ -1,0 +1,12 @@
+package org.sopt.bofit.global.oauth.constant;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class JwtExceptionConstants {
+    public static final String EXPIRED = "JWT_EXPIRED";
+    public static final String INVALID_SIGNATURE = "JWT_INVALID_SIGNATURE";
+    public static final String INVALID = "JWT_INVALID";
+    public static final String UNSUPPORTED = "JWT_UNSUPPORTED";
+}

--- a/src/main/java/org/sopt/bofit/global/oauth/constant/RequestAttributeConstants.java
+++ b/src/main/java/org/sopt/bofit/global/oauth/constant/RequestAttributeConstants.java
@@ -1,0 +1,11 @@
+package org.sopt.bofit.global.oauth.constant;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class RequestAttributeConstants {
+
+    public static final String EXCEPTION = "exception";
+
+}

--- a/src/main/java/org/sopt/bofit/global/oauth/constant/SwaggerPathConstants.java
+++ b/src/main/java/org/sopt/bofit/global/oauth/constant/SwaggerPathConstants.java
@@ -1,0 +1,11 @@
+package org.sopt.bofit.global.oauth.constant;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class SwaggerPathConstants {
+    public static final String SWAGGER_UI = "/swagger-ui";
+    public static final String SWAGGER_DOCS = "/v3/api-docs";
+    public static final String SWAGGER_CONFIG = "/swagger-config";
+}

--- a/src/main/java/org/sopt/bofit/global/oauth/controller/OAuthController.java
+++ b/src/main/java/org/sopt/bofit/global/oauth/controller/OAuthController.java
@@ -35,8 +35,7 @@ public class OAuthController {
     @CustomExceptionDescription(TOKEN_REISSUE)
     @Operation(summary = "토큰 재발급")
     @PostMapping("/reissue")
-    public BaseResponse<TokenReissueResponse> reissue(@Parameter(hidden = true) @RequestHeader("Authorization") String bearerToken) {
-        String refreshToken = bearerToken.replace("Bearer ", "").trim();
+    public BaseResponse<TokenReissueResponse> reissue(@Parameter(hidden = true) @RequestHeader("Authorization") String refreshToken) {
         return BaseResponse.ok(oAuthService.reissue(refreshToken), "토큰 재발급 성공");
     }
 

--- a/src/main/java/org/sopt/bofit/global/oauth/jwt/CustomAccessDeniedHandler.java
+++ b/src/main/java/org/sopt/bofit/global/oauth/jwt/CustomAccessDeniedHandler.java
@@ -4,21 +4,24 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.sopt.bofit.global.dto.response.BaseErrorResponse;
 import org.sopt.bofit.global.exception.constant.ErrorCode;
 import org.sopt.bofit.global.exception.constant.GlobalErrorCode;
-import org.sopt.bofit.global.dto.response.BaseErrorResponse;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.web.access.AccessDeniedHandler;
 
 import java.io.IOException;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 public class CustomAccessDeniedHandler implements AccessDeniedHandler {
     @Override
     public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
         ErrorCode error = GlobalErrorCode.FORBIDDEN;
         response.setStatus(error.getHttpStatus());
-        response.setContentType("application/json");
-        response.setCharacterEncoding("UTF-8");
+        response.setContentType(APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(UTF_8.name());
 
         String json = new ObjectMapper().writeValueAsString(BaseErrorResponse.of(error));
         response.getWriter().write(json);

--- a/src/main/java/org/sopt/bofit/global/oauth/jwt/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/org/sopt/bofit/global/oauth/jwt/CustomAuthenticationEntryPoint.java
@@ -4,26 +4,31 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.sopt.bofit.global.dto.response.BaseErrorResponse;
 import org.sopt.bofit.global.exception.constant.ErrorCode;
 import org.sopt.bofit.global.exception.constant.GlobalErrorCode;
-import org.sopt.bofit.global.dto.response.BaseErrorResponse;
+import org.sopt.bofit.global.oauth.constant.RequestAttributeConstants;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.sopt.bofit.global.oauth.constant.JwtExceptionConstants.*;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
 @Component
-public class CustomAuthenticationEnrtyPoint implements AuthenticationEntryPoint {
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
-        Object exceptionType = request.getAttribute("exception");
+        Object exceptionType = request.getAttribute(RequestAttributeConstants.EXCEPTION);
 
         ErrorCode error = getErrorCode(exceptionType);
 
         response.setStatus(error.getHttpStatus());
-        response.setContentType("application/json");
-        response.setCharacterEncoding("UTF-8");
+        response.setContentType(APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(UTF_8.name());
 
         String json = new ObjectMapper().writeValueAsString(BaseErrorResponse.of(error));
         response.getWriter().write(json);
@@ -31,13 +36,13 @@ public class CustomAuthenticationEnrtyPoint implements AuthenticationEntryPoint 
 
     private ErrorCode getErrorCode(Object exceptionType) {
         ErrorCode error;
-        if ("JWT_EXPIRED".equals(exceptionType)) {
+        if (EXPIRED.equals(exceptionType)) {
             error = GlobalErrorCode.JWT_EXPIRED;
-        } else if ("JWT_INVALID_SIGNATURE".equals(exceptionType)) {
+        } else if (INVALID_SIGNATURE.equals(exceptionType)) {
             error = GlobalErrorCode.JWT_INVALID_SIGNATURE;
-        } else if ("JWT_INVALID".equals(exceptionType)) {
+        } else if (INVALID.equals(exceptionType)) {
             error = GlobalErrorCode.JWT_INVALID;
-        } else if("JWT_UNSUPPORTED".equals(exceptionType)) {
+        } else if(UNSUPPORTED.equals(exceptionType)) {
             error = GlobalErrorCode.JWT_UNSUPPORTED;
         } else {
             error = GlobalErrorCode.UNAUTHORIZED;

--- a/src/main/java/org/sopt/bofit/global/oauth/jwt/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/org/sopt/bofit/global/oauth/jwt/CustomAuthenticationEntryPoint.java
@@ -13,6 +13,7 @@ import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
+import java.util.Map;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.sopt.bofit.global.oauth.constant.JwtExceptionConstants.*;
@@ -20,6 +21,13 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 @Component
 public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    private static final Map<Object, ErrorCode> exceptionErrorCodeMap = Map.of(
+            EXPIRED, GlobalErrorCode.JWT_EXPIRED,
+            INVALID_SIGNATURE, GlobalErrorCode.JWT_INVALID_SIGNATURE,
+            INVALID, GlobalErrorCode.JWT_INVALID,
+            UNSUPPORTED, GlobalErrorCode.JWT_UNSUPPORTED
+    );
+
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
         Object exceptionType = request.getAttribute(RequestAttributeConstants.EXCEPTION);
@@ -34,19 +42,8 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
         response.getWriter().write(json);
     }
 
+
     private ErrorCode getErrorCode(Object exceptionType) {
-        ErrorCode error;
-        if (EXPIRED.equals(exceptionType)) {
-            error = GlobalErrorCode.JWT_EXPIRED;
-        } else if (INVALID_SIGNATURE.equals(exceptionType)) {
-            error = GlobalErrorCode.JWT_INVALID_SIGNATURE;
-        } else if (INVALID.equals(exceptionType)) {
-            error = GlobalErrorCode.JWT_INVALID;
-        } else if(UNSUPPORTED.equals(exceptionType)) {
-            error = GlobalErrorCode.JWT_UNSUPPORTED;
-        } else {
-            error = GlobalErrorCode.UNAUTHORIZED;
-        }
-        return error;
+        return exceptionErrorCodeMap.getOrDefault(exceptionType, GlobalErrorCode.UNAUTHORIZED);
     }
 }

--- a/src/main/java/org/sopt/bofit/global/oauth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/org/sopt/bofit/global/oauth/jwt/JwtAuthenticationFilter.java
@@ -9,6 +9,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.sopt.bofit.global.exception.custom_exception.CustomException;
 import org.sopt.bofit.global.oauth.constant.HttpHeaderConstants;
 import org.sopt.bofit.global.oauth.constant.RequestAttributeConstants;
+import org.sopt.bofit.global.oauth.constant.SwaggerPathConstants;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
@@ -45,7 +46,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     protected boolean shouldNotFilter(HttpServletRequest request) {
         String uri = request.getRequestURI();
-        return uri.startsWith("/swagger-ui") || uri.startsWith("/v3/api-docs") || uri.startsWith("/swagger-config");
+        return uri.startsWith(SwaggerPathConstants.SWAGGER_CONFIG) || uri.startsWith(SwaggerPathConstants.SWAGGER_UI) || uri.startsWith(SwaggerPathConstants.SWAGGER_DOCS);
     }
 
     private String getToken(HttpServletRequest request) {

--- a/src/main/java/org/sopt/bofit/global/oauth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/org/sopt/bofit/global/oauth/jwt/JwtAuthenticationFilter.java
@@ -7,10 +7,11 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.sopt.bofit.global.exception.custom_exception.CustomException;
+import org.sopt.bofit.global.oauth.constant.HttpHeaderConstants;
+import org.sopt.bofit.global.oauth.constant.RequestAttributeConstants;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
-import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
@@ -34,7 +35,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                     SecurityContextHolder.getContext().setAuthentication(authentication);
                 }
             } catch (CustomException e) {
-                request.setAttribute("exception", e.getErrorCode());
+                request.setAttribute(RequestAttributeConstants.EXCEPTION, e.getErrorCode());
                 throw e;
             }
         }
@@ -48,8 +49,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     }
 
     private String getToken(HttpServletRequest request) {
-        String authorization = request.getHeader("authorization");
-        String validTokenPrefix = "Bearer ";
+        String authorization = request.getHeader(HttpHeaderConstants.AUTHORIZATION);
+        String validTokenPrefix = HttpHeaderConstants.BEARER_PREFIX;
         if (authorization == null || !authorization.startsWith(validTokenPrefix)) {
             return null;
         }

--- a/src/main/java/org/sopt/bofit/global/oauth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/org/sopt/bofit/global/oauth/jwt/JwtAuthenticationFilter.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.util.List;
 
 @Slf4j
 @Component
@@ -23,6 +24,12 @@ import java.io.IOException;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtUtil jwtUtil;
+
+    private static final List<String> EXCLUDED_PATH_PREFIXES = List.of(
+            SwaggerPathConstants.SWAGGER_CONFIG,
+            SwaggerPathConstants.SWAGGER_UI,
+            SwaggerPathConstants.SWAGGER_DOCS
+    );
 
 
     @Override
@@ -46,7 +53,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     protected boolean shouldNotFilter(HttpServletRequest request) {
         String uri = request.getRequestURI();
-        return uri.startsWith(SwaggerPathConstants.SWAGGER_CONFIG) || uri.startsWith(SwaggerPathConstants.SWAGGER_UI) || uri.startsWith(SwaggerPathConstants.SWAGGER_DOCS);
+        return EXCLUDED_PATH_PREFIXES.stream().anyMatch(uri::startsWith);
     }
 
     private String getToken(HttpServletRequest request) {

--- a/src/main/java/org/sopt/bofit/global/oauth/jwt/JwtProvider.java
+++ b/src/main/java/org/sopt/bofit/global/oauth/jwt/JwtProvider.java
@@ -20,7 +20,7 @@ public class JwtProvider {
     private final Long accessTokenExpireMillis;
     private final Long refreshTokenExpireMillis;
     private final SecretKey secretKey;
-
+    
     public JwtProvider(
             @Value("${jwt.secret}") String secretKey,
             @Value("${jwt.accessTokenExpiration}") Long accessExpiration,

--- a/src/main/java/org/sopt/bofit/global/oauth/jwt/JwtProvider.java
+++ b/src/main/java/org/sopt/bofit/global/oauth/jwt/JwtProvider.java
@@ -5,7 +5,7 @@ import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
+import org.sopt.bofit.global.config.properties.JwtProperties;
 import org.springframework.stereotype.Component;
 
 import javax.crypto.SecretKey;
@@ -20,15 +20,11 @@ public class JwtProvider {
     private final Long accessTokenExpireMillis;
     private final Long refreshTokenExpireMillis;
     private final SecretKey secretKey;
-    
-    public JwtProvider(
-            @Value("${jwt.secret}") String secretKey,
-            @Value("${jwt.accessTokenExpiration}") Long accessExpiration,
-            @Value("${jwt.refreshTokenExpiration}") Long refreshExpiration
-    ){
-        this.secretKey = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
-        this.accessTokenExpireMillis = accessExpiration;
-        this.refreshTokenExpireMillis = refreshExpiration;
+
+    public JwtProvider(JwtProperties jwtProperties) {
+        this.secretKey = Keys.hmacShaKeyFor(jwtProperties.secret().getBytes(StandardCharsets.UTF_8));
+        this.accessTokenExpireMillis = jwtProperties.accessTokenExpiration();
+        this.refreshTokenExpireMillis = jwtProperties.refreshTokenExpiration();
     }
 
     public String generateAccessToken(Long userId) {

--- a/src/main/java/org/sopt/bofit/global/oauth/jwt/JwtUtil.java
+++ b/src/main/java/org/sopt/bofit/global/oauth/jwt/JwtUtil.java
@@ -1,21 +1,13 @@
 package org.sopt.bofit.global.oauth.jwt;
 
 import io.jsonwebtoken.*;
-import io.jsonwebtoken.security.Keys;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.sopt.bofit.global.exception.constant.GlobalErrorCode;
-import org.sopt.bofit.global.exception.constant.OAuthErrorCode;
 import org.sopt.bofit.global.exception.custom_exception.InternalException;
 import org.sopt.bofit.global.exception.custom_exception.UnAuthorizedException;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
-import javax.crypto.SecretKey;
-import java.nio.charset.StandardCharsets;
-
 import static org.sopt.bofit.global.exception.constant.GlobalErrorCode.*;
-import static org.sopt.bofit.global.exception.constant.OAuthErrorCode.*;
 
 @Component
 @Slf4j
@@ -35,6 +27,7 @@ public class JwtUtil {
     public boolean isTokenValid(String token) {
         try {
             getClaims(token);
+            return true;
         } catch (SecurityException | MalformedJwtException e) {
             throw new UnAuthorizedException(JWT_INVALID_SIGNATURE);
         } catch (ExpiredJwtException e) {
@@ -44,10 +37,9 @@ public class JwtUtil {
         } catch (IllegalArgumentException e) {
             throw new UnAuthorizedException(JWT_INVALID);
         } catch (Exception e) {
-            log.info(e.getMessage());
+            log.warn("Unexpected JWT error: {}", e.getMessage());
             throw new InternalException(INTERNAL_SERVER_ERROR);
         }
-        return true;
     }
 
     public Long extractUserIdFromToken(String token) {

--- a/src/main/java/org/sopt/bofit/global/oauth/service/OAuthService.java
+++ b/src/main/java/org/sopt/bofit/global/oauth/service/OAuthService.java
@@ -47,10 +47,10 @@ public class OAuthService {
     private final WebClient webClient = WebClient.create();
 
     private Mono<KaKaoTokenResponse> requestToken(String code) {
-        String body = OAuthUtil.buildTokenRequestBody(code, properties.getClientId(), properties.getRedirectUri());
+        String body = OAuthUtil.buildTokenRequestBody(code, properties.clientId(), properties.redirectUri());
 
         return webClient.post()
-                .uri(properties.getTokenUri())
+                .uri(properties.tokenUri())
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED)
                 .bodyValue(body)
                 .retrieve()
@@ -69,7 +69,7 @@ public class OAuthService {
 
     private Mono<KakaoUserResponse> getUserInfo(String accessToken) {
         return webClient.get()
-                .uri(properties.getUserInfoUri())
+                .uri(properties.userInfoUri())
                 .headers(headers -> headers.setBearerAuth(accessToken))
                 .retrieve()
                 .bodyToMono(KakaoUserResponse.class);

--- a/src/main/java/org/sopt/bofit/global/oauth/service/OAuthService.java
+++ b/src/main/java/org/sopt/bofit/global/oauth/service/OAuthService.java
@@ -130,7 +130,8 @@ public class OAuthService {
     }
 
     @Transactional
-    public TokenReissueResponse reissue(String refreshToken) {
+    public TokenReissueResponse reissue(String bearerToken) {
+        String refreshToken = bearerToken.replace("Bearer ", "").trim();
         if (!jwtUtil.isTokenValid(refreshToken)) {
             throw new UnAuthorizedException(JWT_INVALID);
         }

--- a/src/main/java/org/sopt/bofit/global/oauth/service/OAuthService.java
+++ b/src/main/java/org/sopt/bofit/global/oauth/service/OAuthService.java
@@ -8,6 +8,7 @@ import org.sopt.bofit.domain.user.repository.UserRepository;
 import org.sopt.bofit.global.config.properties.KakaoProperties;
 import org.sopt.bofit.global.exception.custom_exception.BadRequestException;
 import org.sopt.bofit.global.exception.custom_exception.UnAuthorizedException;
+import org.sopt.bofit.global.oauth.constant.HttpHeaderConstants;
 import org.sopt.bofit.global.oauth.dto.KaKaoLoginResponse;
 import org.sopt.bofit.global.oauth.dto.KaKaoTokenResponse;
 import org.sopt.bofit.global.oauth.dto.KakaoUserResponse;
@@ -131,7 +132,7 @@ public class OAuthService {
 
     @Transactional
     public TokenReissueResponse reissue(String bearerToken) {
-        String refreshToken = bearerToken.replace("Bearer ", "").trim();
+        String refreshToken = bearerToken.replace(HttpHeaderConstants.BEARER_PREFIX, "").trim();
         if (!jwtUtil.isTokenValid(refreshToken)) {
             throw new UnAuthorizedException(JWT_INVALID);
         }

--- a/src/main/java/org/sopt/bofit/global/oauth/service/OAuthService.java
+++ b/src/main/java/org/sopt/bofit/global/oauth/service/OAuthService.java
@@ -5,7 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.sopt.bofit.domain.user.entity.User;
 import org.sopt.bofit.domain.user.entity.constant.LoginProvider;
 import org.sopt.bofit.domain.user.repository.UserRepository;
-import org.sopt.bofit.global.config.KakaoProperties;
+import org.sopt.bofit.global.config.properties.KakaoProperties;
 import org.sopt.bofit.global.exception.custom_exception.BadRequestException;
 import org.sopt.bofit.global.exception.custom_exception.UnAuthorizedException;
 import org.sopt.bofit.global.oauth.dto.KaKaoLoginResponse;


### PR DESCRIPTION
## Related issue 🛠
- closed #67  
  
## Work Description 📝
- [x] 하드코딩된 부분 상수 분리
- [x] try-catch 블록 많은 부분 early return 사용
- [x] 환경변수 설정 파일 생성

## To Reviewers 📢
JWT와 카카오 관련 환경변수들을 `@Value` 어노테이션을 사용하던 것에서 Properties 파일로 분리했습니다. 객체의 불변성을 보장하고, 테스트 코드의 용이성과 가독성을 높였습니다. 처음에 KakaoProperties는 Setter로 바인딩하는 방식을 사용하다가 클래스 바인딩 방식으로 변경했는데, Setter를 통해 바인딩을 하게 되면 `@Setter` 어노테이션에 의해 어디서든 환경변수 값이 변경될 수 있어서 불변성이 보장되지 않아 파일을 분리하는 이점이 사라진다고 생각하여 클래스 바인딩 방식을 적용했습니다. 이 방식으로 인해 생성자 이외에는 값을 변경할 수 없게 됩니다.