### PR TITLE
[Feat] 좋아요 삭제 API 구현

### DIFF
--- a/src/main/java/org/sopt/bofit/domain/post/controller/PostController.java
+++ b/src/main/java/org/sopt/bofit/domain/post/controller/PostController.java
@@ -7,6 +7,7 @@ import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.CR
 import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.CREATE_POST_LIKE;
 import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.DELETE_COMMENT;
 import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.DELETE_POST;
+import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.DELETE_POST_LIKE;
 import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.POST_DETAIL;
 import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.UPDATE_POST;
 import static org.sopt.bofit.global.constant.SwaggerConstant.TAG_DESCRIPTION_COMMUNITY;
@@ -154,6 +155,18 @@ public class PostController {
     ){
         postLikeService.createPostLike(userId, postId);
         return BaseResponse.create("좋아요 추가 성공");
+    }
+
+    @Tag(name = TAG_NAME_COMMUNITY, description = TAG_DESCRIPTION_COMMUNITY)
+    @Operation(summary = "게시글 좋아요 삭제", description = "유저가 커뮤니티 게시글에 생성했던 좋아요를 삭제합니다.")
+    @CustomExceptionDescription(DELETE_POST_LIKE)
+    @DeleteMapping("/{post-id}/likes")
+    public BaseResponse<Void> deletePostLike(
+        @PathVariable(name = "post-id") Long postId,
+        @Parameter(hidden = true) @LoginUserId Long userId
+    ){
+        postLikeService.deletePostLike(userId, postId);
+        return BaseResponse.create("좋아요 삭제 성공");
     }
 
 }

--- a/src/main/java/org/sopt/bofit/domain/post/repository/PostLikeRepository.java
+++ b/src/main/java/org/sopt/bofit/domain/post/repository/PostLikeRepository.java
@@ -1,5 +1,6 @@
 package org.sopt.bofit.domain.post.repository;
 
+import java.util.Optional;
 import org.sopt.bofit.domain.post.entity.Post;
 import org.sopt.bofit.domain.post.entity.PostLike;
 import org.sopt.bofit.domain.user.entity.User;
@@ -10,4 +11,5 @@ import org.springframework.stereotype.Repository;
 public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
 
     boolean existsByPostAndUser(Post post, User user);
+    Optional<PostLike> findByPostAndUser(Post post, User user);
 }

--- a/src/main/java/org/sopt/bofit/domain/post/service/PostLikeReader.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/PostLikeReader.java
@@ -19,7 +19,7 @@ public class PostLikeReader {
         return postLikeRepository.existsByPostAndUser(post, user);
     }
 
-    public PostLike findByPostAnsUser(Post post, User user){
+    public PostLike findByPostAndUser(Post post, User user){
         return postLikeRepository.findByPostAndUser(post, user)
             .orElseThrow(() -> new NotFoundException(PostErrorCode.POST_LIKE_NOT_FOUND));
     }

--- a/src/main/java/org/sopt/bofit/domain/post/service/PostLikeReader.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/PostLikeReader.java
@@ -2,8 +2,11 @@ package org.sopt.bofit.domain.post.service;
 
 import lombok.RequiredArgsConstructor;
 import org.sopt.bofit.domain.post.entity.Post;
+import org.sopt.bofit.domain.post.entity.PostLike;
 import org.sopt.bofit.domain.post.repository.PostLikeRepository;
 import org.sopt.bofit.domain.user.entity.User;
+import org.sopt.bofit.global.exception.constant.PostErrorCode;
+import org.sopt.bofit.global.exception.customexception.NotFoundException;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -14,5 +17,10 @@ public class PostLikeReader {
 
     public boolean isExistsByPostAndUser(Post post, User user){
         return postLikeRepository.existsByPostAndUser(post, user);
+    }
+
+    public PostLike findByPostAnsUser(Post post, User user){
+        return postLikeRepository.findByPostAndUser(post, user)
+            .orElseThrow(() -> new NotFoundException(PostErrorCode.POST_LIKE_DELETE_CONFLICT));
     }
 }

--- a/src/main/java/org/sopt/bofit/domain/post/service/PostLikeReader.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/PostLikeReader.java
@@ -21,6 +21,6 @@ public class PostLikeReader {
 
     public PostLike findByPostAnsUser(Post post, User user){
         return postLikeRepository.findByPostAndUser(post, user)
-            .orElseThrow(() -> new NotFoundException(PostErrorCode.POST_LIKE_DELETE_CONFLICT));
+            .orElseThrow(() -> new NotFoundException(PostErrorCode.POST_LIKE_NOT_FOUND));
     }
 }

--- a/src/main/java/org/sopt/bofit/domain/post/service/PostLikeService.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/PostLikeService.java
@@ -42,7 +42,7 @@ public class PostLikeService {
         Post post = postReader.findById(postId);
         User user = userReader.findById(userId);
 
-        PostLike postLike = postLikeReader.findByPostAnsUser(post, user);
+        PostLike postLike = postLikeReader.findByPostAndUser(post, user);
 
         postLikeWriter.delete(postLike);
 

--- a/src/main/java/org/sopt/bofit/domain/post/service/PostLikeService.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/PostLikeService.java
@@ -37,4 +37,15 @@ public class PostLikeService {
         postWriter.increaseLikeCount(post);
     }
 
+    @Transactional
+    public void deletePostLike(Long userId, Long postId){
+        Post post = postReader.findById(postId);
+        User user = userReader.findById(userId);
+
+        PostLike postLike = postLikeReader.findByPostAnsUser(post, user);
+
+        postLikeWriter.delete(postLike);
+
+        postWriter.decreaseLikeCount(post);
+    }
 }

--- a/src/main/java/org/sopt/bofit/domain/post/service/PostLikeWriter.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/PostLikeWriter.java
@@ -20,4 +20,7 @@ public class PostLikeWriter {
         return postLike;
     }
 
+    public void delete(PostLike postLike){
+        postLikeRepository.delete(postLike);
+    }
 }

