### PR TITLE
[Feat]  소셜로그인 리다이렉트 url 동적으로 사용하도록 변경

### DIFF
--- a/src/main/java/org/sopt/bofit/global/oauth/controller/OAuthController.java
+++ b/src/main/java/org/sopt/bofit/global/oauth/controller/OAuthController.java
@@ -1,20 +1,28 @@
 package org.sopt.bofit.global.oauth.controller;
 
+import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.*;
+import static org.sopt.bofit.global.constant.SwaggerConstant.*;
+
+import java.util.Optional;
+
+import org.sopt.bofit.global.annotation.CustomExceptionDescription;
+import org.sopt.bofit.global.dto.response.BaseResponse;
+import org.sopt.bofit.global.oauth.dto.request.OAuthLoginRequest;
+import org.sopt.bofit.global.oauth.dto.response.KaKaoLoginResponse;
+import org.sopt.bofit.global.oauth.dto.response.TokenReissueResponse;
+import org.sopt.bofit.global.oauth.service.OAuthService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.sopt.bofit.global.annotation.CustomExceptionDescription;
-import org.sopt.bofit.global.dto.response.BaseResponse;
-import org.sopt.bofit.global.oauth.dto.KaKaoLoginResponse;
-import org.sopt.bofit.global.oauth.dto.TokenReissueResponse;
-import org.sopt.bofit.global.oauth.service.OAuthService;
-import org.springframework.web.bind.annotation.*;
-
-import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.KAKAO_TOKEN_REQUEST;
-import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.TOKEN_REISSUE;
-import static org.sopt.bofit.global.constant.SwaggerConstant.TAG_DESCRIPTION_KAKAO_LOGIN;
-import static org.sopt.bofit.global.constant.SwaggerConstant.TAG_NAME_KAKAO_LOGIN;
 
 @RestController
 @RequiredArgsConstructor
@@ -35,12 +43,19 @@ public class OAuthController {
     }
 
     @Tag(name = TAG_NAME_KAKAO_LOGIN, description = TAG_DESCRIPTION_KAKAO_LOGIN)
+    @CustomExceptionDescription(KAKAO_TOKEN_REQUEST)
+    @Operation(summary = "카카오 로그인 - POST", description = "카카오 API를 통해 로그인합니다. POST 요청을 사용하여 Body에 필요한 데이터를 받아옵니다.")
+    @PostMapping("/kakao/login")
+    public BaseResponse<KaKaoLoginResponse> kakaoCallback(@RequestBody OAuthLoginRequest oAuthLoginRequest) {
+        return BaseResponse.ok(oAuthService.login(oAuthLoginRequest), "카카오 로그인 성공");
+    }
+
+    @Tag(name = TAG_NAME_KAKAO_LOGIN, description = TAG_DESCRIPTION_KAKAO_LOGIN)
     @CustomExceptionDescription(TOKEN_REISSUE)
     @Operation(summary = "토큰 재발급")
     @PostMapping("/reissue")
     public BaseResponse<TokenReissueResponse> reissue(@Parameter(hidden = true) @RequestHeader("Authorization") String refreshToken) {
         return BaseResponse.ok(oAuthService.reissue(refreshToken), "토큰 재발급 성공");
     }
-
 
 }

