### PR TITLE
[Feat] .dockerignore 파일 추가

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+# Gradle build cache & output
+.gradle/
+build/
+out/
+
+# IDE/Editor
+.idea/
+*.iml
+.vscode/
+
+# OS files
+.DS_Store
+
+# Docs or others
+*.md
+Dockerfile
+docker-compose.yml


### PR DESCRIPTION
## Related issue 🛠
- closed #111
  

## Work Description 📝
Docker 빌드 시간을 단축시키는 작업을 진행했습니다. 
기존에 저희는 Jenkins CI/CD 파이프라인에서 JAR 파일을 빌드하여 Dockerfile 내부에서 생성된 JAR 파일을 COPY 하는 방식으로 빌드를 진행했습니다. 또 다른 방법으로는 Dockerfile 내부에서 빌드 명령어를 실행하여 빌드하는 방법이 있었습니다. 이 방식에서, 레이어를 분리하고 멀티 스테이징 전략을 사용하여 성능을 최적화하는 방법을 사용할까 고민했는데, 결론적으로는 Dockerfile 외부에서 빌드하고 COPY하는 방식이 더 빠르다고 생각했습니다. 외부에서 전달하는 경우, JAR 파일만 전달하기 때문에 컨텍스트 크기가 작고 훨씬 더 빠르다고 생각했고, 의존성 관련 부분은 자동으로 캐싱되어 더 빠르다고 합니다. 따라서, 기존 방식을 유지하되 `.dockerignore` 파일을 추가하여 Docker build 시 불필요한 파일들이 컨텍스트에 포함되지 않도록 설정했습니다. 