--- a/src/main/java/org/sopt/bofit/domain/post/service/PostWriter.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/PostWriter.java
@@ -58,8 +58,13 @@ public class PostWriter {
         commentRepository.findAllByPostIdAndStatus(postId, CommentStatus.ACTIVE).forEach(Comment::softDelete);
 
     }
-
+    @Transactional
     public void increaseLikeCount(Post post){
         postRepository.increaseLikeCount(post);
+    }
+
+    @Transactional
+    public void decreaseLikeCount(Post post){
+        postRepository.decreaseLikeCount(post);
     }
 }

--- a/src/main/java/org/sopt/bofit/global/config/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/org/sopt/bofit/global/config/swagger/SwaggerResponseDescription.java
@@ -13,6 +13,7 @@ import static org.sopt.bofit.global.exception.constant.OAuthErrorCode.KAKAO_USER
 import static org.sopt.bofit.global.exception.constant.PostErrorCode.POST_CONTENT_BLANK;
 import static org.sopt.bofit.global.exception.constant.PostErrorCode.POST_CONTENT_LONG;
 import static org.sopt.bofit.global.exception.constant.PostErrorCode.POST_LIKE_CREATE_CONFLICT;
+import static org.sopt.bofit.global.exception.constant.PostErrorCode.POST_LIKE_NOT_FOUND;
 import static org.sopt.bofit.global.exception.constant.PostErrorCode.POST_NOT_FOUND;
 import static org.sopt.bofit.global.exception.constant.PostErrorCode.POST_TITLE_BLANK;
 import static org.sopt.bofit.global.exception.constant.PostErrorCode.POST_TITLE_LONG;
@@ -94,6 +95,11 @@ public enum SwaggerResponseDescription {
         USER_NOT_FOUND,
         POST_NOT_FOUND,
         POST_LIKE_CREATE_CONFLICT
+    ))),
+    DELETE_POST_LIKE(new LinkedHashSet<>(Set.of(
+        USER_NOT_FOUND,
+        POST_NOT_FOUND,
+        POST_LIKE_NOT_FOUND
     )))
     ;
     private final Set<ErrorCode> errorCodeList;

--- a/src/main/java/org/sopt/bofit/global/exception/constant/PostErrorCode.java
+++ b/src/main/java/org/sopt/bofit/global/exception/constant/PostErrorCode.java
@@ -8,10 +8,11 @@ public enum PostErrorCode implements ErrorCode {
     POST_TITLE_BLANK(HttpStatus.BAD_REQUEST.value(), "제목은 비어있을 수 없습니다."),
     POST_CONTENT_BLANK(HttpStatus.BAD_REQUEST.value(), "본문은 비어있을 수 없습니다."),
     POST_TITLE_LONG(HttpStatus.BAD_REQUEST.value(), "제목은 30자 미만으로 입력해주세요."),
-    POST_CONTENT_LONG(HttpStatus.BAD_REQUEST.value(), "내용은 3000자 미만으로 작성해주세요"),
+    POST_CONTENT_LONG(HttpStatus.BAD_REQUEST.value(), "내용은 3000자 미만으로 작성해주세요."),
     POST_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "존재하지 않는 게시글입니다."),
     POST_UNAUTHORIZED(HttpStatus.FORBIDDEN.value(), "본인의 게시글만 수정/삭제할 수 있습니다."),
