### PR TITLE
[Feature] 보험 상품 관련 캐싱 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -80,11 +80,15 @@ dependencies {
 	//resilience4j
 	implementation "io.github.resilience4j:resilience4j-spring-boot3:${resilience4jVersion}"
 
-	//aop
+	// Aop
 	implementation 'org.springframework.boot:spring-boot-starter-aop'
 
-	// prometheus
+	//Prometheus
 	implementation 'io.micrometer:micrometer-registry-prometheus'
+
+	//Cache
+	implementation 'org.springframework.boot:spring-boot-starter-cache'
+	implementation 'com.github.ben-manes.caffeine:caffeine:3.1.8'
 }
 
 def generated = "build/generated/querydsl"

--- a/src/main/java/org/sopt/bofit/BofitApplication.java
+++ b/src/main/java/org/sopt/bofit/BofitApplication.java
@@ -6,8 +6,10 @@ import org.sopt.bofit.global.config.properties.OpenAiProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableCaching
 @EnableJpaAuditing
 @SpringBootApplication
 @EnableConfigurationProperties({JwtProperties.class, KakaoProperties.class, OpenAiProperties.class})

--- a/src/main/java/org/sopt/bofit/domain/insurance/service/InsuranceStatisticReader.java
+++ b/src/main/java/org/sopt/bofit/domain/insurance/service/InsuranceStatisticReader.java
@@ -1,10 +1,13 @@
 package org.sopt.bofit.domain.insurance.service;
 
+import static org.sopt.bofit.global.constant.CacheConstant.*;
+
 import org.sopt.bofit.domain.insurance.entity.statistic.InsuranceStatistic;
 import org.sopt.bofit.domain.insurance.entity.statistic.StatisticRange;
 import org.sopt.bofit.domain.insurance.repository.InsuranceStatisticRepository;
 import org.sopt.bofit.global.exception.constant.InsuranceErrorCode;
 import org.sopt.bofit.global.exception.customexception.InternalException;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
