### PR TITLE
[Refactor] 무한 스크롤 로직 리팩토링

### DIFF
--- a/src/main/java/org/sopt/bofit/domain/comment/dto/response/CommentResponse.java
+++ b/src/main/java/org/sopt/bofit/domain/comment/dto/response/CommentResponse.java
@@ -2,6 +2,7 @@ package org.sopt.bofit.domain.comment.dto.response;
 
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import org.sopt.bofit.global.dto.response.CursorProvider;
 
 import java.time.LocalDateTime;
 
@@ -26,5 +27,10 @@ public record CommentResponse (
 
 	@Schema(description = "수정 시간")
 	LocalDateTime updatedAt
-){
+) implements CursorProvider<Long>
+{
+	@Override
+	public Long getCursor() {
+		return commentId;
+	}
 }

--- a/src/main/java/org/sopt/bofit/domain/comment/service/CommentService.java
+++ b/src/main/java/org/sopt/bofit/domain/comment/service/CommentService.java
@@ -1,9 +1,6 @@
 package org.sopt.bofit.domain.comment.service;
 
-import static org.sopt.bofit.global.exception.constant.CommentErrorCode.*;
-
-import java.util.Optional;
-
+import lombok.RequiredArgsConstructor;
 import org.sopt.bofit.domain.comment.dto.request.CommentCreateRequest;
 import org.sopt.bofit.domain.comment.dto.response.CommentResponse;
 import org.sopt.bofit.domain.comment.entity.Comment;
@@ -16,7 +13,9 @@ import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import lombok.RequiredArgsConstructor;
+import java.util.Optional;
+
+import static org.sopt.bofit.global.exception.constant.CommentErrorCode.COMMENT_UNAUTHORIZED;
 
 
 @Service
@@ -47,7 +46,7 @@ public class CommentService {
 		commentWriter.softDelete(comment);
 	}
 
