### PR TITLE
[Feat] 게시물 생성/ 수정 시 이미지 업로드 기능 구현

### DIFF
--- a/src/main/java/org/sopt/bofit/domain/post/controller/PostController.java
+++ b/src/main/java/org/sopt/bofit/domain/post/controller/PostController.java
@@ -1,23 +1,9 @@
 package org.sopt.bofit.domain.post.controller;
 
-import static org.sopt.bofit.domain.comment.constant.CommentConstant.COMMENTS_DEFAULT_SIZE;
-import static org.sopt.bofit.domain.post.constant.PostConstant.POSTS_DEFAULT_SIZE;
-import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.CREATE_COMMENT;
-import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.CREATE_POST;
-import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.CREATE_POST_LIKE;
-import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.DELETE_COMMENT;
-import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.DELETE_POST;
-import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.DELETE_POST_LIKE;
-import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.POST_DETAIL;
-import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.UPDATE_POST;
-import static org.sopt.bofit.global.constant.SwaggerConstant.TAG_DESCRIPTION_COMMUNITY;
-import static org.sopt.bofit.global.constant.SwaggerConstant.TAG_NAME_COMMUNITY;
-
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.sopt.bofit.domain.comment.dto.request.CommentCreateRequest;
 import org.sopt.bofit.domain.comment.dto.response.CommentResponse;
@@ -32,15 +18,15 @@ import org.sopt.bofit.global.annotation.CustomExceptionDescription;
 import org.sopt.bofit.global.annotation.LoginUserId;
 import org.sopt.bofit.global.dto.response.BaseResponse;
 import org.sopt.bofit.global.dto.response.SliceResponse;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Optional;
+
+import static org.sopt.bofit.domain.comment.constant.CommentConstant.COMMENTS_DEFAULT_SIZE;
+import static org.sopt.bofit.domain.post.constant.PostConstant.POSTS_DEFAULT_SIZE;
+import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.*;
+import static org.sopt.bofit.global.constant.SwaggerConstant.TAG_DESCRIPTION_COMMUNITY;
+import static org.sopt.bofit.global.constant.SwaggerConstant.TAG_NAME_COMMUNITY;
 
 @RestController
 @RequiredArgsConstructor
@@ -59,7 +45,7 @@ public class PostController {
             @RequestBody @Valid PostCreateRequest request,
             @Parameter(hidden = true) @LoginUserId Long userId
     ){
-        return BaseResponse.create(postService.createPost(userId, request.title(), request.content()),"게시물 생성 완료");
+        return BaseResponse.create(postService.createPost(userId, request.title(), request.content(), request.imageUrls()),"게시물 생성 완료");
     }
 
     @Tag(name = TAG_NAME_COMMUNITY, description = TAG_DESCRIPTION_COMMUNITY)

--- a/src/main/java/org/sopt/bofit/domain/post/controller/PostController.java
+++ b/src/main/java/org/sopt/bofit/domain/post/controller/PostController.java
@@ -9,6 +9,7 @@ import org.sopt.bofit.domain.comment.dto.request.CommentCreateRequest;
 import org.sopt.bofit.domain.comment.dto.response.CommentResponse;
 import org.sopt.bofit.domain.comment.service.CommentService;
 import org.sopt.bofit.domain.post.dto.request.PostCreateRequest;
+import org.sopt.bofit.domain.post.dto.request.PostUpdateRequest;
 import org.sopt.bofit.domain.post.dto.response.PostCreateResponse;
 import org.sopt.bofit.domain.post.dto.response.PostDetailResponse;
 import org.sopt.bofit.domain.post.dto.response.PostSummaryResponse;
