### PR TITLE
[Refactor] 외부 API 요청 RestClient 방식으로 변경

### DIFF
--- a/src/main/java/org/sopt/bofit/BofitApplication.java
+++ b/src/main/java/org/sopt/bofit/BofitApplication.java
@@ -2,6 +2,7 @@ package org.sopt.bofit;
 
 import org.sopt.bofit.global.config.properties.JwtProperties;
 import org.sopt.bofit.global.config.properties.KakaoProperties;
+import org.sopt.bofit.global.config.properties.OpenAiProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -9,7 +10,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @EnableJpaAuditing
 @SpringBootApplication
-@EnableConfigurationProperties({JwtProperties.class, KakaoProperties.class})
+@EnableConfigurationProperties({JwtProperties.class, KakaoProperties.class, OpenAiProperties.class})
 public class BofitApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/org/sopt/bofit/global/config/properties/OpenAiProperties.java
+++ b/src/main/java/org/sopt/bofit/global/config/properties/OpenAiProperties.java
@@ -1,0 +1,13 @@
+package org.sopt.bofit.global.config.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "openai")
+public record OpenAiProperties(
+        String secretKey,
+        String baseUrl,
+        String model,
+        int maxTokens,
+        double temperature
+) {
+}

--- a/src/main/java/org/sopt/bofit/global/external/openai/client/OpenAiClient.java
+++ b/src/main/java/org/sopt/bofit/global/external/openai/client/OpenAiClient.java
@@ -1,52 +1,52 @@
 package org.sopt.bofit.global.external.openai.client;
 
-import java.util.List;
-import java.util.Objects;
-
-import org.sopt.bofit.global.external.openai.dto.request.OpenAiRequest;
 import org.sopt.bofit.global.external.openai.dto.request.ChatRequestMessage;
+import org.sopt.bofit.global.external.openai.dto.request.OpenAiRequest;
 import org.sopt.bofit.global.external.openai.dto.response.OpenAiResponse;
