### PR TITLE
[Feat] 로그아웃 기능 구현

### DIFF
--- a/src/main/java/org/sopt/bofit/global/config/properties/KakaoProperties.java
+++ b/src/main/java/org/sopt/bofit/global/config/properties/KakaoProperties.java
@@ -8,5 +8,6 @@ public record KakaoProperties(
         String clientId,
         String tokenUri,
         String redirectUri,
-        String userInfoUri
+        String userInfoUri,
+        String logoutUri
 ) { }

--- a/src/main/java/org/sopt/bofit/global/oauth/controller/OAuthController.java
+++ b/src/main/java/org/sopt/bofit/global/oauth/controller/OAuthController.java
@@ -1,28 +1,24 @@
 package org.sopt.bofit.global.oauth.controller;
 
-import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.*;
-import static org.sopt.bofit.global.constant.SwaggerConstant.*;
-
-import java.util.Optional;
-
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
 import org.sopt.bofit.global.annotation.CustomExceptionDescription;
+import org.sopt.bofit.global.annotation.LoginUserId;
 import org.sopt.bofit.global.dto.response.BaseResponse;
 import org.sopt.bofit.global.oauth.dto.request.OAuthLoginRequest;
 import org.sopt.bofit.global.oauth.dto.response.KaKaoLoginResponse;
 import org.sopt.bofit.global.oauth.dto.response.TokenReissueResponse;
 import org.sopt.bofit.global.oauth.service.OAuthService;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.tags.Tag;
-import lombok.RequiredArgsConstructor;
+import java.util.Optional;
+
+import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.KAKAO_TOKEN_REQUEST;
+import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.TOKEN_REISSUE;
+import static org.sopt.bofit.global.constant.SwaggerConstant.TAG_DESCRIPTION_KAKAO_LOGIN;
+import static org.sopt.bofit.global.constant.SwaggerConstant.TAG_NAME_KAKAO_LOGIN;
 
 @RestController
 @RequiredArgsConstructor
@@ -57,5 +53,14 @@ public class OAuthController {
     public BaseResponse<TokenReissueResponse> reissue(@Parameter(hidden = true) @RequestHeader("Authorization") String refreshToken) {
         return BaseResponse.ok(oAuthService.reissue(refreshToken), "토큰 재발급 성공");
     }
+    @Tag(name = TAG_NAME_KAKAO_LOGIN, description = TAG_DESCRIPTION_KAKAO_LOGIN)
+    @Operation(summary = "로그아웃")
+    @PostMapping("/kakao/logout")
+    public BaseResponse<String> logout(
+           @LoginUserId @Parameter(hidden = true) Long userId,
+           @RequestParam(value = "redirect-url", required = false) String redirectUrl){
+        return BaseResponse.ok(oAuthService.logout(userId, redirectUrl), "카카오 로그아웃 성공, 반환된 URL로 리다이렉트 시켜주세요");
+    }
+
 
 }

--- a/src/main/java/org/sopt/bofit/global/oauth/service/OAuthService.java
+++ b/src/main/java/org/sopt/bofit/global/oauth/service/OAuthService.java
@@ -1,13 +1,7 @@
 package org.sopt.bofit.global.oauth.service;
 
-import static org.sopt.bofit.global.exception.constant.GlobalErrorCode.*;
-import static org.sopt.bofit.global.exception.constant.OAuthErrorCode.*;
-import static org.sopt.bofit.global.oauth.dto.response.KakaoUserResponse.*;
-import static org.sopt.bofit.global.oauth.dto.response.KakaoUserResponse.KakaoAccount.*;
-
-import java.nio.charset.StandardCharsets;
-import java.util.Optional;
-
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.sopt.bofit.domain.user.entity.User;
 import org.sopt.bofit.domain.user.entity.constant.LoginProvider;
 import org.sopt.bofit.domain.user.repository.UserRepository;