@@ -53,11 +54,12 @@ public class PostController {
     @CustomExceptionDescription(UPDATE_POST)
     @PutMapping("{post-id}")
     public BaseResponse<PostCreateResponse> updatePost(
-            @RequestBody @Valid PostCreateRequest request,
+            @RequestBody @Valid PostUpdateRequest request,
             @Parameter(hidden = true) @LoginUserId Long userId,
             @PathVariable(name = "post-id") Long postId
     ){
-        return BaseResponse.ok(postService.updatePost(userId,postId,request.title(), request.content()),"게시물 수정 완료");
+        return BaseResponse.ok(postService.updatePost(userId, postId, request.newTitle(), request.newContent(), request.newImages(),
+                request.updateImages(), request.deleteImageIds()),"게시물 수정 완료");
     }
 
     @Tag(name = TAG_NAME_COMMUNITY, description = TAG_DESCRIPTION_COMMUNITY)

--- a/src/main/java/org/sopt/bofit/domain/post/dto/request/NewImageRequest.java
+++ b/src/main/java/org/sopt/bofit/domain/post/dto/request/NewImageRequest.java
@@ -1,0 +1,16 @@
+package org.sopt.bofit.domain.post.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
+
+public record NewImageRequest(
+        @Schema(description = "이미지 URL")
+        @NotBlank
+        String imageUrl,
+
+        @Schema(description = "순서 (null이면 맨 뒤에 추가)", example = "3")
+        @Positive
+        Integer sequence
+) {
+}

--- a/src/main/java/org/sopt/bofit/domain/post/dto/request/NewImageRequest.java
+++ b/src/main/java/org/sopt/bofit/domain/post/dto/request/NewImageRequest.java
@@ -9,7 +9,7 @@ public record NewImageRequest(
         @NotBlank
         String imageUrl,
 
-        @Schema(description = "순서 (null이면 맨 뒤에 추가)", example = "3")
+        @Schema(description = "순서 (null이면 맨 뒤에 추가, 1부터 시작)", example = "3")
         @Positive
         Integer sequence
 ) {

--- a/src/main/java/org/sopt/bofit/domain/post/dto/request/PostCreateRequest.java
+++ b/src/main/java/org/sopt/bofit/domain/post/dto/request/PostCreateRequest.java
@@ -10,7 +10,7 @@ import java.util.List;
 public record PostCreateRequest(
         @Schema(description = "글 제목", example = "아니")
         @NotBlank(message = "제목은 비어있을 수 없습니다.")
-        @Length(max = PostInfoConstant.MAX_TITLE_LENGTH)
+        @Length(max = PostInfoConstant.MAX_TITLE_LENGTH, message = "제목은 {max}자 미만으로 작성해주세요.")
         String title,
 
         @Schema(description = "내용", example = "저희 대상타면 어떡하나요 ㅈㅉ로?")

--- a/src/main/java/org/sopt/bofit/domain/post/dto/request/PostCreateRequest.java
+++ b/src/main/java/org/sopt/bofit/domain/post/dto/request/PostCreateRequest.java
@@ -5,6 +5,8 @@ import jakarta.validation.constraints.NotBlank;
 import org.hibernate.validator.constraints.Length;
 import org.sopt.bofit.domain.post.entity.constant.PostInfoConstant;
 
+import java.util.List;
+
 public record PostCreateRequest(
         @Schema(description = "글 제목", example = "아니")
         @NotBlank(message = "제목은 비어있을 수 없습니다.")
@@ -14,6 +16,10 @@ public record PostCreateRequest(
         @Schema(description = "내용", example = "저희 대상타면 어떡하나요 ㅈㅉ로?")
         @NotBlank(message = "본문은 비어있을 수 없습니다.")
         @Length(max = PostInfoConstant.MAX_CONTENT_LENGTH, message = "내용은 {max}자 미만으로 작성해주세요.")
-        String content
+        String content,
+
+        @Schema(description = "이미지 url")
+        List<String> imageUrls
 ) {
+
 }

--- a/src/main/java/org/sopt/bofit/domain/post/dto/request/PostUpdateRequest.java
+++ b/src/main/java/org/sopt/bofit/domain/post/dto/request/PostUpdateRequest.java
@@ -1,0 +1,36 @@
+package org.sopt.bofit.domain.post.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import org.hibernate.validator.constraints.Length;
+import org.sopt.bofit.domain.post.entity.constant.PostInfoConstant;
+
+import java.util.List;
+
+public record PostUpdateRequest(
+        @Schema(description = "제목", example = "ㅇㅇ")
+        @NotBlank(message = "제목은 비어있을 수 없습니다.")
+        @Length(max = PostInfoConstant.MAX_TITLE_LENGTH, message = "제목은 {max}자 미만으로 작성해주세요.")
+        String newTitle,
+
+        @Schema(description = "내용", example = "ㅇㅇㅇ")
+        @NotBlank(message = "본문은 비어있을 수 없습니다.")
+        @Length(max = PostInfoConstant.MAX_CONTENT_LENGTH, message = "내용은 {max}자 미만으로 작성해주세요.")
+        String newContent,
+
+        @Schema(description = "추가할 이미지 목록")
+        @Valid
+        List<NewImageRequest> newImages,
+
+        @Schema(description = "수정할 이미지 목록")
+        @Valid
+        List<UpdateImageRequest> updateImages,
+
+        @Schema(description = "삭제할 이미지 ID 목록")
+        @Valid
+        List<@NotNull Long> deleteImageIds
+
+) {
+}

--- a/src/main/java/org/sopt/bofit/domain/post/dto/request/UpdateImageRequest.java
+++ b/src/main/java/org/sopt/bofit/domain/post/dto/request/UpdateImageRequest.java
@@ -1,0 +1,19 @@
+package org.sopt.bofit.domain.post.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+public record UpdateImageRequest(
+        @Schema(description = "수정할 이미지 ID")
+        @NotNull
+        Long id,
+
+        @Schema(description = "새 이미지 URL (변경 없으면 null)")
+        String newImageUrl,
+
+        @Schema(description = "새 순서")
+        @Positive
+        Integer newSequence
+) {
+}

--- a/src/main/java/org/sopt/bofit/domain/post/dto/request/UpdateImageRequest.java
+++ b/src/main/java/org/sopt/bofit/domain/post/dto/request/UpdateImageRequest.java
@@ -12,7 +12,7 @@ public record UpdateImageRequest(
         @Schema(description = "새 이미지 URL (변경 없으면 null)")
         String newImageUrl,
 
-        @Schema(description = "새 순서")
+        @Schema(description = "새 순서, 1부터 시작")
         @Positive
         Integer newSequence
 ) {

--- a/src/main/java/org/sopt/bofit/domain/post/entity/Post.java
+++ b/src/main/java/org/sopt/bofit/domain/post/entity/Post.java
@@ -1,25 +1,12 @@
 package org.sopt.bofit.domain.post.entity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import java.util.Objects;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import jakarta.persistence.*;
+import lombok.*;
 import org.sopt.bofit.domain.post.entity.constant.PostStatus;
 import org.sopt.bofit.domain.user.entity.User;
 import org.sopt.bofit.global.entity.BaseEntity;
+
+import java.util.Objects;
 
 @Entity
 @Getter
@@ -62,7 +49,7 @@ public class Post extends BaseEntity {
                 .build();
     }
 
-    public void updatePost(String title, String content){
+    public void updateTitleAndContent(String title, String content){
         this.title = title;
         this.content = content;
     }

--- a/src/main/java/org/sopt/bofit/domain/post/entity/PostImage.java
+++ b/src/main/java/org/sopt/bofit/domain/post/entity/PostImage.java
@@ -31,4 +31,12 @@ public class PostImage {
                 .sequence(sequence)
                 .build();
     }
+
+    public void updateImageUrl(String imageUrl){
+        this.imageUrl = imageUrl;
+    }
+
+    public void updateSequence(int sequence){
+        this.sequence = sequence;
+    }
 }

--- a/src/main/java/org/sopt/bofit/domain/post/entity/PostImage.java
+++ b/src/main/java/org/sopt/bofit/domain/post/entity/PostImage.java
@@ -1,0 +1,34 @@
+package org.sopt.bofit.domain.post.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class PostImage {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "post_image_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String imageUrl;
+
+    @Column(nullable = false)
+    private int sequence;
+
+    public static PostImage create(String imageUrl, Post post, int sequence){
+        return PostImage.builder()
+                .imageUrl(imageUrl)
+                .post(post)
+                .sequence(sequence)
+                .build();
+    }
+}

--- a/src/main/java/org/sopt/bofit/domain/post/repository/PostImageRepository.java
+++ b/src/main/java/org/sopt/bofit/domain/post/repository/PostImageRepository.java
@@ -1,0 +1,7 @@
+package org.sopt.bofit.domain.post.repository;
+
+import org.sopt.bofit.domain.post.entity.PostImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostImageRepository extends JpaRepository<PostImage, Long> {
+}

--- a/src/main/java/org/sopt/bofit/domain/post/repository/PostImageRepository.java
+++ b/src/main/java/org/sopt/bofit/domain/post/repository/PostImageRepository.java
@@ -2,6 +2,18 @@ package org.sopt.bofit.domain.post.repository;
 
 import org.sopt.bofit.domain.post.entity.PostImage;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface PostImageRepository extends JpaRepository<PostImage, Long> {
+    List<PostImage> findByPostIdOrderBySequenceAsc(Long postId);
+
+    @Modifying
+    @Query("delete from PostImage pi where pi.post.id = :postId and pi.id in :ids")
+    void deleteAllByPostIdAndIdIn(@Param("postId") Long postId, @Param("ids") List<Long> ids);
+
+    boolean existsByIdAndPostId(Long id, Long postId);
 }

--- a/src/main/java/org/sopt/bofit/domain/post/service/PostService.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/PostService.java
@@ -8,6 +8,8 @@ import org.sopt.bofit.global.dto.response.SliceResponse;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class PostService {
@@ -16,8 +18,8 @@ public class PostService {
 
     private final PostWriter postWriter;
 
-    public PostCreateResponse createPost(Long userId, String title, String content) {
-        return postWriter.createPost(userId, title, content);
+    public PostCreateResponse createPost(Long userId, String title, String content, List<String> imageUrls) {
+        return postWriter.createPost(userId, title, content, imageUrls);
     }
 
     @Transactional

--- a/src/main/java/org/sopt/bofit/domain/post/service/PostService.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/PostService.java
@@ -1,6 +1,8 @@
 package org.sopt.bofit.domain.post.service;
 
 import lombok.RequiredArgsConstructor;
+import org.sopt.bofit.domain.post.dto.request.NewImageRequest;
+import org.sopt.bofit.domain.post.dto.request.UpdateImageRequest;
 import org.sopt.bofit.domain.post.dto.response.PostCreateResponse;
 import org.sopt.bofit.domain.post.dto.response.PostDetailResponse;
 import org.sopt.bofit.domain.post.dto.response.PostSummaryResponse;
@@ -23,8 +25,10 @@ public class PostService {
     }
 
     @Transactional
-    public PostCreateResponse updatePost (Long userId, Long postId, String title, String content) {
-        return postWriter.updatePost(userId, postId, title, content);
+    public PostCreateResponse updatePost (Long userId, Long postId, String title, String content,
+                                          List<NewImageRequest> newImages, List<UpdateImageRequest> updateImages,
+                                          List<Long> deleteImageIds) {
+        return postWriter.updatePost(userId, postId, title, content, newImages, updateImages, deleteImageIds);
     }
 
     @Transactional

--- a/src/main/java/org/sopt/bofit/domain/post/service/PostWriter.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/PostWriter.java
@@ -4,6 +4,8 @@ import lombok.RequiredArgsConstructor;
 import org.sopt.bofit.domain.comment.entity.Comment;
 import org.sopt.bofit.domain.comment.entity.CommentStatus;
 import org.sopt.bofit.domain.comment.repository.CommentRepository;
+import org.sopt.bofit.domain.post.dto.request.NewImageRequest;
+import org.sopt.bofit.domain.post.dto.request.UpdateImageRequest;
 import org.sopt.bofit.domain.post.dto.response.PostCreateResponse;
 import org.sopt.bofit.domain.post.entity.Post;
 import org.sopt.bofit.domain.post.entity.PostImage;
@@ -11,12 +13,16 @@ import org.sopt.bofit.domain.post.repository.PostImageRepository;
 import org.sopt.bofit.domain.post.repository.PostRepository;
 import org.sopt.bofit.domain.user.entity.User;
 import org.sopt.bofit.domain.user.service.UserReader;
+import org.sopt.bofit.global.exception.customexception.BadRequestException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
+import static org.sopt.bofit.global.exception.constant.PostErrorCode.POST_IMAGE_MISMATCH;
 import static org.sopt.bofit.global.exception.constant.PostErrorCode.POST_UNAUTHORIZED;
 
 @Service
@@ -55,14 +61,84 @@ public class PostWriter {
     }
 
     @Transactional
-    public PostCreateResponse updatePost (Long userId, Long postId, String title, String content) {
+    public PostCreateResponse updatePost (Long userId, Long postId, String newTitle, String newContent,
+                                          List<NewImageRequest> newImages, List<UpdateImageRequest> updateImages,
+                                          List<Long> deleteImageIds) {
         User user = userReader.findById(userId);
         Post post = postReader.findById(postId);
 
         post.getUser().checkIsWriter(userId, POST_UNAUTHORIZED);
-        post.updatePost(title, content);
+        post.updateTitleAndContent(newTitle, newContent);
+
+        List<PostImage> currentImages = postImageRepository.findByPostIdOrderBySequenceAsc(postId);
+
+        if(deleteImageIds != null && !deleteImageIds.isEmpty()) {
+            for(Long imageId : deleteImageIds) {
+                if(currentImages.stream().noneMatch(image -> image.getId().equals(imageId))) {
+                    throw new BadRequestException(POST_IMAGE_MISMATCH);
+                }
+            }
+            postImageRepository.deleteAllByPostIdAndIdIn(postId, deleteImageIds);
+            currentImages.removeIf(image -> deleteImageIds.contains(image.getId()));
+        }
+
+        if (updateImages != null && !updateImages.isEmpty()) {
+            Map<Long, Integer> indexById = new HashMap<>();
+            for (int i = 0; i < currentImages.size(); i++) {
+                indexById.put(currentImages.get(i).getId(), i);
+            }
+
+            for (UpdateImageRequest req : updateImages) {
+                Integer from = indexById.get(req.id());
+                if (from == null) throw new BadRequestException(POST_IMAGE_MISMATCH);
+
+                PostImage img = currentImages.get(from);
+
+                if (req.newImageUrl() != null && !req.newImageUrl().isBlank()) {
+                    img.updateImageUrl(req.newImageUrl());
+                }
+
+                if (req.newSequence() != null) {
+                    int to = Math.max(0, Math.min(req.newSequence() - 1, currentImages.size() - 1));
+                    move(currentImages, from, to);
+
+                    indexById.clear();
+                    for (int i = 0; i < currentImages.size(); i++) {
+                        indexById.put(currentImages.get(i).getId(), i);
+                    }
+                }
+            }
+        }
+
+        if(newImages != null){
+            for(NewImageRequest req : newImages) {
+                int sequence = req.sequence() == null ? (currentImages.size() + 1) : req.sequence();
+
+                if(sequence < 1) sequence = 1;
+                if(sequence > currentImages.size() + 1) sequence = currentImages.size() + 1;
+
+                PostImage created = PostImage.create(req.imageUrl(), post, sequence);
+                postImageRepository.save(created);
+
+                currentImages.add(sequence -1 ,created);
+            }
+        }
+
+        int seq = 1;
+        for(PostImage pi : currentImages) {
+            if(pi.getSequence() != seq){
+                pi.updateSequence(seq);
+            }
+            seq++;
+        }
 
         return PostCreateResponse.from(post.getId());
+    }
+
+    private static <T> void move(List<T> list, int fromIdx, int toIdx) {
+        if (fromIdx == toIdx) return;
+        T e = list.remove(fromIdx);
+        list.add(toIdx, e);
     }
 
     @Transactional

--- a/src/main/java/org/sopt/bofit/domain/post/service/PostWriter.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/PostWriter.java
@@ -72,16 +72,40 @@ public class PostWriter {
 
         List<PostImage> currentImages = postImageRepository.findByPostIdOrderBySequenceAsc(postId);
 
-        if(deleteImageIds != null && !deleteImageIds.isEmpty()) {
-            for(Long imageId : deleteImageIds) {
-                if(currentImages.stream().noneMatch(image -> image.getId().equals(imageId))) {
-                    throw new BadRequestException(POST_IMAGE_MISMATCH);
-                }
+        deleteImages(postId, deleteImageIds, currentImages);
+
+        updateImages(updateImages, currentImages);
+
+        addImages(newImages, currentImages, post);
+
+        int seq = 1;
+        for(PostImage pi : currentImages) {
+            if(pi.getSequence() != seq){
+                pi.updateSequence(seq);
             }
-            postImageRepository.deleteAllByPostIdAndIdIn(postId, deleteImageIds);
-            currentImages.removeIf(image -> deleteImageIds.contains(image.getId()));
+            seq++;
         }
 
+        return PostCreateResponse.from(post.getId());
+    }
+
+    private void addImages(List<NewImageRequest> newImages, List<PostImage> currentImages, Post post) {
+        if(newImages != null){
+            for(NewImageRequest req : newImages) {
+                int sequence = req.sequence() == null ? (currentImages.size() + 1) : req.sequence();
+
+                if(sequence < 1) sequence = 1;
+                if(sequence > currentImages.size() + 1) sequence = currentImages.size() + 1;
+
+                PostImage created = PostImage.create(req.imageUrl(), post, sequence);
+                postImageRepository.save(created);
+
+                currentImages.add(sequence - 1 ,created);
+            }
+        }
+    }
+
+    private void updateImages(List<UpdateImageRequest> updateImages, List<PostImage> currentImages) {
         if (updateImages != null && !updateImages.isEmpty()) {
             Map<Long, Integer> indexById = new HashMap<>();
             for (int i = 0; i < currentImages.size(); i++) {
@@ -100,7 +124,7 @@ public class PostWriter {
 
                 if (req.newSequence() != null) {
                     int to = Math.max(0, Math.min(req.newSequence() - 1, currentImages.size() - 1));
-                    move(currentImages, from, to);
+                    moveSequence(currentImages, from, to);
 
                     indexById.clear();
                     for (int i = 0; i < currentImages.size(); i++) {
@@ -109,33 +133,21 @@ public class PostWriter {
                 }
             }
         }
-
-        if(newImages != null){
-            for(NewImageRequest req : newImages) {
-                int sequence = req.sequence() == null ? (currentImages.size() + 1) : req.sequence();
-
-                if(sequence < 1) sequence = 1;
-                if(sequence > currentImages.size() + 1) sequence = currentImages.size() + 1;
-
-                PostImage created = PostImage.create(req.imageUrl(), post, sequence);
-                postImageRepository.save(created);
-
-                currentImages.add(sequence -1 ,created);
-            }
-        }
-
-        int seq = 1;
-        for(PostImage pi : currentImages) {
-            if(pi.getSequence() != seq){
-                pi.updateSequence(seq);
-            }
-            seq++;
-        }
-
-        return PostCreateResponse.from(post.getId());
     }
 
-    private static <T> void move(List<T> list, int fromIdx, int toIdx) {
+    private void deleteImages(Long postId, List<Long> deleteImageIds, List<PostImage> currentImages) {
+        if(deleteImageIds != null && !deleteImageIds.isEmpty()) {
+            for(Long imageId : deleteImageIds) {
+                if(currentImages.stream().noneMatch(image -> image.getId().equals(imageId))) {
+                    throw new BadRequestException(POST_IMAGE_MISMATCH);
+                }
+            }
+            postImageRepository.deleteAllByPostIdAndIdIn(postId, deleteImageIds);
+            currentImages.removeIf(image -> deleteImageIds.contains(image.getId()));
+        }
+    }
+
+    private static <T> void moveSequence(List<T> list, int fromIdx, int toIdx) {
         if (fromIdx == toIdx) return;
         T e = list.remove(fromIdx);
         list.add(toIdx, e);

--- a/src/main/java/org/sopt/bofit/domain/post/service/PostWriter.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/PostWriter.java
@@ -1,18 +1,23 @@
 package org.sopt.bofit.domain.post.service;
 
-import static org.sopt.bofit.global.exception.constant.PostErrorCode.POST_UNAUTHORIZED;
-
 import lombok.RequiredArgsConstructor;
 import org.sopt.bofit.domain.comment.entity.Comment;
 import org.sopt.bofit.domain.comment.entity.CommentStatus;
 import org.sopt.bofit.domain.comment.repository.CommentRepository;
 import org.sopt.bofit.domain.post.dto.response.PostCreateResponse;
 import org.sopt.bofit.domain.post.entity.Post;
+import org.sopt.bofit.domain.post.entity.PostImage;
+import org.sopt.bofit.domain.post.repository.PostImageRepository;
 import org.sopt.bofit.domain.post.repository.PostRepository;
 import org.sopt.bofit.domain.user.entity.User;
 import org.sopt.bofit.domain.user.service.UserReader;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.sopt.bofit.global.exception.constant.PostErrorCode.POST_UNAUTHORIZED;
 
 @Service
 @RequiredArgsConstructor
@@ -26,13 +31,26 @@ public class PostWriter {
 
     private final CommentRepository commentRepository;
 
+    private final PostImageRepository postImageRepository;
+
 
     @Transactional
-    public PostCreateResponse createPost(Long userId, String title, String content) {
+    public PostCreateResponse createPost(Long userId, String title, String content, List<String> imageUrls) {
         User user = userReader.findById(userId);
         Post newPost = Post.create(user, title, content);
-
         postRepository.save(newPost);
+
+        int sequence = 1;
+        List<PostImage> postImages = new ArrayList<>();
+
+        if(imageUrls != null && !imageUrls.isEmpty()) {
+            for (String imageUrl : imageUrls) {
+                postImages.add(PostImage.create(imageUrl, newPost, sequence++));
+            }
+        }
+
+        postImageRepository.saveAll(postImages);
+
         return PostCreateResponse.from(newPost.getId());
     }
 

--- a/src/main/java/org/sopt/bofit/global/config/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/org/sopt/bofit/global/config/swagger/SwaggerResponseDescription.java
@@ -53,7 +53,8 @@ public enum SwaggerResponseDescription {
             POST_CONTENT_BLANK,
             POST_TITLE_BLANK,
             POST_CONTENT_LONG,
-            POST_TITLE_LONG
+            POST_TITLE_LONG,
+            POST_IMAGE_MISMATCH
     ))),
     DELETE_POST(new LinkedHashSet<>(Set.of(
             USER_NOT_FOUND,

--- a/src/main/java/org/sopt/bofit/global/exception/constant/PostErrorCode.java
+++ b/src/main/java/org/sopt/bofit/global/exception/constant/PostErrorCode.java
@@ -12,7 +12,9 @@ public enum PostErrorCode implements ErrorCode {
     POST_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "존재하지 않는 게시글입니다."),
     POST_UNAUTHORIZED(HttpStatus.FORBIDDEN.value(), "본인의 게시글만 수정/삭제할 수 있습니다."),
     POST_LIKE_CREATE_CONFLICT(HttpStatus.CONFLICT.value(), "이미 좋아요를 누른 게시글입니다."),
-    POST_LIKE_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "해당 게시글의 좋아요를 찾을 수 없습니다.")
+    POST_LIKE_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "해당 게시글의 좋아요를 찾을 수 없습니다."),
+    POST_IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "해당 게시물의 이미지를 찾을 수 없습니다."),
+    POST_IMAGE_MISMATCH(HttpStatus.BAD_REQUEST.value(), "해당 게시물에 속하지 않는 이미지입니다.")
 
     ;
     private final int httpStatus;


### PR DESCRIPTION
## Related issue 🛠
- closed #135
  


## Work Description 📝
### 게시물 생성
게시물 생성 시에는 기존 DTO에 imageUrl을 List 형태로 받도록 구현했습니다.
### 게시물 수정 - 이미지 삭제
게시물 수정 시에 세가지 DTO가 추가되었는데요, 삭제할 이미지 ID를 담는 리스트, 추가할 이미지를 담는 리스트, 수정할 리스트를 담는 리스트입니다.
그 중 이미지 삭제 시에는 삭제할 이미지의 ID만 담은 리스트를 받습니다. Path Variable로 넘어온 게시물의 이미지가 맞는지 여부를 확인한 후 이미지를 삭제합니다.
### 게시물 수정 - 이미지 수정
이미지 수정 DTO에는 url과 sequence가 있습니다. url만 수정 시에는 삭제할 때와 동일하게 게시물의 이미지가 맞는지를 확인하고 url을 수정하는데, sequence를 수정할 때는 주어진 위치에 이미지를 삽입하는 것이기 때문에 2번 순서로 이미지를 바꾸겠다 하면 기존 2번에 있던 이미지가 3번으로 밀려나는 로직을 구현했습니다.
### 게시물 수정 - 이미지 추가
기존에 없던 이미지를 추가할 때도 url과 sequence를 받습니다. 


## To Reviewers 📢
현재 이미지 추가 시에 sequence값이 이미지 수를 초과하는 값, 즉 매우 큰 값이 오면 자동으로 마지막에 이미지가 추가되게 하도록 했는데 이를 예외로 보는 것이 맞는지, 혹은 정상 작동하게 하는건지 고민을 좀 했는데, 재헌님의 생각이 궁금합니다.
그리고 현재 시퀀스 관리 로직이 지저분히다고 생각하는데, 이를 양방향 연관관계로 전환해서 어노테이션으로 DB가 순서를 관리하게끔 하는건 어떤가요??