### PR TITLE
[Refactor] 카카오 로그인 시 Redirect URI 동적으로 처리

### DIFF
--- a/src/main/java/org/sopt/bofit/global/config/properties/KakaoProperties.java
+++ b/src/main/java/org/sopt/bofit/global/config/properties/KakaoProperties.java
@@ -6,7 +6,6 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties(prefix = "kakao")
 public record KakaoProperties(
         String clientId,
-        String redirectUri,
         String tokenUri,
         String userInfoUri
 ) { }

--- a/src/main/java/org/sopt/bofit/global/oauth/controller/OAuthController.java
+++ b/src/main/java/org/sopt/bofit/global/oauth/controller/OAuthController.java
@@ -3,6 +3,7 @@ package org.sopt.bofit.global.oauth.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.sopt.bofit.global.annotation.CustomExceptionDescription;
 import org.sopt.bofit.global.dto.response.BaseResponse;
@@ -27,8 +28,10 @@ public class OAuthController {
     @CustomExceptionDescription(KAKAO_TOKEN_REQUEST)
     @Operation(summary = "카카오 로그인", description = "카카오 API를 통해 로그인합니다.")
     @GetMapping("/kakao/login")
-    public BaseResponse<KaKaoLoginResponse> kakaoCallback(@RequestParam("code") String code) {
-        return BaseResponse.ok(oAuthService.login(code), "카카오 로그인 성공");
+    public BaseResponse<KaKaoLoginResponse> kakaoCallback(@RequestParam("code") String code,
+                                                          HttpServletRequest request) {
+        String redirectUri = request.getRequestURL().toString();
+        return BaseResponse.ok(oAuthService.login(code, redirectUri), "카카오 로그인 성공");
     }
 
     @Tag(name = TAG_NAME_KAKAO_LOGIN, description = TAG_DESCRIPTION_KAKAO_LOGIN)
@@ -38,5 +41,6 @@ public class OAuthController {
     public BaseResponse<TokenReissueResponse> reissue(@Parameter(hidden = true) @RequestHeader("Authorization") String refreshToken) {
         return BaseResponse.ok(oAuthService.reissue(refreshToken), "토큰 재발급 성공");
     }
+
 
 }

--- a/src/main/java/org/sopt/bofit/global/oauth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/org/sopt/bofit/global/oauth/jwt/JwtAuthenticationFilter.java
@@ -18,9 +18,6 @@ import org.springframework.web.filter.OncePerRequestFilter;
 import java.io.IOException;
 import java.util.List;
 
-import static org.sopt.bofit.global.oauth.constant.PathConstant.ACTUATOR_PATH;
-import static org.sopt.bofit.global.oauth.constant.PathConstant.OAUTH_KAKAO_LOGIN_PATH;
-
 @Slf4j
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/org/sopt/bofit/global/oauth/service/OAuthService.java
+++ b/src/main/java/org/sopt/bofit/global/oauth/service/OAuthService.java
@@ -47,8 +47,8 @@ public class OAuthService {
 
     private final RestClient restClient = RestClient.builder().baseUrl("").build();
 
-    private KaKaoTokenResponse requestToken(String code) {
-        String body = OAuthUtil.buildTokenRequestBody(code, properties.clientId(), properties.redirectUri());
+    private KaKaoTokenResponse requestToken(String code, String redirectUri) {
+        String body = OAuthUtil.buildTokenRequestBody(code, properties.clientId(), redirectUri);
 
         return restClient.post()
                 .uri(properties.tokenUri())
@@ -96,8 +96,8 @@ public class OAuthService {
     }
 
     @Transactional
-    public KaKaoLoginResponse login(String code) {
-        KaKaoTokenResponse token = requestToken(code);
+    public KaKaoLoginResponse login(String code, String redirectUri) {
+        KaKaoTokenResponse token = requestToken(code, redirectUri);
         User user = registerOrLogin(token.accessToken());
 
         String accessToken = jwtProvider.generateAccessToken(user.getId());


### PR DESCRIPTION
## Related issue 🛠
- closed #97
 

## Work Description 📝
- 기존에 환경변수로 주입받아 사용하던 Redirect URI를 동적으로 받을 수 있게끔 처리하여 클라이언트의 로컬 환경, 배포 환경에서 모두 정상적으로 작동할 수 있도록 수정했습니다.