-    POST_LIKE_CREATE_CONFLICT(HttpStatus.CONFLICT.value(), "이미 좋아요를 누른 게시글입니다")
+    POST_LIKE_CREATE_CONFLICT(HttpStatus.CONFLICT.value(), "이미 좋아요를 누른 게시글입니다."),
+    POST_LIKE_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "해당 게시글의 좋아요를 찾을 수 없습니다.")
 
     ;
     private final int httpStatus;

--- a/src/test/java/org/sopt/bofit/domain/post/service/PostLikeServiceTest.java
+++ b/src/test/java/org/sopt/bofit/domain/post/service/PostLikeServiceTest.java
@@ -15,8 +15,10 @@ import org.sopt.bofit.domain.post.repository.PostRepository;
 import org.sopt.bofit.domain.user.entity.User;
 import org.sopt.bofit.domain.user.entity.constant.LoginProvider;
 import org.sopt.bofit.domain.user.repository.UserRepository;
+import org.sopt.bofit.global.exception.constant.ErrorCode;
 import org.sopt.bofit.global.exception.constant.PostErrorCode;
 import org.sopt.bofit.global.exception.customexception.ConflictException;
+import org.sopt.bofit.global.exception.customexception.CustomException;
 import org.sopt.bofit.global.exception.customexception.NotFoundException;
 import org.sopt.bofit.support.IntegrationTestSupport;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -41,6 +43,17 @@ class PostLikeServiceTest extends IntegrationTestSupport {
         postRepository.deleteAllInBatch();
         userRepository.deleteAllInBatch();
     }
+
+    private <T extends CustomException> void assertExceptionAndErrorCode(
+        Runnable action,
+        ErrorCode errorCode,
+        Class<T> customException)
+    {
+        assertThatThrownBy(action::run)
+            .isInstanceOf(customException)
+            .satisfies(e -> assertThat(((T)e).getErrorCode()).isEqualTo(errorCode));
+    }
+
 
     @DisplayName("게시글 좋아요가 정상적으로 생성됨")
     @Test
@@ -85,12 +98,10 @@ class PostLikeServiceTest extends IntegrationTestSupport {
         postLikeRepository.save(postLike);
 
         // when // then
-        assertThatThrownBy(() -> postLikeService.createPostLike(user.getId(), post.getId()))
-            .isInstanceOf(ConflictException.class)
-            .satisfies(e -> {
-                ConflictException exception = (ConflictException) e;
-                assertThat(exception.getErrorCode()).isEqualTo(PostErrorCode.POST_LIKE_CREATE_CONFLICT);
-            });
+        assertExceptionAndErrorCode(
+            ()-> postLikeService.createPostLike(user.getId(), post.getId()),
+            PostErrorCode.POST_LIKE_CREATE_CONFLICT,
+            ConflictException.class);
     }
 
     @DisplayName("게시글 좋아요가 정상적으로 삭제됨")
@@ -137,12 +148,10 @@ class PostLikeServiceTest extends IntegrationTestSupport {
         postRepository.save(post);
 
         // when // then
-        assertThatThrownBy(() -> postLikeService.deletePostLike(user.getId(), post.getId()))
-            .isInstanceOf(NotFoundException.class)
-            .satisfies(e -> {
-                NotFoundException exception = (NotFoundException) e;
-                assertThat(exception.getErrorCode()).isEqualTo(PostErrorCode.POST_LIKE_NOT_FOUND);
-            });
+        assertExceptionAndErrorCode(
+            () -> postLikeService.deletePostLike(user.getId(), post.getId()),
+            PostErrorCode.POST_LIKE_NOT_FOUND,
+            NotFoundException.class);
     }
 
 }