-	public SliceResponse<CommentResponse> findAllByPostIdAndCursor(Long postId, Long userId, Optional<Long> cursor, int size) {
+	public SliceResponse<CommentResponse, Long> findAllByPostIdAndCursor(Long postId, Long userId, Optional<Long> cursor, int size) {
 		Post post = postReader.findById(postId);
 
 		Slice<CommentResponse> commentsByCursorId = commentReader.findCommentsByCursorId(postId, cursor, size);

--- a/src/main/java/org/sopt/bofit/domain/post/controller/PostController.java
+++ b/src/main/java/org/sopt/bofit/domain/post/controller/PostController.java
@@ -5,7 +5,6 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-
 import org.sopt.bofit.domain.comment.dto.request.CommentCreateRequest;
 import org.sopt.bofit.domain.comment.dto.response.CommentResponse;
 import org.sopt.bofit.domain.comment.service.CommentService;
@@ -14,18 +13,19 @@ import org.sopt.bofit.domain.post.dto.response.PostCreateResponse;
 import org.sopt.bofit.domain.post.dto.response.PostDetailResponse;
 import org.sopt.bofit.domain.post.dto.response.PostSummaryResponse;
 import org.sopt.bofit.domain.post.service.PostService;
-import org.sopt.bofit.global.dto.response.SliceResponse;
 import org.sopt.bofit.global.annotation.CustomExceptionDescription;
 import org.sopt.bofit.global.annotation.LoginUserId;
 import org.sopt.bofit.global.dto.response.BaseResponse;
+import org.sopt.bofit.global.dto.response.SliceResponse;
 import org.springframework.web.bind.annotation.*;
 
-import static org.sopt.bofit.domain.comment.constant.CommentConstant.*;
-import static org.sopt.bofit.domain.post.constant.PostConstant.*;
-import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.*;
-import static org.sopt.bofit.global.constant.SwaggerConstant.*;
-
 import java.util.Optional;
+
+import static org.sopt.bofit.domain.comment.constant.CommentConstant.COMMENTS_DEFAULT_SIZE;
+import static org.sopt.bofit.domain.post.constant.PostConstant.POSTS_DEFAULT_SIZE;
+import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.*;
+import static org.sopt.bofit.global.constant.SwaggerConstant.TAG_DESCRIPTION_COMMUNITY;
+import static org.sopt.bofit.global.constant.SwaggerConstant.TAG_NAME_COMMUNITY;
 
 @RestController
 @RequiredArgsConstructor
@@ -73,7 +73,7 @@ public class PostController {
     @Tag(name = TAG_NAME_COMMUNITY, description = TAG_DESCRIPTION_COMMUNITY)
     @Operation(summary = "게시물 전체 조회", description = "커뮤니티에서 모든 글을 조회합니다.")
     @GetMapping()
-    public BaseResponse<SliceResponse<PostSummaryResponse>> getAllPosts(
+    public BaseResponse<SliceResponse<PostSummaryResponse, Long>> getAllPosts(
             @RequestParam(required = false, name = "cursor") Long cursorId,
             @RequestParam(required = false, defaultValue = POSTS_DEFAULT_SIZE) int size){
         return BaseResponse.ok(postService.getAllPosts(cursorId, size), "게시물 전체 조회 성공");
@@ -119,13 +119,13 @@ public class PostController {
     @Operation(summary = "댓글 목록 조회 ", description = "커뮤니티 게시글의 댓글 목록을 조회합니다.")
     @CustomExceptionDescription(DELETE_COMMENT)
     @GetMapping("/{post-id}/comments")
-    public BaseResponse<SliceResponse<CommentResponse>> getComments(
+    public BaseResponse<SliceResponse<CommentResponse,Long>> getComments(
         @PathVariable(name = "post-id") Long postId,
         @RequestParam(required = false, name = "cursor") Long cursorId,
         @RequestParam(defaultValue = COMMENTS_DEFAULT_SIZE) int size,
         @Parameter(hidden = true) @LoginUserId Long userId
     ){
-        SliceResponse<CommentResponse> response = commentService.findAllByPostIdAndCursor(postId, userId, Optional.ofNullable(cursorId), size);
+        SliceResponse<CommentResponse,Long> response = commentService.findAllByPostIdAndCursor(postId, userId, Optional.ofNullable(cursorId), size);
         return BaseResponse.ok(response, "댓글 목록 조회 성공");
     }
 }

--- a/src/main/java/org/sopt/bofit/domain/post/dto/response/PostSummaryResponse.java
+++ b/src/main/java/org/sopt/bofit/domain/post/dto/response/PostSummaryResponse.java
@@ -1,10 +1,11 @@
 package org.sopt.bofit.domain.post.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import org.sopt.bofit.global.dto.response.CursorProvider;
 
 import java.time.LocalDateTime;
 
-public record PostSummaryResponse(
+public record PostSummaryResponse (
         @Schema(description = "게시글 ID")
         Long postId,
 
@@ -29,4 +30,9 @@ public record PostSummaryResponse(
         @Schema(description = "게시물 작성 시각")
         LocalDateTime createdAt
 
-) {}
+) implements CursorProvider<Long>{
+        @Override
+        public Long getCursor() {
+                return postId;
+        }
+}

--- a/src/main/java/org/sopt/bofit/domain/post/service/PostReader.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/PostReader.java
@@ -27,7 +27,7 @@ public class PostReader {
 
     private final CommentRepository commentRepository;
 
-    public SliceResponse<PostSummaryResponse> getAllPosts(Long cursorId, int size){
+    public SliceResponse<PostSummaryResponse, Long> getAllPosts(Long cursorId, int size){
 
         Slice<PostSummaryResponse> postList = postRepository.findAllByCursorId(cursorId, size);
 

--- a/src/main/java/org/sopt/bofit/domain/post/service/PostService.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/PostService.java
@@ -30,7 +30,7 @@ public class PostService {
         postWriter.deletePost(userId, postId);
     }
 
-    public SliceResponse<PostSummaryResponse> getAllPosts(Long cursorId, int size){
+    public SliceResponse<PostSummaryResponse, Long> getAllPosts(Long cursorId, int size){
         return postReader.getAllPosts(cursorId, size);
     }
 

--- a/src/main/java/org/sopt/bofit/domain/user/controller/UserController.java
+++ b/src/main/java/org/sopt/bofit/domain/user/controller/UserController.java
@@ -46,7 +46,7 @@ public class UserController {
     @CustomExceptionDescription(MY_POSTS)
     @Operation(summary = "내가 쓴 글 조회", description = "내가 쓴 글을 조회합니다.")
     @GetMapping("me/posts")
-    public BaseResponse<SliceResponse<MyPostSummaryResponse>> getMyPosts(
+    public BaseResponse<SliceResponse<MyPostSummaryResponse, Long>> getMyPosts(
             @Parameter(hidden = true) @LoginUserId Long userId,
             @RequestParam(required = false) Long cursorId,
             @RequestParam(defaultValue = POSTS_DEFAULT_SIZE) int size
@@ -58,7 +58,7 @@ public class UserController {
     @CustomExceptionDescription(MY_COMMENTS)
     @Operation(summary = "내가 쓴 댓글 조회", description = "내가 쓴 댓글을 조회합니다.")
     @GetMapping("me/comments")
-    public BaseResponse<SliceResponse<MyCommentSummaryResponse>> getMyComments(
+    public BaseResponse<SliceResponse<MyCommentSummaryResponse, Long>> getMyComments(
             @Parameter(hidden = true) @LoginUserId Long userId,
             @RequestParam(required = false) Long cursorId,
             @RequestParam(defaultValue = COMMENTS_DEFAULT_SIZE) int size

--- a/src/main/java/org/sopt/bofit/domain/user/dto/response/MyCommentSummaryResponse.java
+++ b/src/main/java/org/sopt/bofit/domain/user/dto/response/MyCommentSummaryResponse.java
@@ -1,6 +1,7 @@
 package org.sopt.bofit.domain.user.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import org.sopt.bofit.global.dto.response.CursorProvider;
 
 import java.time.LocalDateTime;
 
@@ -17,4 +18,10 @@ public record MyCommentSummaryResponse(
 
         @Schema(description = "작성 시간")
         LocalDateTime createdAt
-) {}
+) implements CursorProvider<Long>
+{
+        @Override
+        public Long getCursor() {
+                return commentId;
+        }
+}

--- a/src/main/java/org/sopt/bofit/domain/user/dto/response/MyPostSummaryResponse.java
+++ b/src/main/java/org/sopt/bofit/domain/user/dto/response/MyPostSummaryResponse.java
@@ -1,6 +1,7 @@
 package org.sopt.bofit.domain.user.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import org.sopt.bofit.global.dto.response.CursorProvider;
 
 import java.time.LocalDateTime;
 
@@ -20,4 +21,10 @@ public record MyPostSummaryResponse(
 
         @Schema(description = "작성 시간")
         LocalDateTime createdAt
-){}
+) implements CursorProvider<Long> {
+
+        @Override
+        public Long getCursor() {
+                return postId;
+        }
+}

--- a/src/main/java/org/sopt/bofit/domain/user/service/UserReader.java
+++ b/src/main/java/org/sopt/bofit/domain/user/service/UserReader.java
@@ -1,24 +1,19 @@
 package org.sopt.bofit.domain.user.service;
 
 import lombok.RequiredArgsConstructor;
-
 import org.sopt.bofit.domain.comment.repository.CommentRepository;
 import org.sopt.bofit.domain.post.repository.PostRepository;
-import org.sopt.bofit.domain.user.dto.response.DiagnosedDiseaseResponses;
 import org.sopt.bofit.domain.user.dto.response.MyCommentSummaryResponse;
-import org.sopt.bofit.domain.user.dto.response.JobResponses;
 import org.sopt.bofit.domain.user.dto.response.MyPostSummaryResponse;
-import org.sopt.bofit.global.dto.response.SliceResponse;
 import org.sopt.bofit.domain.user.dto.response.UserProfileResponse;
 import org.sopt.bofit.domain.user.entity.User;
-import org.sopt.bofit.domain.user.entity.constant.DiagnosedDisease;
-import org.sopt.bofit.domain.user.entity.constant.Job;
 import org.sopt.bofit.domain.user.repository.UserRepository;
+import org.sopt.bofit.global.dto.response.SliceResponse;
 import org.sopt.bofit.global.exception.custom_exception.NotFoundException;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 
-import static org.sopt.bofit.global.exception.constant.UserErrorCode.*;
+import static org.sopt.bofit.global.exception.constant.UserErrorCode.USER_NOT_FOUND;
 
 @Service
 @RequiredArgsConstructor
@@ -38,7 +33,7 @@ public class UserReader {
 
     }
 
-    public SliceResponse<MyPostSummaryResponse> getMyPosts(Long userId, Long cursorId, int size) {
+    public SliceResponse<MyPostSummaryResponse, Long> getMyPosts(Long userId, Long cursorId, int size) {
 
         findById(userId);
 
@@ -51,7 +46,7 @@ public class UserReader {
         return userRepository.findById(userId).orElseThrow(() -> new NotFoundException(USER_NOT_FOUND));
     }
 
-    public SliceResponse<MyCommentSummaryResponse> getMyComments(Long userId, Long cursorId, int size) {
+    public SliceResponse<MyCommentSummaryResponse, Long> getMyComments(Long userId, Long cursorId, int size) {
 
         findById(userId);
 

--- a/src/main/java/org/sopt/bofit/domain/user/service/UserService.java
+++ b/src/main/java/org/sopt/bofit/domain/user/service/UserService.java
@@ -58,11 +58,11 @@ public class UserService {
 		);
 	}
 
-	public SliceResponse<MyPostSummaryResponse> getMyPosts(Long userId, Long cursorId, int size){
+	public SliceResponse<MyPostSummaryResponse, Long> getMyPosts(Long userId, Long cursorId, int size){
 		return userReader.getMyPosts(userId, cursorId, size);
 	}
 
-	public SliceResponse<MyCommentSummaryResponse> getMyComments(Long userId, Long cursorId, int size) {
+	public SliceResponse<MyCommentSummaryResponse, Long> getMyComments(Long userId, Long cursorId, int size) {
 		return userReader.getMyComments(userId, cursorId, size);
 	}
 }

--- a/src/main/java/org/sopt/bofit/global/dto/response/CursorProvider.java
+++ b/src/main/java/org/sopt/bofit/global/dto/response/CursorProvider.java
@@ -1,0 +1,5 @@
+package org.sopt.bofit.global.dto.response;
+
+public interface CursorProvider<C> {
+    C getCursor();
+}

--- a/src/main/java/org/sopt/bofit/global/dto/response/SliceResponse.java
+++ b/src/main/java/org/sopt/bofit/global/dto/response/SliceResponse.java
@@ -7,7 +7,7 @@ import java.util.List;
 
 public record SliceResponse<T, C>(
         @Schema(description = "데이터 목록") List<T> content,
-        @Schema(description = "다음 커서 ID") C nextCursor,
+        @Schema(description = "다음 커서") C nextCursor,
         @Schema(description = "마지막 페이지 여부") boolean isLast
 ) {
     public static <T extends CursorProvider<C>, C> SliceResponse<T, C> of(Slice<T> slice) {

--- a/src/main/java/org/sopt/bofit/global/dto/response/SliceResponse.java
+++ b/src/main/java/org/sopt/bofit/global/dto/response/SliceResponse.java
@@ -1,40 +1,21 @@
 package org.sopt.bofit.global.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import org.sopt.bofit.domain.comment.dto.response.CommentResponse;
-import org.sopt.bofit.domain.post.dto.response.PostSummaryResponse;
-import org.sopt.bofit.domain.user.dto.response.MyCommentSummaryResponse;
-import org.sopt.bofit.domain.user.dto.response.MyPostSummaryResponse;
 import org.springframework.data.domain.Slice;
 
 import java.util.List;
 
-public record SliceResponse<T>(
+public record SliceResponse<T, C>(
         @Schema(description = "데이터 목록") List<T> content,
-        @Schema(description = "다음 커서 ID") Long nextCursor,
+        @Schema(description = "다음 커서 ID") C nextCursor,
         @Schema(description = "마지막 페이지 여부") boolean isLast
 ) {
-    public static <T> SliceResponse<T> of(Slice<T> slice) {
+    public static <T extends CursorProvider<C>, C> SliceResponse<T, C> of(Slice<T> slice) {
         List<T> content = slice.getContent();
-        Long nextCursorId = null;
+        C nextCursor = !slice.isLast() && !content.isEmpty()
+                ? content.get(content.size() - 1).getCursor()
+                : null;
 
-        if (!slice.isLast() && !content.isEmpty()) {
-            Object lastElement = content.get(content.size() - 1);
-            if (lastElement instanceof MyPostSummaryResponse lastPost) {
-                nextCursorId = lastPost.postId();
-            }
-            else if (lastElement instanceof MyCommentSummaryResponse lastComment) {
-                nextCursorId = lastComment.commentId();
-            }
-            else if (lastElement instanceof CommentResponse lastComment){
-                nextCursorId = lastComment.commentId();
-            }
-            else if(lastElement instanceof PostSummaryResponse lastPost){
-                nextCursorId = lastPost.postId();
-            }
-        }
-
-        return new SliceResponse<>(content, nextCursorId, slice.isLast());
+        return new SliceResponse<>(content, nextCursor, slice.isLast());
     }
 }


### PR DESCRIPTION
## Related issue 🛠
- closed #72
  
## Work Description 📝
SliceResponse 내에서 DTO의 타입을 판단하여 nextCursor를 반환하는 로직을 각 DTO가 하도록 분리하였습니다. 
또한 Cursor에는 Id 값이 아닌 다른 값들도 올 수 있기 때문에 제네릭으로 선언했습니다.
### 기존 로직
```
if (!slice.isLast() && !content.isEmpty()) {
            Object lastElement = content.get(content.size() - 1);
            if (lastElement instanceof MyPostSummaryResponse lastPost) {
                nextCursorId = lastPost.postId();
            }
            else if (lastElement instanceof MyCommentSummaryResponse lastComment) {
                nextCursorId = lastComment.commentId();
            }
            else if (lastElement instanceof CommentResponse lastComment){
                nextCursorId = lastComment.commentId();
            }
            else if(lastElement instanceof PostSummaryResponse lastPost){
                nextCursorId = lastPost.postId();
            }
        }
```
이와 같이 instanceof를 통해 일일이 DTO 타입을 비교하여 Cursor 값을 반환하는 것이 비효율적이고 객체지향적인 코드가 아니라고 생각하여, 
무한 스크롤 응답 DTO들이 CursorProvider 인터페이스를 상속받도록 구현하였습니다.
```
public record CommentResponse (
	@Schema(description = "게시글 id")
	Long commentId,

	@Schema(description = "작성자 ID")
	Long writerId,

	@Schema(description = "작성자 닉네임")
	String wrtierNickname,

	@Schema(description = "작성자 프로필 이미지")
	String profileImage,

	@Schema(description = "댓글 내용")
	String content,

	@Schema(description = "생성 시간")
	LocalDateTime createdAt,

	@Schema(description = "수정 시간")
	LocalDateTime updatedAt
) implements CursorProvider<Long>
{
	@Override
	public Long getCursor() {
		return commentId;
	}
}
```
이와 같이 각 DTO에서 cursor값을 직접 지정하여 반환하도록 수정했습니다.