--- a/src/main/java/org/sopt/bofit/global/oauth/controller/OAuthController.java
+++ b/src/main/java/org/sopt/bofit/global/oauth/controller/OAuthController.java
@@ -27,8 +27,11 @@ public class OAuthController {
     @CustomExceptionDescription(KAKAO_TOKEN_REQUEST)
     @Operation(summary = "카카오 로그인", description = "카카오 API를 통해 로그인합니다.")
     @GetMapping("/kakao/login")
-    public BaseResponse<KaKaoLoginResponse> kakaoCallback(@RequestParam("code") String code) {
-        return BaseResponse.ok(oAuthService.login(code), "카카오 로그인 성공");
+    public BaseResponse<KaKaoLoginResponse> kakaoCallback(
+        @RequestParam("code") String code,
+        @RequestParam(value = "redirect-url", required = false) String redirectUrl
+    ) {
+        return BaseResponse.ok(oAuthService.login(code, Optional.ofNullable(redirectUrl)), "카카오 로그인 성공");
     }
 
     @Tag(name = TAG_NAME_KAKAO_LOGIN, description = TAG_DESCRIPTION_KAKAO_LOGIN)

--- a/src/main/java/org/sopt/bofit/global/oauth/dto/request/OAuthLoginRequest.java
+++ b/src/main/java/org/sopt/bofit/global/oauth/dto/request/OAuthLoginRequest.java
@@ -1,0 +1,10 @@
+package org.sopt.bofit.global.oauth.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record OAuthLoginRequest (
+	@NotNull
+	String code,
+	String redirectUrl
+){
+}

--- a/src/main/java/org/sopt/bofit/global/oauth/dto/response/KaKaoLoginResponse.java
+++ b/src/main/java/org/sopt/bofit/global/oauth/dto/response/KaKaoLoginResponse.java
@@ -1,4 +1,4 @@
-package org.sopt.bofit.global.oauth.dto;
+package org.sopt.bofit.global.oauth.dto.response;
 
 
 import io.swagger.v3.oas.annotations.media.Schema;

--- a/src/main/java/org/sopt/bofit/global/oauth/dto/response/KaKaoTokenResponse.java
+++ b/src/main/java/org/sopt/bofit/global/oauth/dto/response/KaKaoTokenResponse.java
@@ -1,8 +1,8 @@
-package org.sopt.bofit.global.oauth.dto;
+package org.sopt.bofit.global.oauth.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.Getter;
 
 
 public record KaKaoTokenResponse(

--- a/src/main/java/org/sopt/bofit/global/oauth/dto/response/KakaoUserResponse.java
+++ b/src/main/java/org/sopt/bofit/global/oauth/dto/response/KakaoUserResponse.java
@@ -1,7 +1,7 @@
-package org.sopt.bofit.global.oauth.dto;
-
+package org.sopt.bofit.global.oauth.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record KakaoUserResponse(

--- a/src/main/java/org/sopt/bofit/global/oauth/dto/response/TokenReissueResponse.java
+++ b/src/main/java/org/sopt/bofit/global/oauth/dto/response/TokenReissueResponse.java
@@ -1,4 +1,4 @@
-package org.sopt.bofit.global.oauth.dto;
+package org.sopt.bofit.global.oauth.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 

--- a/src/main/java/org/sopt/bofit/global/oauth/service/OAuthService.java
+++ b/src/main/java/org/sopt/bofit/global/oauth/service/OAuthService.java
@@ -1,7 +1,13 @@
 package org.sopt.bofit.global.oauth.service;
 
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import static org.sopt.bofit.global.exception.constant.GlobalErrorCode.*;
+import static org.sopt.bofit.global.exception.constant.OAuthErrorCode.*;
+import static org.sopt.bofit.global.oauth.dto.KakaoUserResponse.*;
+import static org.sopt.bofit.global.oauth.dto.KakaoUserResponse.KakaoAccount.*;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+
 import org.sopt.bofit.domain.user.entity.User;
 import org.sopt.bofit.domain.user.entity.constant.LoginProvider;
 import org.sopt.bofit.domain.user.repository.UserRepository;
@@ -23,12 +29,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestClient;
 
-import java.nio.charset.StandardCharsets;
-
-import static org.sopt.bofit.global.exception.constant.GlobalErrorCode.JWT_INVALID;
-import static org.sopt.bofit.global.exception.constant.OAuthErrorCode.*;
-import static org.sopt.bofit.global.oauth.dto.KakaoUserResponse.KakaoAccount;
-import static org.sopt.bofit.global.oauth.dto.KakaoUserResponse.KakaoAccount.UserProfile;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Service
@@ -47,8 +49,9 @@ public class OAuthService {
 
     private final RestClient restClient = RestClient.builder().baseUrl("").build();
 
-    private KaKaoTokenResponse requestToken(String code) {
-        String body = OAuthUtil.buildTokenRequestBody(code, properties.clientId(), properties.redirectUri());
+    private KaKaoTokenResponse requestToken(String code, Optional<String> redirectUrl) {
+        String body = OAuthUtil.buildTokenRequestBody(code, properties.clientId(),
+            redirectUrl.orElseGet(properties::redirectUri));
 
         return restClient.post()
                 .uri(properties.tokenUri())
@@ -96,8 +99,8 @@ public class OAuthService {
     }
 
     @Transactional
-    public KaKaoLoginResponse login(String code) {
-        KaKaoTokenResponse token = requestToken(code);
+    public KaKaoLoginResponse login(String code, Optional<String> redirectUrl) {
+        KaKaoTokenResponse token = requestToken(code, redirectUrl);
         User user = registerOrLogin(token.accessToken());
 
         String accessToken = jwtProvider.generateAccessToken(user.getId());

--- a/src/main/java/org/sopt/bofit/global/oauth/service/OAuthService.java
+++ b/src/main/java/org/sopt/bofit/global/oauth/service/OAuthService.java
@@ -2,8 +2,8 @@ package org.sopt.bofit.global.oauth.service;
 
 import static org.sopt.bofit.global.exception.constant.GlobalErrorCode.*;
 import static org.sopt.bofit.global.exception.constant.OAuthErrorCode.*;
-import static org.sopt.bofit.global.oauth.dto.KakaoUserResponse.*;
-import static org.sopt.bofit.global.oauth.dto.KakaoUserResponse.KakaoAccount.*;
+import static org.sopt.bofit.global.oauth.dto.response.KakaoUserResponse.*;
+import static org.sopt.bofit.global.oauth.dto.response.KakaoUserResponse.KakaoAccount.*;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
@@ -15,10 +15,11 @@ import org.sopt.bofit.global.config.properties.KakaoProperties;
 import org.sopt.bofit.global.exception.customexception.BadRequestException;
 import org.sopt.bofit.global.exception.customexception.UnAuthorizedException;
 import org.sopt.bofit.global.oauth.constant.HttpHeaderConstants;
-import org.sopt.bofit.global.oauth.dto.KaKaoLoginResponse;
-import org.sopt.bofit.global.oauth.dto.KaKaoTokenResponse;
-import org.sopt.bofit.global.oauth.dto.KakaoUserResponse;
-import org.sopt.bofit.global.oauth.dto.TokenReissueResponse;
+import org.sopt.bofit.global.oauth.dto.request.OAuthLoginRequest;
+import org.sopt.bofit.global.oauth.dto.response.KaKaoLoginResponse;
+import org.sopt.bofit.global.oauth.dto.response.KaKaoTokenResponse;
+import org.sopt.bofit.global.oauth.dto.response.KakaoUserResponse;
+import org.sopt.bofit.global.oauth.dto.response.TokenReissueResponse;
 import org.sopt.bofit.global.oauth.entity.RefreshToken;
 import org.sopt.bofit.global.oauth.jwt.JwtProvider;
 import org.sopt.bofit.global.oauth.jwt.JwtUtil;
@@ -111,6 +112,22 @@ public class OAuthService {
                         existing -> existing.updateToken(refreshToken),
                         () -> refreshTokenRepository.save(RefreshToken.of(user.getId(), refreshToken))
                 );
+        return KaKaoLoginResponse.of(user.getId(), accessToken, refreshToken);
+    }
+
+    @Transactional
+    public KaKaoLoginResponse login(OAuthLoginRequest request) {
+        KaKaoTokenResponse token = requestToken(request.code(), Optional.ofNullable(request.redirectUrl()));
+        User user = registerOrLogin(token.accessToken());
+
+        String accessToken = jwtProvider.generateAccessToken(user.getId());
+        String refreshToken = jwtProvider.generateRefreshToken(user.getId());
+
+        refreshTokenRepository.findByUserId(user.getId())
+            .ifPresentOrElse(
+                existing -> existing.updateToken(refreshToken),
+                () -> refreshTokenRepository.save(RefreshToken.of(user.getId(), refreshToken))
+            );
         return KaKaoLoginResponse.of(user.getId(), accessToken, refreshToken);
     }
 


### PR DESCRIPTION
## Related issue 🛠
- closed #123 
  


## Work Description 📝
- 현재 구조를 고민하면서 로그인 api를 임시로 GET, POST 두 가지 메서드를 사용할 수 있도록 둠. EndPoint는 `/oauth/kakao/login` 으로 동일
  - GET 의 경우 쿼리 파라미터를 사용함. 
    - code -> 필수 O
    - redirect-url -> 필수 X. 기존의 클라이언트 구조를 그대로 사용할 수 있도록 하기 위함. 동적으로 사용하기 위해선 이곳에 클라이언트가 카카오 로그인 페이지에 사용하는 redirectUrl을 넣어주면 됨
  - POST 의 경우 RequestBody를 사용함.
    - code -> 필수 O
    - redirectUrl -> 필수 X. 이 부분도 입력하지 않을 경우 기존 서버에서 내장된 기본값을 사용하는 형태로 구현함. (입력할 것을 권장)
  - 되도록 구조를 유지하고자 했기 때문에 소셜 로그인 시 Provider 같은 값들을 추가하거나 하진 않음. 그러나 추후 확장 시 필요해보임.


## Uncompleted Tasks 😅

## To Reviewers 📢
- 서비스단 리팩토링이 필요해보입니다... 현재 구조는 소셜 로그인 확장자가 늘어날 때마다 서비스단 코드 수정이 너무 많아질 것 같습니다. 소셜 로그인을 진행하는 외부 의존성을 분리해서 이 부분을 쉽게 갈아낄 수 있도록 작업할 필요성이 있어보입니다~
- 임시로 서비스단의 login 메서드를 그대로 복붙해서 api 별 처리를 진행했습니다. 추후 한가지 방법으로 방향이 정해지면 사용하지 않는 쪽을 삭제하면 될 것 같습니다.