@@ -14,6 +17,7 @@ import lombok.RequiredArgsConstructor;
 public class InsuranceStatisticReader {
 	private final InsuranceStatisticRepository insuranceStatisticRepository;
 
+	@Cacheable(value = INSURANCE_STATISTIC_CACHE_NAME)
 	public InsuranceStatistic getTotalAverage (){
 		return insuranceStatisticRepository.findByStatisticRange(StatisticRange.TOTAL_AVERAGE).orElseThrow(() ->
 			new InternalException(InsuranceErrorCode.NOT_FOUND_INSURANCE_TOTAL_AVERAGE));

--- a/src/main/java/org/sopt/bofit/domain/insurancereport/service/InsuranceReportReader.java
+++ b/src/main/java/org/sopt/bofit/domain/insurancereport/service/InsuranceReportReader.java
@@ -1,5 +1,7 @@
 package org.sopt.bofit.domain.insurancereport.service;
 
+import static org.sopt.bofit.global.constant.CacheConstant.*;
+
 import java.util.UUID;
 
 import org.sopt.bofit.domain.insurancereport.entity.InsuranceReport;
@@ -7,6 +9,7 @@ import org.sopt.bofit.domain.insurancereport.errorcode.InsuranceReportErrorCode;
 import org.sopt.bofit.domain.insurancereport.repository.InsuranceReportRepository;
 import org.sopt.bofit.domain.user.entity.User;
 import org.sopt.bofit.global.exception.customexception.NotFoundException;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
@@ -21,6 +24,7 @@ public class InsuranceReportReader {
 			new NotFoundException(InsuranceReportErrorCode.NOT_FOUND_INSURANCE_REPORT));
 	}
 
+	@Cacheable(cacheNames = INSURANCE_REPORT_CACHE_NAME, key = "#insuranceReportId")
 	public InsuranceReport findByIdWithRelatedEntity(UUID insuranceReportId){
 		return insuranceReportRepository.findByIdWithProductAndStatistic(insuranceReportId).orElseThrow(() ->
 			new NotFoundException(InsuranceReportErrorCode.NOT_FOUND_INSURANCE_REPORT));

--- a/src/main/java/org/sopt/bofit/domain/insurancereport/service/InsuranceReportWriter.java
+++ b/src/main/java/org/sopt/bofit/domain/insurancereport/service/InsuranceReportWriter.java
@@ -1,5 +1,7 @@
 package org.sopt.bofit.domain.insurancereport.service;
 
+import static org.sopt.bofit.domain.insurancereport.constant.InsuranceReportConstant.*;
+import static org.sopt.bofit.global.constant.CacheConstant.*;
 import static org.sopt.bofit.global.external.openai.constant.OpenAiRole.*;
 
 import java.util.Comparator;
@@ -26,6 +28,8 @@ import org.sopt.bofit.domain.user.service.UserInfoWriter;
 import org.sopt.bofit.global.external.openai.client.OpenAiClient;
 import org.sopt.bofit.global.external.openai.dto.request.ChatRequestMessage;
 import org.sopt.bofit.global.external.openai.template.OpenAiPromptManager;
+import org.springframework.cache.annotation.CachePut;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -66,7 +70,7 @@ public class InsuranceReportWriter {
 		return scoringRuledProduct.orElseGet(insuranceProductReader::getRecommendedStatusProducts);
 	}
 
-	@Transactional
+	@CachePut(cacheNames = INSURANCE_REPORT_CACHE_NAME, key = "#result.id", unless = "#result==null")
 	public InsuranceReport writeReport(
 		InsuranceStatistic average,
 		InsuranceProduct product,

--- a/src/main/java/org/sopt/bofit/domain/insurancereport/service/scoringrule/ScoringRuleProvider.java
+++ b/src/main/java/org/sopt/bofit/domain/insurancereport/service/scoringrule/ScoringRuleProvider.java
@@ -1,5 +1,7 @@
 package org.sopt.bofit.domain.insurancereport.service.scoringrule;
 
+import static org.sopt.bofit.global.constant.CacheConstant.*;
+
 import java.util.List;
 
 import org.sopt.bofit.domain.insurancereport.entity.scoringrule.diseasehistory.DiseaseHistoryScoringRule;
@@ -13,6 +15,7 @@ import org.sopt.bofit.domain.insurancereport.repository.scoringrule.SelectedScor
 import org.sopt.bofit.domain.insurancereport.repository.scoringrule.UserInfoScoringRuleRepository;
 import org.sopt.bofit.domain.user.entity.constant.CoveragePreference;
 import org.sopt.bofit.domain.user.entity.constant.DiagnosedDisease;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
@@ -25,18 +28,22 @@ public class ScoringRuleProvider {
 	private final FamilyHistoryScoringRuleRepository familyHistoryScoringRuleRepository;
 	private final SelectedScoringRuleRepository selectedScoringRuleRepository;
 
+	@Cacheable(cacheNames = USER_INFO_SCORING_RULE_CACHE_NAME, key = "#userInfoRuleType")
 	public List<UserInfoScoringRule> findAllUserInfoRuleType(UserInfoRuleType userInfoRuleType){
 		return userInfoScoringRuleRepository.findAllByUserInfoRuleType(userInfoRuleType);
 	}
 
+	@Cacheable(cacheNames = DISEASE_HISTORY_SCORING_RULE_CACHE_NAME, key = "#diagnosedDisease")
 	public List<DiseaseHistoryScoringRule> findAllDiseaseHistory(DiagnosedDisease diagnosedDisease){
 		return diseaseHistoryScoringRuleRepository.findAllByDiagnosedDisease(diagnosedDisease);
 	}
 
+	@Cacheable(cacheNames = FAMILY_HISTORY_SCORING_RULE_CACHE_NAME, key = "#diagnosedDisease")
 	public List<FamilyHistoryScoringRule> findAllFamilyHistory(DiagnosedDisease diagnosedDisease){
 		return familyHistoryScoringRuleRepository.findAllByDiagnosedDisease(diagnosedDisease);
 	}
 
+	@Cacheable(cacheNames = SELECTED_SCORING_RULE_CACHE_NAME, key = "#coveragePreference")
 	public List<SelectedScoringRule> findAllCoveragePreference(CoveragePreference coveragePreference){
 		return selectedScoringRuleRepository.findAllByCoveragePreference(coveragePreference);
 	}

--- a/src/main/java/org/sopt/bofit/global/config/CacheConfig.java
+++ b/src/main/java/org/sopt/bofit/global/config/CacheConfig.java
@@ -1,0 +1,58 @@
+package org.sopt.bofit.global.config;
+
+import static org.sopt.bofit.global.constant.CacheConstant.*;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.concurrent.TimeUnit;
+
+@Configuration
+public class CacheConfig {
+
+	@Bean
+	public CacheManager cacheManager() {
+		CaffeineCacheManager cacheManager = new CaffeineCacheManager();
+		cacheManager.setCaffeine(Caffeine.newBuilder()
+			.initialCapacity(100)
+			.maximumSize(500)
+			.expireAfterAccess(30, TimeUnit.MINUTES));
+		cacheManager.setCacheNames(java.util.Arrays.asList(DEFAULT_CACHE_NAME)); // 캐시 이름 지정
+		cacheManager.registerCustomCache(USER_INFO_SCORING_RULE_CACHE_NAME, scoringRuleCacheBuilder().build());
+		cacheManager.registerCustomCache(DISEASE_HISTORY_SCORING_RULE_CACHE_NAME, scoringRuleCacheBuilder().build());
+		cacheManager.registerCustomCache(FAMILY_HISTORY_SCORING_RULE_CACHE_NAME, scoringRuleCacheBuilder().build());
+		cacheManager.registerCustomCache(SELECTED_SCORING_RULE_CACHE_NAME, scoringRuleCacheBuilder().build());
+
+		cacheManager.registerCustomCache(INSURANCE_REPORT_CACHE_NAME, insuranceReportCacheBuilder().build());
+		cacheManager.registerCustomCache(INSURANCE_STATISTIC_CACHE_NAME, insuranceStatisticCacheBuilder().build());
+		return cacheManager;
+	}
+
+	private Caffeine<Object, Object> scoringRuleCacheBuilder(){
+		return Caffeine.newBuilder()
+			.expireAfterWrite(1, TimeUnit.DAYS)
+			.maximumSize(200)
+			.softValues()
+			;
+	}
+
+	private Caffeine<Object, Object> insuranceReportCacheBuilder(){
+		return Caffeine.newBuilder()
+			.expireAfterAccess(60, TimeUnit.MINUTES)
+			.maximumSize(50)
+			.softValues()
+			// .recordStats()
+			;
+	}
+
+	private Caffeine<Object, Object> insuranceStatisticCacheBuilder(){
+		return Caffeine.newBuilder()
+			.expireAfterWrite(1, TimeUnit.DAYS)
+			.maximumSize(10)
+			.softValues()
+			;
+	}
+}

--- a/src/main/java/org/sopt/bofit/global/constant/CacheConstant.java
+++ b/src/main/java/org/sopt/bofit/global/constant/CacheConstant.java
@@ -1,0 +1,18 @@
+ package org.sopt.bofit.global.constant;
+
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class CacheConstant {
+
+	public final static String DEFAULT_CACHE_NAME = "default";
+	public final static String USER_INFO_SCORING_RULE_CACHE_NAME = "userInfoScoringRule";
+	public final static String DISEASE_HISTORY_SCORING_RULE_CACHE_NAME = "diseaseHistoryScoringRule";
+	public final static String FAMILY_HISTORY_SCORING_RULE_CACHE_NAME = "familyHistoryScoringRule";
+	public final static String SELECTED_SCORING_RULE_CACHE_NAME = "selectedScoringRule";
+	public final static String INSURANCE_STATISTIC_CACHE_NAME = "insuranceStatistic";
+	public final static String INSURANCE_REPORT_CACHE_NAME = "insuranceReport";
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -55,7 +55,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: prometheus, openapi, swagger, health, metrics
+        include: prometheus, openapi, swagger, health, metrics, info
   metrics:
     tags:
       application: bofit-server # 메트릭에 애플리케이션 이름 태그 추가


### PR DESCRIPTION
## Related issue 🛠
- closed #114 
  


## Work Description 📝
- 보험 상품 관련 캐싱 적용
  - InsuranceReport
  - InsuranceStatistic
  - 4 Types of ScoringRule

- 로컬 캐싱을 사용한 이유는 
  - 현재 캐싱의 주 대상인 스코어링 룰 가중치의 경우 기획의 요구에 따라 변경 가능, 외부에 노출하지 않기 위해 DB에 넣고 사용하고 있지만, 변동이 아주 드문 값이므로 정합성을 크게 고려할 필요가 없다고 생각했음.
  - 가중치의 경우 한번 보험 상품의 점수 측정을 위해 계산할 때 사용자의 요구사항에 따라 DB와 통신이 20번 이상까지도 발생할 수 있기 때문에(물론 거의 모든 항목들을 선택하는 정말 드문 경우임) 캐싱을 하더라도 Redis와 통신을 하는 것 자체가 리소스로 다가올 수 있다고 생각했음.
  -  보험 추천 리포트의 경우 수정이 불가능한 항목이므로 정합성을 고려하지 않아도 무방했기에 로컬 캐싱과 잘 어울렸고, 리포트 조회 API를 분리한 상태이므로 사용자가 리포트를 읽을 경우 조회가 잦게 발생하지만, 사용되지 않는 경우에는 메모리 차지를 하지 않도록 하고 싶었기에 AfterAccess로 TTL을 설정함

-  InsuranceReport 캐싱 시에는 아래와 같이 연관 엔티티들이 함께 잘 들어갑니다. 사실 메모리에 객체 자체를 저장하고 있는 형태이므로, 연관관계가 맺어지지 않은  InsuranceReport 까지 저장하는 형태가 된다면 캐시를 분리하거나(근데 이건 메모리 낭비가 심할 것 같아서 별로인 것 같아요) 따로 처리를 해서 필요 시 연관관계를 업데이트하도록 해야할 것 같습니다. 현재는 연관관계를 모두 갖는 경우만 사용하기 때문에 캐싱도 연관관계를 모두 갖는 경우에만 진행하는 형태입니다.

<img width="1986" height="1714" alt="스크린샷 2025-08-01 234305" src="https://github.com/user-attachments/assets/bbb26ed5-dce0-4685-b7e4-aefadc733320" />


## Uncompleted Tasks 😅


## To Reviewers 📢
- 캐싱 관련 사항들 커밋 메세지에 조금 더 작성해두었습니다.