@@ -30,8 +24,13 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestClient;
 
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+
+import static org.sopt.bofit.global.exception.constant.GlobalErrorCode.JWT_INVALID;
+import static org.sopt.bofit.global.exception.constant.OAuthErrorCode.*;
+import static org.sopt.bofit.global.oauth.dto.response.KakaoUserResponse.KakaoAccount;
+import static org.sopt.bofit.global.oauth.dto.response.KakaoUserResponse.KakaoAccount.UserProfile;
 
 @Slf4j
 @Service
@@ -153,6 +152,14 @@ public class OAuthService {
         refreshTokenRepository.save(savedToken);
 
         return TokenReissueResponse.of(newAccessToken, newRefreshToken);
+    }
+
+    @Transactional
+    public String logout(Long userId, String redirectUri) {
+        refreshTokenRepository.findByUserId(userId)
+                .ifPresent(refreshTokenRepository::delete);
+
+        return OAuthUtil.buildKakaoLogoutRedirectUrl(properties.logoutUri(), properties.clientId(), redirectUri).toString();
     }
 }
 

--- a/src/main/java/org/sopt/bofit/global/oauth/util/OAuthUtil.java
+++ b/src/main/java/org/sopt/bofit/global/oauth/util/OAuthUtil.java
@@ -1,6 +1,10 @@
 package org.sopt.bofit.global.oauth.util;
 
 
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+
 public class OAuthUtil {
 
     public static String buildTokenRequestBody(String code, String clientId, String redirectUri) {
@@ -8,5 +12,14 @@ public class OAuthUtil {
                + "&client_id=" + clientId
                + "&redirect_uri=" + redirectUri
                + "&code=" + code;
+    }
+
+    public static URI buildKakaoLogoutRedirectUrl(String logoutBaseUri, String clientId, String logoutRedirectUri) {
+        return UriComponentsBuilder
+                .fromHttpUrl(logoutBaseUri)
+                .queryParam("client_id", clientId)
+                .queryParam("logout_redirect_uri", logoutRedirectUri)
+                .build(true)
+                .toUri();
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -42,6 +42,7 @@ kakao:
   authorization-uri: https://kauth.kakao.com/oauth/authorize
   token-uri: https://kauth.kakao.com/oauth/token
   user-info-uri: https://kapi.kakao.com/v2/user/me
+  logout-uri: https://kauth.kakao.com/oauth/logout
 jwt:
   secret: ${JWT_SECRET}
   accessTokenExpiration: ${ACCESS_EXPIRED_AT}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -58,3 +58,4 @@ cloud:
       bucket: bofit-bucket
     stack:
       auto: false
+  logout-uri: https://kauth.kakao.com/oauth/logout


### PR DESCRIPTION
## Related issue 🛠
- closed #131
  

## Work Description 📝
- 로그아웃 기능을 구현하였습니다.
- 로그아웃은 카카오 디벨로퍼스 공식 문서에 기재되어 있는 '카카오 계정과 함께 로그아웃하기' 방식으로 구현했습니다.
로그아웃 요청이 오면 서비스에서 로그아웃 처리를 하고 카카오 로그아웃 Redirect URI를 반환하면 클라이언트에서 이 URI로 리다이렉트하여 카카오 로그아웃을 마칩니다.
- 로그인과 마찬가지로 Redirect URI를 파라미터로 받아 동적으로 처리할 수 있도록 구현하였습니다.
- 리다이렉트를 하게 되면 다음과 같은 화면이 나타나고, 파라미터에 서비스 메인 화면 주소를 입력하였기 때문에 메인 화면으로 이동하게 됩니다.
<img width="630" height="685" alt="스크린샷 2025-09-04 오후 9 22 57" src="https://github.com/user-attachments/assets/90cbc1eb-5c80-45e3-b372-48d1bd705b5c" />
<img width="432" height="828" alt="스크린샷 2025-09-04 오후 9 23 37" src="https://github.com/user-attachments/assets/0d9d7463-f4e4-4395-97f4-a2e99436024f" />


## To Reviewers 📢
- 현재 서비스 로그아웃 처리에서는 Refresh Token만 무효화하도록 설정했는데, 액세스 토큰 무효화까지 해야한다고 보시나요?