### PR TITLE
[Fix] 도커 빌드 오류 현상 해결

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,5 @@
-# Gradle build cache & output
+# Gradle build cache (but not output)
 .gradle/
-build/
 out/
 
 # IDE/Editor
@@ -13,5 +12,3 @@ out/
 
 # Docs or others
 *.md
-Dockerfile
-docker-compose.yml


### PR DESCRIPTION
## Related issue 🛠
- closed #117
  


## Work Description 📝
- 도커 빌드 성능 향상을 위해 추가했던 .dockerignore 파일에서 build/ 디렉토리를 제외하여 도커 빌드가 실패하던 현상을 해결했습니다.