--- a/src/test/java/org/sopt/bofit/domain/post/service/PostLikeServiceTest.java
+++ b/src/test/java/org/sopt/bofit/domain/post/service/PostLikeServiceTest.java
@@ -1,0 +1,148 @@
+package org.sopt.bofit.domain.post.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.sopt.bofit.domain.post.entity.Post;
+import org.sopt.bofit.domain.post.entity.PostLike;
+import org.sopt.bofit.domain.post.repository.PostLikeRepository;
+import org.sopt.bofit.domain.post.repository.PostRepository;
+import org.sopt.bofit.domain.user.entity.User;
+import org.sopt.bofit.domain.user.entity.constant.LoginProvider;
+import org.sopt.bofit.domain.user.repository.UserRepository;
+import org.sopt.bofit.global.exception.constant.PostErrorCode;
+import org.sopt.bofit.global.exception.customexception.ConflictException;
+import org.sopt.bofit.global.exception.customexception.NotFoundException;
+import org.sopt.bofit.support.IntegrationTestSupport;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class PostLikeServiceTest extends IntegrationTestSupport {
+
+    @Autowired
+    private PostLikeService postLikeService;
+
+    @Autowired
+    private PostRepository postRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PostLikeRepository postLikeRepository;
+
+    @AfterEach
+    void clearInAfterTest(){
+        postLikeRepository.deleteAllInBatch();
+        postRepository.deleteAllInBatch();
+        userRepository.deleteAllInBatch();
+    }
+
+    @DisplayName("게시글 좋아요가 정상적으로 생성됨")
+    @Test
+    void createPostLike(){
+        // given
+        User user = User.builder()
+            .name("유저1")
+            .loginProvider(LoginProvider.KAKAO)
+            .oauthId("0123456")
+            .build();
+        userRepository.save(user);
+
+        Post post = Post.create(user, "testTitle", "testComment");
+        postRepository.save(post);
+
+        assertThat(post.getLikeCount()).isEqualTo(0);
+
+        // when
+        postLikeService.createPostLike(user.getId(), post.getId());
+
+        // then
+        Post updatedPost = postRepository.findById(post.getId()).get();
+        assertThat(updatedPost.getLikeCount()).isEqualTo(1);
+        assertTrue(postLikeRepository.existsByPostAndUser(post, user));
+    }
+
+    @DisplayName("게시글 좋아요가 이미 존재하는 경우 예외가 발생함")
+    @Test
+    void createPostLikeConflict(){
+        // given
+        User user = User.builder()
+            .name("유저1")
+            .loginProvider(LoginProvider.KAKAO)
+            .oauthId("0123456")
+            .build();
+        userRepository.save(user);
+
+        Post post = Post.create(user, "testTitle", "testComment");
+        postRepository.save(post);
+
+        PostLike postLike = PostLike.create(post, user);
+        postLikeRepository.save(postLike);
+
+        // when // then
+        assertThatThrownBy(() -> postLikeService.createPostLike(user.getId(), post.getId()))
+            .isInstanceOf(ConflictException.class)
+            .satisfies(e -> {
+                ConflictException exception = (ConflictException) e;
+                assertThat(exception.getErrorCode()).isEqualTo(PostErrorCode.POST_LIKE_CREATE_CONFLICT);
+            });
+    }
+
+    @DisplayName("게시글 좋아요가 정상적으로 삭제됨")
+    @Test
+    void deletePostLike(){
+        // given
+        User user = User.builder()
+            .name("유저1")
+            .loginProvider(LoginProvider.KAKAO)
+            .oauthId("0123456")
+            .build();
+        userRepository.save(user);
+
+        Post post = Post.create(user, "testTitle", "testComment");
+        postRepository.save(post);
+
+        postLikeService.createPostLike(user.getId(), post.getId());
+
+        Post updatedPost = postRepository.findById(post.getId()).get();
+
+        assertThat(updatedPost.getLikeCount()).isEqualTo(1);
+
+        // when
+        postLikeService.deletePostLike(user.getId(), post.getId());
+
+        // then
+        updatedPost = postRepository.findById(post.getId()).get();
+        assertThat(updatedPost.getLikeCount()).isEqualTo(0);
+        assertFalse(postLikeRepository.existsByPostAndUser(post, user));
+    }
+
+    @DisplayName("게시글에 좋아요가 존재하지 않는 상태에서 삭제 요청을 보내는 경우 예외가 발생함")
+    @Test
+    void deletePostLikeConflict(){
+        // given
+        User user = User.builder()
+            .name("유저1")
+            .loginProvider(LoginProvider.KAKAO)
+            .oauthId("0123456")
+            .build();
+        userRepository.save(user);
+
+        Post post = Post.create(user, "testTitle", "testComment");
+        postRepository.save(post);
+
+        // when // then
+        assertThatThrownBy(() -> postLikeService.deletePostLike(user.getId(), post.getId()))
+            .isInstanceOf(NotFoundException.class)
+            .satisfies(e -> {
+                NotFoundException exception = (NotFoundException) e;
+                assertThat(exception.getErrorCode()).isEqualTo(PostErrorCode.POST_LIKE_NOT_FOUND);
+            });
+    }
+
+}


### PR DESCRIPTION
## Related issue 🛠
- closed #128 


## Work Description 📝
- 좋아요 수의 경우 생성과 마찬가지로 증분 쿼리를 통해 관리함
- 좋아요가 존재하지 않을 경우 NotFound 예외 처리
- PostLike 생성, 삭제 관련 테스트 작성
  - 시간 날 때 Test 관련 Fixture 작성하도록 리팩토링 할 예정

## Uncompleted Tasks 😅

## To Reviewers 📢