+import org.sopt.bofit.global.oauth.constant.HttpHeaderConstants;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
-import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.client.RestClient;
+
+import java.util.List;
+import java.util.Objects;
 
 @Component
 public class OpenAiClient {
-	public final static String REQUEST_URI = "/chat/completions";
-	public final static String BEARER_TYPE = "Bearer ";
+	public static final String REQUEST_URI = "/chat/completions";
 
-	private final WebClient webClient;
+	private final RestClient restClient;
 
 	@Value("${openai.model}")
 	private String model;
+
 	@Value("${openai.max-tokens}")
 	private int maxTokens;
+
 	@Value("${openai.temperature}")
 	private double temperature;
 
 	public OpenAiClient(
-		WebClient.Builder webClientBuilder,
-		@Value("${openai.secret-key}") String secretKey,
-		@Value("${openai.base-url}") String baseUrl
-	){
-		this.webClient = webClientBuilder
-			.baseUrl(baseUrl)
-			.defaultHeader(HttpHeaders.AUTHORIZATION, BEARER_TYPE + secretKey)
-			.defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-			.build();
+			@Value("${openai.secret-key}") String secretKey,
+			@Value("${openai.base-url}") String baseUrl
+	) {
+		this.restClient = RestClient.builder()
+				.baseUrl(baseUrl)
+				.defaultHeader(HttpHeaders.AUTHORIZATION, HttpHeaderConstants.BEARER_PREFIX + secretKey)
+				.defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+				.build();
 	}
 
 	public String sendRequest(List<ChatRequestMessage> messages) {
 		OpenAiRequest request = new OpenAiRequest(model, messages, maxTokens, temperature);
 
-		OpenAiResponse response = webClient.post()
-			.uri(REQUEST_URI)
-			.bodyValue(request)
-			.retrieve()
-			.bodyToMono(OpenAiResponse.class)
-			.block();
+		OpenAiResponse response = restClient.post()
+				.uri(REQUEST_URI)
+				.body(request)
+				.retrieve()
+				.body(OpenAiResponse.class);
 
 		return parseContent(Objects.requireNonNull(response));
 	}
@@ -54,5 +54,4 @@ public class OpenAiClient {
 	private String parseContent(OpenAiResponse response) {
 		return response.choices().get(0).message().content().trim();
 	}
-
 }

--- a/src/main/java/org/sopt/bofit/global/external/openai/client/OpenAiClient.java
+++ b/src/main/java/org/sopt/bofit/global/external/openai/client/OpenAiClient.java
@@ -1,10 +1,10 @@
 package org.sopt.bofit.global.external.openai.client;
 
+import org.sopt.bofit.global.config.properties.OpenAiProperties;
 import org.sopt.bofit.global.external.openai.dto.request.ChatRequestMessage;
 import org.sopt.bofit.global.external.openai.dto.request.OpenAiRequest;
 import org.sopt.bofit.global.external.openai.dto.response.OpenAiResponse;
 import org.sopt.bofit.global.oauth.constant.HttpHeaderConstants;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
@@ -18,29 +18,24 @@ public class OpenAiClient {
 	public static final String REQUEST_URI = "/chat/completions";
 
 	private final RestClient restClient;
+	private final OpenAiProperties properties;
 
-	@Value("${openai.model}")
-	private String model;
-
-	@Value("${openai.max-tokens}")
-	private int maxTokens;
-
-	@Value("${openai.temperature}")
-	private double temperature;
-
-	public OpenAiClient(
-			@Value("${openai.secret-key}") String secretKey,
-			@Value("${openai.base-url}") String baseUrl
-	) {
+	public OpenAiClient(OpenAiProperties properties) {
+		this.properties = properties;
 		this.restClient = RestClient.builder()
-				.baseUrl(baseUrl)
-				.defaultHeader(HttpHeaders.AUTHORIZATION, HttpHeaderConstants.BEARER_PREFIX + secretKey)
+				.baseUrl(properties.baseUrl())
+				.defaultHeader(HttpHeaders.AUTHORIZATION, HttpHeaderConstants.BEARER_PREFIX + properties.secretKey())
 				.defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
 				.build();
 	}
 
 	public String sendRequest(List<ChatRequestMessage> messages) {
-		OpenAiRequest request = new OpenAiRequest(model, messages, maxTokens, temperature);
+		OpenAiRequest request = new OpenAiRequest(
+				properties.model(),
+				messages,
+				properties.maxTokens(),
+				properties.temperature()
+		);
 
 		OpenAiResponse response = restClient.post()
 				.uri(REQUEST_URI)

--- a/src/main/java/org/sopt/bofit/global/oauth/controller/OAuthController.java
+++ b/src/main/java/org/sopt/bofit/global/oauth/controller/OAuthController.java
@@ -4,16 +4,17 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.sopt.bofit.global.annotation.CustomExceptionDescription;
+import org.sopt.bofit.global.dto.response.BaseResponse;
 import org.sopt.bofit.global.oauth.dto.KaKaoLoginResponse;
 import org.sopt.bofit.global.oauth.dto.TokenReissueResponse;
 import org.sopt.bofit.global.oauth.service.OAuthService;
-import org.sopt.bofit.global.annotation.CustomExceptionDescription;
-import org.sopt.bofit.global.dto.response.BaseResponse;
 import org.springframework.web.bind.annotation.*;
-import reactor.core.publisher.Mono;
 
-import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.*;
-import static org.sopt.bofit.global.constant.SwaggerConstant.*;
+import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.KAKAO_TOKEN_REQUEST;
+import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.TOKEN_REISSUE;
+import static org.sopt.bofit.global.constant.SwaggerConstant.TAG_DESCRIPTION_KAKAO_LOGIN;
+import static org.sopt.bofit.global.constant.SwaggerConstant.TAG_NAME_KAKAO_LOGIN;
 
 @RestController
 @RequiredArgsConstructor
@@ -26,9 +27,8 @@ public class OAuthController {
     @CustomExceptionDescription(KAKAO_TOKEN_REQUEST)
     @Operation(summary = "카카오 로그인", description = "카카오 API를 통해 로그인합니다.")
     @GetMapping("/kakao/login")
-    public Mono<BaseResponse<KaKaoLoginResponse>> kakaoCallback(@RequestParam("code") String code) {
-        return oAuthService.login(code)
-                .map(response -> BaseResponse.ok(response, "카카오 로그인 성공"));
+    public BaseResponse<KaKaoLoginResponse> kakaoCallback(@RequestParam("code") String code) {
+        return BaseResponse.ok(oAuthService.login(code), "카카오 로그인 성공");
     }
 
     @Tag(name = TAG_NAME_KAKAO_LOGIN, description = TAG_DESCRIPTION_KAKAO_LOGIN)

--- a/src/main/java/org/sopt/bofit/global/oauth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/org/sopt/bofit/global/oauth/jwt/JwtAuthenticationFilter.java
@@ -6,7 +6,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-
 import org.sopt.bofit.global.exception.custom_exception.CustomException;
 import org.sopt.bofit.global.oauth.constant.HttpHeaderConstants;
 import org.sopt.bofit.global.oauth.constant.RequestAttributeConstants;
@@ -18,7 +17,9 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.stream.Stream;
+
+import static org.sopt.bofit.global.oauth.constant.PathConstant.ACTUATOR_PATH;
+import static org.sopt.bofit.global.oauth.constant.PathConstant.OAUTH_KAKAO_LOGIN_PATH;
 
 @Slf4j
 @Component

--- a/src/main/java/org/sopt/bofit/global/oauth/service/OAuthService.java
+++ b/src/main/java/org/sopt/bofit/global/oauth/service/OAuthService.java
@@ -22,8 +22,6 @@ import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestClient;
-import reactor.core.publisher.Mono;
-import reactor.core.scheduler.Schedulers;
 
 import java.nio.charset.StandardCharsets;
 
@@ -49,10 +47,10 @@ public class OAuthService {
 
     private final RestClient restClient = RestClient.builder().baseUrl("").build();
 
-    private Mono<KaKaoTokenResponse> requestToken(String code) {
+    private KaKaoTokenResponse requestToken(String code) {
         String body = OAuthUtil.buildTokenRequestBody(code, properties.clientId(), properties.redirectUri());
 
-        return Mono.fromCallable(() -> restClient.post()
+        return restClient.post()
                 .uri(properties.tokenUri())
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED)
                 .body(body)
@@ -63,73 +61,55 @@ public class OAuthService {
                             log.error("❌ Kakao 토큰 요청 실패: {}", errorBody);
                             throw new BadRequestException(KAKAO_TOKEN_REQUEST_FAILED);
                         })
-                .body(KaKaoTokenResponse.class))
-                .subscribeOn(Schedulers.boundedElastic())
-                .doOnNext(token -> log.info("✅ Kakao access token 발급 성공"))
-                .doOnError(e -> log.error("❌ Kakao 토큰 요청 중 예외 발생", e));
+                .body(KaKaoTokenResponse.class);
     }
 
-    private Mono<KakaoUserResponse> getUserInfo(String accessToken) {
-        return Mono.fromCallable(() -> restClient.get()
+    private KakaoUserResponse getUserInfo(String accessToken) {
+        return restClient.get()
                 .uri(properties.userInfoUri())
                 .headers(h -> h.setBearerAuth(accessToken))
                 .retrieve()
-                .body(KakaoUserResponse.class))
-                .subscribeOn(Schedulers.boundedElastic());
+                .body(KakaoUserResponse.class);
     }
 
-    private Mono<User> registerOrLogin(String accessToken) {
-        return getUserInfo(accessToken)
-                .flatMap(kakaoUser -> {
-                    KakaoAccount account = kakaoUser.kakaoAccount();
-                    if (account == null) {
-                        return Mono.error(new BadRequestException(KAKAO_USER_INFO_REQUEST_FAILED));
-                    }
-                    UserProfile profile = account.profile();
-                    boolean isDefault = account.profile().isDefaultImage();
-                    String userProfileImage = isDefault ? null : account.profile().profileImageUrl();
+    private User registerOrLogin(String accessToken) {
+        KakaoUserResponse kakaoUser = getUserInfo(accessToken);
+        KakaoAccount account = kakaoUser.kakaoAccount();
+        if (account == null) {
+            throw new BadRequestException(KAKAO_USER_INFO_REQUEST_FAILED);
+        }
 
-                    return Mono.fromCallable(() ->
-                                    userRepository.findByOauthId(String.valueOf(kakaoUser.oauthId()))
-                            )
-                            .subscribeOn(Schedulers.boundedElastic())
-                            .flatMap(optionalUser ->
-                                    optionalUser.map(Mono::just).orElseGet(() -> {
-                                        User newUser = User.builder()
-                                                .loginProvider(LoginProvider.KAKAO)
-                                                .oauthId(String.valueOf(kakaoUser.oauthId()))
-                                                .nickname(profile.nickname())
-                                                .profileImage(userProfileImage)
-                                                .build();
-                                        return Mono.fromCallable(() -> userRepository.save(newUser))
-                                                .subscribeOn(Schedulers.boundedElastic());
-                                    })
-                            );
+        UserProfile profile = account.profile();
+        boolean isDefault = profile.isDefaultImage();
+        String userProfileImage = isDefault ? null : profile.profileImageUrl();
+
+        return userRepository.findByOauthId(String.valueOf(kakaoUser.oauthId()))
+                .orElseGet(() -> {
+                    User newUser = User.builder()
+                            .loginProvider(LoginProvider.KAKAO)
+                            .oauthId(String.valueOf(kakaoUser.oauthId()))
+                            .nickname(profile.nickname())
+                            .profileImage(userProfileImage)
+                            .build();
+                    return userRepository.save(newUser);
                 });
     }
 
     @Transactional
-    public Mono<KaKaoLoginResponse> login(String code) {
-        return requestToken(code)
-                .flatMap(token ->
-                        registerOrLogin(token.accessToken())
-                                .publishOn(Schedulers.boundedElastic())
-                                .map(user -> {
-                                    String accessToken = jwtProvider.generateAccessToken(user.getId());
-                                    String refreshToken = jwtProvider.generateRefreshToken(user.getId());
+    public KaKaoLoginResponse login(String code) {
+        KaKaoTokenResponse token = requestToken(code);
+        User user = registerOrLogin(token.accessToken());
 
-                                    refreshTokenRepository.findByUserId(user.getId())
-                                            .ifPresentOrElse(
-                                                    existing -> existing.updateToken(refreshToken),
-                                                    () -> refreshTokenRepository.save(RefreshToken.of(user.getId(), refreshToken))
-                                            );
-                                    return KaKaoLoginResponse.of(
-                                            user.getId(),
-                                            accessToken,
-                                            refreshToken
-                                    );
-                                })
+        String accessToken = jwtProvider.generateAccessToken(user.getId());
+        String refreshToken = jwtProvider.generateRefreshToken(user.getId());
+
+        refreshTokenRepository.findByUserId(user.getId())
+                .ifPresentOrElse(
+                        existing -> existing.updateToken(refreshToken),
+                        () -> refreshTokenRepository.save(RefreshToken.of(user.getId(), refreshToken))
                 );
+
+        return KaKaoLoginResponse.of(user.getId(), accessToken, refreshToken);
     }
 
     @Transactional

--- a/src/main/java/org/sopt/bofit/global/oauth/service/OAuthService.java
+++ b/src/main/java/org/sopt/bofit/global/oauth/service/OAuthService.java
@@ -108,7 +108,6 @@ public class OAuthService {
                         existing -> existing.updateToken(refreshToken),
                         () -> refreshTokenRepository.save(RefreshToken.of(user.getId(), refreshToken))
                 );
-
         return KaKaoLoginResponse.of(user.getId(), accessToken, refreshToken);
     }
 


### PR DESCRIPTION
## Related issue 🛠
- closed #81
  


## Work Description 📝
- 기존에 카카오 로그인, Open API 등 요청을 보낼 때 WebClient를 사용했습니다. WebClient의 가장 큰 장점이 작업을 '비동기적'으로 처리할 수 있는 것인데, 현재 로직 상 카카오 로그인과 Chat GPT 호출 과정에서는 실제로 동기적인 작업이 이루어지고 있었습니다. 그러면 WebClient를 쓰는 이유가 없다고 생각하여, `RestClient`를 도입하게 되었습니다.
## Uncompleted Tasks 😅

