### PR TITLE
[Feat] 대댓글 작성 API 구현 및 댓글 작성 시 이미지 추가

### DIFF
--- a/src/main/java/org/sopt/bofit/domain/comment/constant/CommentConstant.java
+++ b/src/main/java/org/sopt/bofit/domain/comment/constant/CommentConstant.java
@@ -8,4 +8,6 @@ public class CommentConstant {
 	public static final int COMMENT_CONTENT_MAX_SIZE = 30;
 
 	public static final String COMMENTS_DEFAULT_SIZE = "10";
+
+	public static final int MAX_IMAGE_COUNT = 1;
 }

--- a/src/main/java/org/sopt/bofit/domain/comment/dto/request/CommentCreateRequest.java
+++ b/src/main/java/org/sopt/bofit/domain/comment/dto/request/CommentCreateRequest.java
@@ -1,16 +1,24 @@
 package org.sopt.bofit.domain.comment.dto.request;
 
-import static org.sopt.bofit.domain.comment.constant.CommentConstant.*;
-
-import org.hibernate.validator.constraints.Length;
+import static org.sopt.bofit.domain.comment.constant.CommentConstant.COMMENT_CONTENT_MAX_SIZE;
+import static org.sopt.bofit.global.file.constant.ImageConstant.MAX_IMAGE_URL_LENGTH;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import java.util.Optional;
+import org.hibernate.validator.constraints.Length;
+import org.sopt.bofit.domain.comment.service.dto.request.CommentCreateCommand;
 
 public record CommentCreateRequest (
 	@Schema(description = "댓글 내용", example = "좋은 글이네요")
 	@NotBlank(message = "content 는 필수 항목입니다.")
 	@Length(max = COMMENT_CONTENT_MAX_SIZE, message = "content 의 최대 길이인 {max}을 초과했습니다.")
-	String content
+	String content,
+
+	@Length(max = MAX_IMAGE_URL_LENGTH, message = "이미지 url 의 최대 길이 ({max}) 를 초과했습니다.")
+	String imageUrl
 ) {
+	public CommentCreateCommand toCommand(){
+		return new CommentCreateCommand(this.content, Optional.of(this.imageUrl));
+	}
 }

--- a/src/main/java/org/sopt/bofit/domain/comment/dto/request/CommentCreateRequest.java
+++ b/src/main/java/org/sopt/bofit/domain/comment/dto/request/CommentCreateRequest.java
@@ -1,11 +1,15 @@
 package org.sopt.bofit.domain.comment.dto.request;
 
 import static org.sopt.bofit.domain.comment.constant.CommentConstant.COMMENT_CONTENT_MAX_SIZE;
+import static org.sopt.bofit.domain.comment.constant.CommentConstant.MAX_IMAGE_COUNT;
 import static org.sopt.bofit.global.file.constant.ImageConstant.MAX_IMAGE_URL_LENGTH;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
-import java.util.Optional;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.util.List;
 import org.hibernate.validator.constraints.Length;
 import org.sopt.bofit.domain.comment.service.dto.request.CommentCreateCommand;
 
@@ -15,10 +19,13 @@ public record CommentCreateRequest (
 	@Length(max = COMMENT_CONTENT_MAX_SIZE, message = "content 의 최대 길이인 {max}을 초과했습니다.")
 	String content,
 
-	@Length(max = MAX_IMAGE_URL_LENGTH, message = "이미지 url 의 최대 길이 ({max}) 를 초과했습니다.")
-	String imageUrl
+	@Schema(description = "이미지 url 목록. url 이 존재하지 않는 경우에도 빈 리스트를 요구")
+	@Size(max = MAX_IMAGE_COUNT, message = "이미지 url 의 최대 개수({max}) 를 초과했습니다.")
+	@NotNull(message = "url 목록은 비어있을 수 없습니다.")
+	@Valid
+	List<@Length(max = MAX_IMAGE_URL_LENGTH, message = "이미지 url 의 최대 길이({max}) 를 초과했습니다.") String> imageUrls
 ) {
 	public CommentCreateCommand toCommand(){
-		return new CommentCreateCommand(this.content, Optional.of(this.imageUrl));
+		return new CommentCreateCommand(this.content, this.imageUrls);
 	}
 }

--- a/src/main/java/org/sopt/bofit/domain/comment/entity/CommentImage.java
+++ b/src/main/java/org/sopt/bofit/domain/comment/entity/CommentImage.java
@@ -1,0 +1,43 @@
+package org.sopt.bofit.domain.comment.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import org.sopt.bofit.global.entity.BaseEntity;
+import org.sopt.bofit.global.file.constant.ImageConstant;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CommentImage extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "comment_image_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    private Comment comment;
+
+    @Column(length = ImageConstant.MAX_IMAGE_URL_LENGTH)
+    private String imageUrl;
+
+    public static CommentImage create(Comment comment, String imageUrl){
+        return CommentImage.builder()
+            .comment(comment)
+            .imageUrl(imageUrl)
+            .build();
+    }
+
+    @Builder
+    private CommentImage(Comment comment, String imageUrl) {
+        this.comment = comment;
+        this.imageUrl = imageUrl;
+    }
+}

--- a/src/main/java/org/sopt/bofit/domain/comment/repository/CommentImageRepository.java
+++ b/src/main/java/org/sopt/bofit/domain/comment/repository/CommentImageRepository.java
@@ -1,0 +1,10 @@
+package org.sopt.bofit.domain.comment.repository;
+
+import org.sopt.bofit.domain.comment.entity.CommentImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CommentImageRepository extends JpaRepository<CommentImage, Long> {
+
+}

--- a/src/main/java/org/sopt/bofit/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/org/sopt/bofit/domain/comment/repository/CommentRepository.java
@@ -1,9 +1,13 @@
 package org.sopt.bofit.domain.comment.repository;
 
+import java.util.Optional;
+import org.sopt.bofit.domain.comment.entity.Comment;
+import org.sopt.bofit.domain.comment.entity.CommentStatus;
 import org.springframework.stereotype.Repository;
 
 
 @Repository
 public interface CommentRepository extends CommentCustomRepository, CommentJpaRepository {
 
+    Optional<Comment> findByIdAndStatus(Long id, CommentStatus commentStatus);
 }

--- a/src/main/java/org/sopt/bofit/domain/comment/service/CommentImageWriter.java
+++ b/src/main/java/org/sopt/bofit/domain/comment/service/CommentImageWriter.java
@@ -1,0 +1,18 @@
+package org.sopt.bofit.domain.comment.service;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.bofit.domain.comment.entity.Comment;
+import org.sopt.bofit.domain.comment.entity.CommentImage;
+import org.sopt.bofit.domain.comment.repository.CommentImageRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CommentImageWriter {
+    private final CommentImageRepository commentImageRepository;
+
+    public CommentImage create(Comment comment, String url){
+        CommentImage commentImage = CommentImage.create(comment, url);
+        return commentImageRepository.save(commentImage);
+    }
+}

--- a/src/main/java/org/sopt/bofit/domain/comment/service/CommentReader.java
+++ b/src/main/java/org/sopt/bofit/domain/comment/service/CommentReader.java
@@ -1,16 +1,15 @@
 package org.sopt.bofit.domain.comment.service;
 
 import java.util.Optional;
-
+import lombok.RequiredArgsConstructor;
 import org.sopt.bofit.domain.comment.dto.response.CommentResponse;
 import org.sopt.bofit.domain.comment.entity.Comment;
+import org.sopt.bofit.domain.comment.entity.CommentStatus;
 import org.sopt.bofit.domain.comment.repository.CommentRepository;
 import org.sopt.bofit.global.exception.constant.CommentErrorCode;
 import org.sopt.bofit.global.exception.customexception.NotFoundException;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
-
-import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
@@ -24,5 +23,10 @@ public class CommentReader {
 
 	public Slice<CommentResponse> findCommentsByCursorId(Long postId, Optional<Long> cursor, int size){
 		return commentRepository.findActivesByPostIdWithCursor(postId, cursor, size);
+	}
+
+	public Comment getActiveById(Long commentId) {
+		return commentRepository.findByIdAndStatus(commentId, CommentStatus.ACTIVE).orElseThrow(() ->
+			new NotFoundException(CommentErrorCode.COMMENT_NOT_FOUND));
 	}
 }

--- a/src/main/java/org/sopt/bofit/domain/comment/service/CommentService.java
+++ b/src/main/java/org/sopt/bofit/domain/comment/service/CommentService.java
@@ -44,9 +44,10 @@ public class CommentService {
 	@Transactional
 	public void deleteComment(Long userId, Long postId, Long commentId) {
 		Comment comment = commentReader.getActiveById(commentId);
+		Post post = postReader.getActiveById(postId);
 
 		comment.getUser().checkIsWriter(userId, COMMENT_UNAUTHORIZED);
-		comment.checkPost(postId);
+		comment.checkPost(post);
 
 		commentWriter.softDelete(comment);
 	}

--- a/src/main/java/org/sopt/bofit/domain/comment/service/CommentService.java
+++ b/src/main/java/org/sopt/bofit/domain/comment/service/CommentService.java
@@ -43,7 +43,7 @@ public class CommentService {
 
 	@Transactional
 	public void deleteComment(Long userId, Long postId, Long commentId) {
-		Comment comment = commentReader.findById(commentId);
+		Comment comment = commentReader.getActiveById(commentId);
 
 		comment.getUser().checkIsWriter(userId, COMMENT_UNAUTHORIZED);
 		comment.checkPost(postId);

--- a/src/main/java/org/sopt/bofit/domain/comment/service/CommentService.java
+++ b/src/main/java/org/sopt/bofit/domain/comment/service/CommentService.java
@@ -32,7 +32,7 @@ public class CommentService {
 	@Transactional
 	public Comment createComment(Long userId, Long postId, CommentCreateCommand command){
 		Post post = postReader.findById(postId);
-		User user = userReader.findById(userId);
+		User user = userReader.getActiveById(userId);
 
 		Comment comment = commentWriter.create(post, user, command.content());
 		command.imageUrls()

--- a/src/main/java/org/sopt/bofit/domain/comment/service/CommentService.java
+++ b/src/main/java/org/sopt/bofit/domain/comment/service/CommentService.java
@@ -1,9 +1,12 @@
 package org.sopt.bofit.domain.comment.service;
 
+import static org.sopt.bofit.global.exception.constant.CommentErrorCode.COMMENT_UNAUTHORIZED;
+
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
-import org.sopt.bofit.domain.comment.dto.request.CommentCreateRequest;
 import org.sopt.bofit.domain.comment.dto.response.CommentResponse;
 import org.sopt.bofit.domain.comment.entity.Comment;
+import org.sopt.bofit.domain.comment.service.dto.request.CommentCreateCommand;
 import org.sopt.bofit.domain.post.entity.Post;
 import org.sopt.bofit.domain.post.service.PostReader;
 import org.sopt.bofit.domain.user.entity.User;
@@ -12,10 +15,6 @@ import org.sopt.bofit.global.dto.response.SliceResponse;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Optional;
-
-import static org.sopt.bofit.global.exception.constant.CommentErrorCode.COMMENT_UNAUTHORIZED;
 
 
 @Service
@@ -28,12 +27,17 @@ public class CommentService {
 
 	private final UserReader userReader;
 
+	private final CommentImageWriter commentImageWriter;
+
 	@Transactional
-	public void createComment(Long userId, Long postId, CommentCreateRequest request){
+	public Comment createComment(Long userId, Long postId, CommentCreateCommand command){
 		Post post = postReader.findById(postId);
 		User user = userReader.findById(userId);
 
-		Comment comment = commentWriter.create(post, user, request.content());
+		Comment comment = commentWriter.create(post, user, command.content());
+		command.imageUrl().ifPresent((url) -> commentImageWriter.create(comment, url));
+
+		return comment;
 	}
 
 	@Transactional

--- a/src/main/java/org/sopt/bofit/domain/comment/service/CommentService.java
+++ b/src/main/java/org/sopt/bofit/domain/comment/service/CommentService.java
@@ -31,7 +31,7 @@ public class CommentService {
 
 	@Transactional
 	public Comment createComment(Long userId, Long postId, CommentCreateCommand command){
-		Post post = postReader.findById(postId);
+		Post post = postReader.getActiveById(postId);
 		User user = userReader.getActiveById(userId);
 
 		Comment comment = commentWriter.create(post, user, command.content());
@@ -52,7 +52,7 @@ public class CommentService {
 	}
 
 	public SliceResponse<CommentResponse, Long> findAllByPostIdAndCursor(Long postId, Long userId, Optional<Long> cursor, int size) {
-		Post post = postReader.findById(postId);
+		Post post = postReader.getActiveById(postId);
 
 		Slice<CommentResponse> commentsByCursorId = commentReader.findCommentsByCursorId(postId, cursor, size);
 

--- a/src/main/java/org/sopt/bofit/domain/comment/service/CommentService.java
+++ b/src/main/java/org/sopt/bofit/domain/comment/service/CommentService.java
@@ -35,7 +35,8 @@ public class CommentService {
 		User user = userReader.findById(userId);
 
 		Comment comment = commentWriter.create(post, user, command.content());
-		command.imageUrl().ifPresent((url) -> commentImageWriter.create(comment, url));
+		command.imageUrls()
+			.forEach(url -> commentImageWriter.create(comment, url));
 
 		return comment;
 	}

--- a/src/main/java/org/sopt/bofit/domain/comment/service/CommentWriter.java
+++ b/src/main/java/org/sopt/bofit/domain/comment/service/CommentWriter.java
@@ -1,13 +1,12 @@
 package org.sopt.bofit.domain.comment.service;
 
+import lombok.RequiredArgsConstructor;
 import org.sopt.bofit.domain.comment.entity.Comment;
 import org.sopt.bofit.domain.comment.repository.CommentRepository;
 import org.sopt.bofit.domain.post.entity.Post;
 import org.sopt.bofit.domain.user.entity.User;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/org/sopt/bofit/domain/comment/service/dto/request/CommentCreateCommand.java
+++ b/src/main/java/org/sopt/bofit/domain/comment/service/dto/request/CommentCreateCommand.java
@@ -1,0 +1,10 @@
+package org.sopt.bofit.domain.comment.service.dto.request;
+
+import java.util.Optional;
+
+public record CommentCreateCommand(
+    String content,
+    Optional<String> imageUrl
+) {
+
+}

--- a/src/main/java/org/sopt/bofit/domain/comment/service/dto/request/CommentCreateCommand.java
+++ b/src/main/java/org/sopt/bofit/domain/comment/service/dto/request/CommentCreateCommand.java
@@ -1,10 +1,10 @@
 package org.sopt.bofit.domain.comment.service.dto.request;
 
-import java.util.Optional;
+import java.util.List;
 
 public record CommentCreateCommand(
     String content,
-    Optional<String> imageUrl
+    List<String> imageUrls
 ) {
 
 }

--- a/src/main/java/org/sopt/bofit/domain/commentreply/constant/CommentReplyConstant.java
+++ b/src/main/java/org/sopt/bofit/domain/commentreply/constant/CommentReplyConstant.java
@@ -7,5 +7,6 @@ import lombok.NoArgsConstructor;
 public class CommentReplyConstant {
 
     public static final int MAX_CONTENT_LENGTH = 300;
+    public static final int MAX_IMAGE_COUNT = 1;
 
 }

--- a/src/main/java/org/sopt/bofit/domain/commentreply/constant/CommentReplyConstant.java
+++ b/src/main/java/org/sopt/bofit/domain/commentreply/constant/CommentReplyConstant.java
@@ -1,0 +1,11 @@
+package org.sopt.bofit.domain.commentreply.constant;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class CommentReplyConstant {
+
+    public static final int MAX_CONTENT_LENGTH = 300;
+
+}

--- a/src/main/java/org/sopt/bofit/domain/commentreply/dto/request/CommentReplyCreateRequest.java
+++ b/src/main/java/org/sopt/bofit/domain/commentreply/dto/request/CommentReplyCreateRequest.java
@@ -1,25 +1,32 @@
 package org.sopt.bofit.domain.commentreply.dto.request;
 
 import static org.sopt.bofit.domain.commentreply.constant.CommentReplyConstant.MAX_CONTENT_LENGTH;
+import static org.sopt.bofit.domain.commentreply.constant.CommentReplyConstant.MAX_IMAGE_COUNT;
 import static org.sopt.bofit.global.file.constant.ImageConstant.MAX_IMAGE_URL_LENGTH;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
-import java.util.Optional;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.util.List;
 import org.hibernate.validator.constraints.Length;
 import org.sopt.bofit.domain.commentreply.service.dto.request.CommentReplyCreateCommand;
 
 public record CommentReplyCreateRequest(
     @Schema(description = "본문", example = "대댓글 작성하기 ~")
     @NotBlank(message = "본문은 비어있을 수 없습니다.")
-    @Length(max = MAX_CONTENT_LENGTH, message = "대댓글의 최대 길이 ({max}) 를 초과했습니다.")
+    @Length(max = MAX_CONTENT_LENGTH, message = "대댓글의 최대 길이({max}) 를 초과했습니다.")
     String content,
 
-    @Length(max = MAX_IMAGE_URL_LENGTH, message = "이미지 url 의 최대 길이 ({max}) 를 초과했습니다.")
-    String imageUrl
+    @Schema(description = "이미지 url 목록. url 이 존재하지 않는 경우에도 빈 리스트를 요구")
+    @Size(max = MAX_IMAGE_COUNT, message = "이미지 url 의 최대 개수({max}) 를 초과했습니다.")
+    @NotNull(message = "url 목록은 비어있을 수 없습니다.")
+    @Valid
+    List<@Length(max = MAX_IMAGE_URL_LENGTH, message = "이미지 url 의 최대 길이({max}) 를 초과했습니다.") String> imageUrls
 ){
     public CommentReplyCreateCommand toCommand(){
-        return new CommentReplyCreateCommand(this.content, Optional.of(this.imageUrl));
+        return new CommentReplyCreateCommand(this.content, this.imageUrls);
     }
 
 }

--- a/src/main/java/org/sopt/bofit/domain/commentreply/dto/request/CommentReplyCreateRequest.java
+++ b/src/main/java/org/sopt/bofit/domain/commentreply/dto/request/CommentReplyCreateRequest.java
@@ -9,7 +9,7 @@ import java.util.Optional;
 import org.hibernate.validator.constraints.Length;
 import org.sopt.bofit.domain.commentreply.service.dto.request.CommentReplyCreateCommand;
 
-public record CommentReplyRequest (
+public record CommentReplyCreateRequest(
     @Schema(description = "본문", example = "대댓글 작성하기 ~")
     @NotBlank(message = "본문은 비어있을 수 없습니다.")
     @Length(max = MAX_CONTENT_LENGTH, message = "대댓글의 최대 길이 ({max}) 를 초과했습니다.")

--- a/src/main/java/org/sopt/bofit/domain/commentreply/dto/request/CommentReplyRequest.java
+++ b/src/main/java/org/sopt/bofit/domain/commentreply/dto/request/CommentReplyRequest.java
@@ -5,7 +5,9 @@ import static org.sopt.bofit.global.file.constant.ImageConstant.MAX_IMAGE_URL_LE
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import java.util.Optional;
 import org.hibernate.validator.constraints.Length;
+import org.sopt.bofit.domain.commentreply.service.dto.request.CommentReplyCreateCommand;
 
 public record CommentReplyRequest (
     @Schema(description = "본문", example = "대댓글 작성하기 ~")
@@ -16,5 +18,8 @@ public record CommentReplyRequest (
     @Length(max = MAX_IMAGE_URL_LENGTH, message = "이미지 url 의 최대 길이 ({max}) 를 초과했습니다.")
     String imageUrl
 ){
+    public CommentReplyCreateCommand toCommand(){
+        return new CommentReplyCreateCommand(this.content, Optional.of(this.imageUrl));
+    }
 
 }

--- a/src/main/java/org/sopt/bofit/domain/commentreply/dto/request/CommentReplyRequest.java
+++ b/src/main/java/org/sopt/bofit/domain/commentreply/dto/request/CommentReplyRequest.java
@@ -1,0 +1,20 @@
+package org.sopt.bofit.domain.commentreply.dto.request;
+
+import static org.sopt.bofit.domain.commentreply.constant.CommentReplyConstant.MAX_CONTENT_LENGTH;
+import static org.sopt.bofit.global.file.constant.ImageConstant.MAX_IMAGE_URL_LENGTH;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import org.hibernate.validator.constraints.Length;
+
+public record CommentReplyRequest (
+    @Schema(description = "본문", example = "대댓글 작성하기 ~")
+    @NotBlank(message = "본문은 비어있을 수 없습니다.")
+    @Length(max = MAX_CONTENT_LENGTH, message = "대댓글의 최대 길이 ({max}) 를 초과했습니다.")
+    String content,
+
+    @Length(max = MAX_IMAGE_URL_LENGTH, message = "이미지 url 의 최대 길이 ({max}) 를 초과했습니다.")
+    String imageUrl
+){
+
+}

--- a/src/main/java/org/sopt/bofit/domain/commentreply/entity/CommentReply.java
+++ b/src/main/java/org/sopt/bofit/domain/commentreply/entity/CommentReply.java
@@ -1,0 +1,59 @@
+package org.sopt.bofit.domain.commentreply.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import org.sopt.bofit.domain.comment.entity.Comment;
+import org.sopt.bofit.domain.commentreply.constant.CommentReplyConstant;
+import org.sopt.bofit.domain.user.entity.User;
+import org.sopt.bofit.global.entity.BaseEntity;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(indexes = {
+    @Index(name = "idx_comment_created_at", columnList = "comment_id, created_at"),
+    @Index(name = "idx_created_at", columnList = "created_at")
+})
+public class CommentReply extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "comment_reply_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "comment_id")
+    private Comment comment;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Column(nullable = false, length = CommentReplyConstant.MAX_CONTENT_LENGTH)
+    String content;
+
+    public static CommentReply create(Comment comment, User user, String content){
+        return CommentReply.builder()
+            .comment(comment)
+            .user(user)
+            .content(content)
+            .build();
+    }
+
+    @Builder
+    private CommentReply(Comment comment, User user, String content) {
+        this.comment = comment;
+        this.user = user;
+        this.content = content;
+    }
+}

--- a/src/main/java/org/sopt/bofit/domain/commentreply/entity/CommentReplyImage.java
+++ b/src/main/java/org/sopt/bofit/domain/commentreply/entity/CommentReplyImage.java
@@ -10,7 +10,6 @@ import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
-import org.sopt.bofit.domain.user.entity.User;
 import org.sopt.bofit.global.entity.BaseEntity;
 import org.sopt.bofit.global.file.constant.ImageConstant;
 
@@ -26,24 +25,20 @@ public class CommentReplyImage extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     private CommentReply commentReply;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    private User user;
 
     @Column(length = ImageConstant.MAX_IMAGE_URL_LENGTH)
     String imageUrl;
 
-    public static CommentReplyImage create(CommentReply commentReply, User user, String imageUrl){
+    public static CommentReplyImage create(CommentReply commentReply, String imageUrl){
         return CommentReplyImage.builder()
             .commentReply(commentReply)
             .imageUrl(imageUrl)
-            .user(user)
             .build();
     }
 
     @Builder
-    private CommentReplyImage(CommentReply commentReply, User user, String imageUrl) {
+    private CommentReplyImage(CommentReply commentReply, String imageUrl) {
         this.commentReply = commentReply;
         this.imageUrl = imageUrl;
-        this.user = user;
     }
 }

--- a/src/main/java/org/sopt/bofit/domain/commentreply/entity/CommentReplyImage.java
+++ b/src/main/java/org/sopt/bofit/domain/commentreply/entity/CommentReplyImage.java
@@ -10,6 +10,7 @@ import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
+import org.sopt.bofit.domain.user.entity.User;
 import org.sopt.bofit.global.entity.BaseEntity;
 import org.sopt.bofit.global.file.constant.ImageConstant;
 
@@ -25,19 +26,24 @@ public class CommentReplyImage extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     private CommentReply commentReply;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User user;
+
     @Column(length = ImageConstant.MAX_IMAGE_URL_LENGTH)
     String imageUrl;
 
-    public static CommentReplyImage create(CommentReply commentReply, String imageUrl){
+    public static CommentReplyImage create(CommentReply commentReply, User user, String imageUrl){
         return CommentReplyImage.builder()
             .commentReply(commentReply)
             .imageUrl(imageUrl)
+            .user(user)
             .build();
     }
 
     @Builder
-    private CommentReplyImage(CommentReply commentReply, String imageUrl) {
+    private CommentReplyImage(CommentReply commentReply, User user, String imageUrl) {
         this.commentReply = commentReply;
         this.imageUrl = imageUrl;
+        this.user = user;
     }
 }

--- a/src/main/java/org/sopt/bofit/domain/commentreply/entity/CommentReplyImage.java
+++ b/src/main/java/org/sopt/bofit/domain/commentreply/entity/CommentReplyImage.java
@@ -19,7 +19,7 @@ public class CommentReplyImage extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "comment_reply_id")
+    @Column(name = "comment_reply_image_id")
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)

--- a/src/main/java/org/sopt/bofit/domain/commentreply/entity/CommentReplyImage.java
+++ b/src/main/java/org/sopt/bofit/domain/commentreply/entity/CommentReplyImage.java
@@ -25,9 +25,8 @@ public class CommentReplyImage extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     private CommentReply commentReply;
 
-
     @Column(length = ImageConstant.MAX_IMAGE_URL_LENGTH)
-    String imageUrl;
+    private String imageUrl;
 
     public static CommentReplyImage create(CommentReply commentReply, String imageUrl){
         return CommentReplyImage.builder()

--- a/src/main/java/org/sopt/bofit/domain/commentreply/entity/CommentReplyImage.java
+++ b/src/main/java/org/sopt/bofit/domain/commentreply/entity/CommentReplyImage.java
@@ -1,0 +1,43 @@
+package org.sopt.bofit.domain.commentreply.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import org.sopt.bofit.global.entity.BaseEntity;
+import org.sopt.bofit.global.file.constant.ImageConstant;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CommentReplyImage extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "comment_reply_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    private CommentReply commentReply;
+
+    @Column(length = ImageConstant.MAX_IMAGE_URL_LENGTH)
+    String imageUrl;
+
+    public static CommentReplyImage create(CommentReply commentReply, String imageUrl){
+        return CommentReplyImage.builder()
+            .commentReply(commentReply)
+            .imageUrl(imageUrl)
+            .build();
+    }
+
+    @Builder
+    private CommentReplyImage(CommentReply commentReply, String imageUrl) {
+        this.commentReply = commentReply;
+        this.imageUrl = imageUrl;
+    }
+}

--- a/src/main/java/org/sopt/bofit/domain/commentreply/repository/CommentReplyImageRepository.java
+++ b/src/main/java/org/sopt/bofit/domain/commentreply/repository/CommentReplyImageRepository.java
@@ -1,0 +1,10 @@
+package org.sopt.bofit.domain.commentreply.repository;
+
+import org.sopt.bofit.domain.commentreply.entity.CommentReplyImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CommentReplyImageRepository extends JpaRepository<CommentReplyImage, Long> {
+
+}

--- a/src/main/java/org/sopt/bofit/domain/commentreply/repository/CommentReplyRepository.java
+++ b/src/main/java/org/sopt/bofit/domain/commentreply/repository/CommentReplyRepository.java
@@ -1,0 +1,10 @@
+package org.sopt.bofit.domain.commentreply.repository;
+
+import org.sopt.bofit.domain.commentreply.entity.CommentReply;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CommentReplyRepository extends JpaRepository<CommentReply, Long> {
+
+}

--- a/src/main/java/org/sopt/bofit/domain/commentreply/service/CommentReplyImageWriter.java
+++ b/src/main/java/org/sopt/bofit/domain/commentreply/service/CommentReplyImageWriter.java
@@ -1,0 +1,20 @@
+package org.sopt.bofit.domain.commentreply.service;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.bofit.domain.commentreply.entity.CommentReply;
+import org.sopt.bofit.domain.commentreply.entity.CommentReplyImage;
+import org.sopt.bofit.domain.commentreply.repository.CommentReplyImageRepository;
+import org.sopt.bofit.domain.user.entity.User;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CommentReplyImageWriter {
+    private final CommentReplyImageRepository commentReplyImageRepository;
+
+    public CommentReplyImage create(CommentReply commentReply, User user, String imageUrl){
+        CommentReplyImage commentReplyImage = CommentReplyImage.create(commentReply, user, imageUrl);
+        return commentReplyImageRepository.save(commentReplyImage);
+    }
+
+}

--- a/src/main/java/org/sopt/bofit/domain/commentreply/service/CommentReplyImageWriter.java
+++ b/src/main/java/org/sopt/bofit/domain/commentreply/service/CommentReplyImageWriter.java
@@ -4,7 +4,6 @@ import lombok.RequiredArgsConstructor;
 import org.sopt.bofit.domain.commentreply.entity.CommentReply;
 import org.sopt.bofit.domain.commentreply.entity.CommentReplyImage;
 import org.sopt.bofit.domain.commentreply.repository.CommentReplyImageRepository;
-import org.sopt.bofit.domain.user.entity.User;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -12,8 +11,8 @@ import org.springframework.stereotype.Service;
 public class CommentReplyImageWriter {
     private final CommentReplyImageRepository commentReplyImageRepository;
 
-    public CommentReplyImage create(CommentReply commentReply, User user, String imageUrl){
-        CommentReplyImage commentReplyImage = CommentReplyImage.create(commentReply, user, imageUrl);
+    public CommentReplyImage create(CommentReply commentReply, String imageUrl){
+        CommentReplyImage commentReplyImage = CommentReplyImage.create(commentReply, imageUrl);
         return commentReplyImageRepository.save(commentReplyImage);
     }
 

--- a/src/main/java/org/sopt/bofit/domain/commentreply/service/CommentReplyService.java
+++ b/src/main/java/org/sopt/bofit/domain/commentreply/service/CommentReplyService.java
@@ -1,10 +1,10 @@
 package org.sopt.bofit.domain.commentreply.service;
 
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.sopt.bofit.domain.comment.entity.Comment;
 import org.sopt.bofit.domain.comment.service.CommentReader;
 import org.sopt.bofit.domain.commentreply.entity.CommentReply;
+import org.sopt.bofit.domain.commentreply.service.dto.request.CommentReplyCreateCommand;
 import org.sopt.bofit.domain.user.entity.User;
 import org.sopt.bofit.domain.user.service.UserReader;
 import org.springframework.stereotype.Service;
@@ -20,14 +20,14 @@ public class CommentReplyService {
     private UserReader userReader;
 
     @Transactional
-    public CommentReply create(Long userId, Long postId, Long commentId, String content, Optional<String> imageUrl){
+    public CommentReply create(Long userId, Long postId, Long commentId, CommentReplyCreateCommand command){
         Comment comment = commentReader.findById(commentId);
         User user = userReader.findById(userId);
 
         comment.checkPost(postId);
 
-        CommentReply commentReply = commentReplyWriter.create(comment, user, content);
-        imageUrl.ifPresent((url) -> commentReplyImageWriter.create(commentReply, url));
+        CommentReply commentReply = commentReplyWriter.create(comment, user, command.content());
+        command.imageUrl().ifPresent((url) -> commentReplyImageWriter.create(commentReply, url));
         return commentReply;
     }
 

--- a/src/main/java/org/sopt/bofit/domain/commentreply/service/CommentReplyService.java
+++ b/src/main/java/org/sopt/bofit/domain/commentreply/service/CommentReplyService.java
@@ -27,7 +27,7 @@ public class CommentReplyService {
         comment.checkPost(postId);
 
         CommentReply commentReply = commentReplyWriter.create(comment, user, content);
-        imageUrl.ifPresent((url) -> commentReplyImageWriter.create(commentReply, user, url));
+        imageUrl.ifPresent((url) -> commentReplyImageWriter.create(commentReply, url));
         return commentReply;
     }
 

--- a/src/main/java/org/sopt/bofit/domain/commentreply/service/CommentReplyService.java
+++ b/src/main/java/org/sopt/bofit/domain/commentreply/service/CommentReplyService.java
@@ -5,6 +5,8 @@ import org.sopt.bofit.domain.comment.entity.Comment;
 import org.sopt.bofit.domain.comment.service.CommentReader;
 import org.sopt.bofit.domain.commentreply.entity.CommentReply;
 import org.sopt.bofit.domain.commentreply.service.dto.request.CommentReplyCreateCommand;
+import org.sopt.bofit.domain.post.entity.Post;
+import org.sopt.bofit.domain.post.service.PostReader;
 import org.sopt.bofit.domain.user.entity.User;
 import org.sopt.bofit.domain.user.service.UserReader;
 import org.springframework.stereotype.Service;
@@ -18,13 +20,15 @@ public class CommentReplyService {
     private CommentReplyImageWriter commentReplyImageWriter;
     private CommentReader commentReader;
     private UserReader userReader;
+    private PostReader postReader;
 
     @Transactional
     public CommentReply create(Long userId, Long postId, Long commentId, CommentReplyCreateCommand command){
         Comment comment = commentReader.getActiveById(commentId);
         User user = userReader.getActiveById(userId);
+        Post post = postReader.getActiveById(postId);
 
-        comment.checkPost(postId);
+        comment.checkPost(post);
 
         CommentReply commentReply = commentReplyWriter.create(comment, user, command.content());
         command.imageUrls().stream()

--- a/src/main/java/org/sopt/bofit/domain/commentreply/service/CommentReplyService.java
+++ b/src/main/java/org/sopt/bofit/domain/commentreply/service/CommentReplyService.java
@@ -1,0 +1,34 @@
+package org.sopt.bofit.domain.commentreply.service;
+
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.sopt.bofit.domain.comment.entity.Comment;
+import org.sopt.bofit.domain.comment.service.CommentReader;
+import org.sopt.bofit.domain.commentreply.entity.CommentReply;
+import org.sopt.bofit.domain.user.entity.User;
+import org.sopt.bofit.domain.user.service.UserReader;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CommentReplyService {
+
+    private CommentReplyWriter commentReplyWriter;
+    private CommentReplyImageWriter commentReplyImageWriter;
+    private CommentReader commentReader;
+    private UserReader userReader;
+
+    @Transactional
+    public CommentReply create(Long userId, Long postId, Long commentId, String content, Optional<String> imageUrl){
+        Comment comment = commentReader.findById(commentId);
+        User user = userReader.findById(userId);
+
+        comment.checkPost(postId);
+
+        CommentReply commentReply = commentReplyWriter.create(comment, user, content);
+        imageUrl.ifPresent((url) -> commentReplyImageWriter.create(commentReply, user, url));
+        return commentReply;
+    }
+
+}

--- a/src/main/java/org/sopt/bofit/domain/commentreply/service/CommentReplyService.java
+++ b/src/main/java/org/sopt/bofit/domain/commentreply/service/CommentReplyService.java
@@ -21,7 +21,7 @@ public class CommentReplyService {
 
     @Transactional
     public CommentReply create(Long userId, Long postId, Long commentId, CommentReplyCreateCommand command){
-        Comment comment = commentReader.findById(commentId);
+        Comment comment = commentReader.getActiveById(commentId);
         User user = userReader.findById(userId);
 
         comment.checkPost(postId);

--- a/src/main/java/org/sopt/bofit/domain/commentreply/service/CommentReplyService.java
+++ b/src/main/java/org/sopt/bofit/domain/commentreply/service/CommentReplyService.java
@@ -22,7 +22,7 @@ public class CommentReplyService {
     @Transactional
     public CommentReply create(Long userId, Long postId, Long commentId, CommentReplyCreateCommand command){
         Comment comment = commentReader.getActiveById(commentId);
-        User user = userReader.findById(userId);
+        User user = userReader.getActiveById(userId);
 
         comment.checkPost(postId);
 

--- a/src/main/java/org/sopt/bofit/domain/commentreply/service/CommentReplyService.java
+++ b/src/main/java/org/sopt/bofit/domain/commentreply/service/CommentReplyService.java
@@ -27,7 +27,8 @@ public class CommentReplyService {
         comment.checkPost(postId);
 
         CommentReply commentReply = commentReplyWriter.create(comment, user, command.content());
-        command.imageUrl().ifPresent((url) -> commentReplyImageWriter.create(commentReply, url));
+        command.imageUrls().stream()
+            .forEach(url -> commentReplyImageWriter.create(commentReply, url)); // 추후 이미지 개수가 많아지면 AllInBatch 등으로 수정하기
         return commentReply;
     }
 

--- a/src/main/java/org/sopt/bofit/domain/commentreply/service/CommentReplyWriter.java
+++ b/src/main/java/org/sopt/bofit/domain/commentreply/service/CommentReplyWriter.java
@@ -1,0 +1,21 @@
+package org.sopt.bofit.domain.commentreply.service;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.bofit.domain.comment.entity.Comment;
+import org.sopt.bofit.domain.commentreply.entity.CommentReply;
+import org.sopt.bofit.domain.commentreply.repository.CommentReplyRepository;
+import org.sopt.bofit.domain.user.entity.User;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CommentReplyWriter {
+
+    private final CommentReplyRepository commentReplyRepository;
+
+    public CommentReply create(Comment comment, User user, String content){
+        CommentReply commentReply = CommentReply.create(comment, user, content);
+        return commentReplyRepository.save(commentReply);
+    }
+
+}

--- a/src/main/java/org/sopt/bofit/domain/commentreply/service/dto/request/CommentReplyCreateCommand.java
+++ b/src/main/java/org/sopt/bofit/domain/commentreply/service/dto/request/CommentReplyCreateCommand.java
@@ -1,0 +1,10 @@
+package org.sopt.bofit.domain.commentreply.service.dto.request;
+
+import java.util.Optional;
+
+public record CommentReplyCreateCommand(
+    String content,
+    Optional<String> imageUrl
+) {
+
+}

--- a/src/main/java/org/sopt/bofit/domain/commentreply/service/dto/request/CommentReplyCreateCommand.java
+++ b/src/main/java/org/sopt/bofit/domain/commentreply/service/dto/request/CommentReplyCreateCommand.java
@@ -1,10 +1,10 @@
 package org.sopt.bofit.domain.commentreply.service.dto.request;
 
-import java.util.Optional;
+import java.util.List;
 
 public record CommentReplyCreateCommand(
     String content,
-    Optional<String> imageUrl
+    List<String> imageUrls
 ) {
 
 }

--- a/src/main/java/org/sopt/bofit/domain/insurancereport/service/InsuranceReportService.java
+++ b/src/main/java/org/sopt/bofit/domain/insurancereport/service/InsuranceReportService.java
@@ -2,7 +2,7 @@ package org.sopt.bofit.domain.insurancereport.service;
 
 import java.util.List;
 import java.util.UUID;
-
+import lombok.RequiredArgsConstructor;
 import org.sopt.bofit.domain.insurance.entity.product.InsuranceProduct;
 import org.sopt.bofit.domain.insurance.entity.statistic.InsuranceStatistic;
 import org.sopt.bofit.domain.insurance.service.InsuranceProductReader;
@@ -22,8 +22,6 @@ import org.sopt.bofit.domain.user.service.UserReader;
 import org.sopt.bofit.domain.user.util.UserUtil;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
@@ -88,7 +86,7 @@ public class InsuranceReportService {
 
 	@Transactional(readOnly = true)
 	public InsuranceReportSummaryResponse findUsersLastReportSummary(Long userId){
-		User user = userReader.findById(userId);
+		User user = userReader.getActiveById(userId);
 		InsuranceReport report = insuranceReportReader.findLastByUser(user);
 		return InsuranceReportSummaryResponse.from(report);
 	}

--- a/src/main/java/org/sopt/bofit/domain/post/controller/PostController.java
+++ b/src/main/java/org/sopt/bofit/domain/post/controller/PostController.java
@@ -183,12 +183,9 @@ public class PostController {
         @PathVariable(name = "post-id") Long postId,
         @PathVariable(name = "comment-id") Long commentId,
         @Parameter(hidden = true) @LoginUserId Long userId,
-        @RequestBody CommentReplyRequest commentReplyRequest
+        @RequestBody CommentReplyRequest request
     ){
-        commentReplyService.create(
-            userId, postId, commentId,
-            commentReplyRequest.content(),
-            Optional.of(commentReplyRequest.imageUrl()));
+        commentReplyService.create(userId, postId, commentId, request.toCommand());
         return BaseResponse.create("대댓글 작성 성공");
     }
 

--- a/src/main/java/org/sopt/bofit/domain/post/controller/PostController.java
+++ b/src/main/java/org/sopt/bofit/domain/post/controller/PostController.java
@@ -120,7 +120,7 @@ public class PostController {
         @PathVariable(name = "post-id") Long postId,
         @Parameter(hidden = true) @LoginUserId Long userId
     ){
-        commentService.createComment(userId, postId, request);
+        commentService.createComment(userId, postId, request.toCommand());
         return BaseResponse.create("댓글 생성 성공");
     }
 

--- a/src/main/java/org/sopt/bofit/domain/post/controller/PostController.java
+++ b/src/main/java/org/sopt/bofit/domain/post/controller/PostController.java
@@ -23,7 +23,7 @@ import lombok.RequiredArgsConstructor;
 import org.sopt.bofit.domain.comment.dto.request.CommentCreateRequest;
 import org.sopt.bofit.domain.comment.dto.response.CommentResponse;
 import org.sopt.bofit.domain.comment.service.CommentService;
-import org.sopt.bofit.domain.commentreply.dto.request.CommentReplyRequest;
+import org.sopt.bofit.domain.commentreply.dto.request.CommentReplyCreateRequest;
 import org.sopt.bofit.domain.commentreply.service.CommentReplyService;
 import org.sopt.bofit.domain.post.dto.request.PostCreateRequest;
 import org.sopt.bofit.domain.post.dto.request.PostUpdateRequest;
@@ -183,7 +183,7 @@ public class PostController {
         @PathVariable(name = "post-id") Long postId,
         @PathVariable(name = "comment-id") Long commentId,
         @Parameter(hidden = true) @LoginUserId Long userId,
-        @RequestBody CommentReplyRequest request
+        @RequestBody CommentReplyCreateRequest request
     ){
         commentReplyService.create(userId, postId, commentId, request.toCommand());
         return BaseResponse.create("대댓글 작성 성공");

--- a/src/main/java/org/sopt/bofit/domain/post/controller/PostController.java
+++ b/src/main/java/org/sopt/bofit/domain/post/controller/PostController.java
@@ -183,7 +183,7 @@ public class PostController {
         @PathVariable(name = "post-id") Long postId,
         @PathVariable(name = "comment-id") Long commentId,
         @Parameter(hidden = true) @LoginUserId Long userId,
-        @RequestBody CommentReplyCreateRequest request
+        @RequestBody @Valid CommentReplyCreateRequest request
     ){
         commentReplyService.create(userId, postId, commentId, request.toCommand());
         return BaseResponse.create("대댓글 작성 성공");

--- a/src/main/java/org/sopt/bofit/domain/post/controller/PostController.java
+++ b/src/main/java/org/sopt/bofit/domain/post/controller/PostController.java
@@ -1,13 +1,30 @@
 package org.sopt.bofit.domain.post.controller;
 
+import static org.sopt.bofit.domain.comment.constant.CommentConstant.COMMENTS_DEFAULT_SIZE;
+import static org.sopt.bofit.domain.post.constant.PostConstant.POSTS_DEFAULT_SIZE;
+import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.CREATE_COMMENT;
+import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.CREATE_COMMENT_REPLY;
+import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.CREATE_POST;
+import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.CREATE_POST_LIKE;
+import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.DELETE_COMMENT;
+import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.DELETE_POST;
+import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.DELETE_POST_LIKE;
+import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.POST_DETAIL;
+import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.UPDATE_POST;
+import static org.sopt.bofit.global.constant.SwaggerConstant.TAG_DESCRIPTION_COMMUNITY;
+import static org.sopt.bofit.global.constant.SwaggerConstant.TAG_NAME_COMMUNITY;
+
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.sopt.bofit.domain.comment.dto.request.CommentCreateRequest;
 import org.sopt.bofit.domain.comment.dto.response.CommentResponse;
 import org.sopt.bofit.domain.comment.service.CommentService;
+import org.sopt.bofit.domain.commentreply.dto.request.CommentReplyRequest;
+import org.sopt.bofit.domain.commentreply.service.CommentReplyService;
 import org.sopt.bofit.domain.post.dto.request.PostCreateRequest;
 import org.sopt.bofit.domain.post.dto.request.PostUpdateRequest;
 import org.sopt.bofit.domain.post.dto.response.PostCreateResponse;
@@ -19,15 +36,15 @@ import org.sopt.bofit.global.annotation.CustomExceptionDescription;
 import org.sopt.bofit.global.annotation.LoginUserId;
 import org.sopt.bofit.global.dto.response.BaseResponse;
 import org.sopt.bofit.global.dto.response.SliceResponse;
-import org.springframework.web.bind.annotation.*;
-
-import java.util.Optional;
-
-import static org.sopt.bofit.domain.comment.constant.CommentConstant.COMMENTS_DEFAULT_SIZE;
-import static org.sopt.bofit.domain.post.constant.PostConstant.POSTS_DEFAULT_SIZE;
-import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.*;
-import static org.sopt.bofit.global.constant.SwaggerConstant.TAG_DESCRIPTION_COMMUNITY;
-import static org.sopt.bofit.global.constant.SwaggerConstant.TAG_NAME_COMMUNITY;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
@@ -37,6 +54,7 @@ public class PostController {
     private final PostService postService;
     private final CommentService commentService;
     private final PostLikeService postLikeService;
+    private final CommentReplyService commentReplyService;
 
     @Tag(name = TAG_NAME_COMMUNITY, description = TAG_DESCRIPTION_COMMUNITY)
     @Operation(summary = "게시물 작성", description = "커뮤니티에 글을 작성합니다.")
@@ -155,6 +173,23 @@ public class PostController {
     ){
         postLikeService.deletePostLike(userId, postId);
         return BaseResponse.create("좋아요 삭제 성공");
+    }
+
+    @Tag(name = TAG_NAME_COMMUNITY, description = TAG_DESCRIPTION_COMMUNITY)
+    @Operation(summary = "대댓글 작성", description = "유저가 커뮤니티 댓글에 대댓글을 작성합니다.")
+    @CustomExceptionDescription(CREATE_COMMENT_REPLY)
+    @PostMapping("/{post-id}/comments/{comment-id}/reply")
+    public BaseResponse<Void> createCommentReply(
+        @PathVariable(name = "post-id") Long postId,
+        @PathVariable(name = "comment-id") Long commentId,
+        @Parameter(hidden = true) @LoginUserId Long userId,
+        @RequestBody CommentReplyRequest commentReplyRequest
+    ){
+        commentReplyService.create(
+            userId, postId, commentId,
+            commentReplyRequest.content(),
+            Optional.of(commentReplyRequest.imageUrl()));
+        return BaseResponse.create("대댓글 작성 성공");
     }
 
 }

--- a/src/main/java/org/sopt/bofit/domain/post/dto/request/PostUpdateRequest.java
+++ b/src/main/java/org/sopt/bofit/domain/post/dto/request/PostUpdateRequest.java
@@ -4,10 +4,11 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import java.util.List;
 import org.hibernate.validator.constraints.Length;
 import org.sopt.bofit.domain.post.entity.constant.PostInfoConstant;
-
-import java.util.List;
+import org.sopt.bofit.global.file.dto.request.NewImageRequest;
+import org.sopt.bofit.global.file.dto.request.UpdateImageRequest;
 
 public record PostUpdateRequest(
         @Schema(description = "제목", example = "ㅇㅇ")

--- a/src/main/java/org/sopt/bofit/domain/post/entity/PostImage.java
+++ b/src/main/java/org/sopt/bofit/domain/post/entity/PostImage.java
@@ -1,7 +1,20 @@
 package org.sopt.bofit.domain.post.entity;
 
-import jakarta.persistence.*;
-import lombok.*;
+import static org.sopt.bofit.global.file.constant.ImageConstant.MAX_IMAGE_URL_LENGTH;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
@@ -18,7 +31,7 @@ public class PostImage {
     @JoinColumn(name = "post_id")
     private Post post;
 
-    @Column(columnDefinition = "TEXT", nullable = false)
+    @Column(nullable = false, length = MAX_IMAGE_URL_LENGTH)
     private String imageUrl;
 
     @Column(nullable = false)

--- a/src/main/java/org/sopt/bofit/domain/post/repository/PostJpaRepository.java
+++ b/src/main/java/org/sopt/bofit/domain/post/repository/PostJpaRepository.java
@@ -1,7 +1,10 @@
 package org.sopt.bofit.domain.post.repository;
 
+import java.util.Optional;
 import org.sopt.bofit.domain.post.entity.Post;
+import org.sopt.bofit.domain.post.entity.constant.PostStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PostJpaRepository extends JpaRepository<Post, Long> {
+    Optional<Post> findByIdAndStatus(Long postId, PostStatus postStatus);
 }

--- a/src/main/java/org/sopt/bofit/domain/post/service/PostLikeService.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/PostLikeService.java
@@ -24,7 +24,7 @@ public class PostLikeService {
 
     @Transactional
     public void createPostLike(Long userId, Long postId){
-        Post post = postReader.findById(postId);
+        Post post = postReader.getActiveById(postId);
         User user = userReader.getActiveById(userId);
 
         boolean isExistLike = postLikeReader.isExistsByPostAndUser(post, user);
@@ -39,7 +39,7 @@ public class PostLikeService {
 
     @Transactional
     public void deletePostLike(Long userId, Long postId){
-        Post post = postReader.findById(postId);
+        Post post = postReader.getActiveById(postId);
         User user = userReader.getActiveById(userId);
 
         PostLike postLike = postLikeReader.findByPostAndUser(post, user);

--- a/src/main/java/org/sopt/bofit/domain/post/service/PostLikeService.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/PostLikeService.java
@@ -25,7 +25,7 @@ public class PostLikeService {
     @Transactional
     public void createPostLike(Long userId, Long postId){
         Post post = postReader.findById(postId);
-        User user = userReader.findById(userId);
+        User user = userReader.getActiveById(userId);
 
         boolean isExistLike = postLikeReader.isExistsByPostAndUser(post, user);
 
@@ -40,7 +40,7 @@ public class PostLikeService {
     @Transactional
     public void deletePostLike(Long userId, Long postId){
         Post post = postReader.findById(postId);
-        User user = userReader.findById(userId);
+        User user = userReader.getActiveById(userId);
 
         PostLike postLike = postLikeReader.findByPostAndUser(post, user);
 

--- a/src/main/java/org/sopt/bofit/domain/post/service/PostReader.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/PostReader.java
@@ -61,6 +61,7 @@ public class PostReader {
     }
 
     public Post getActiveById(Long postId) {
-        return postRepository.findByIdAndStatus(postId, PostStatus.ACTIVE).orElseThrow(() -> new NotFoundException(POST_NOT_FOUND));
+        return postRepository.findByIdAndStatus(postId, PostStatus.ACTIVE)
+            .orElseThrow(() -> new NotFoundException(POST_NOT_FOUND));
     }
 }

--- a/src/main/java/org/sopt/bofit/domain/post/service/PostReader.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/PostReader.java
@@ -1,6 +1,10 @@
 
 package org.sopt.bofit.domain.post.service;
 
+import static org.sopt.bofit.domain.post.dto.response.PostDetailResponse.builder;
+import static org.sopt.bofit.global.exception.constant.PostErrorCode.POST_NOT_FOUND;
+
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.sopt.bofit.domain.comment.entity.Comment;
 import org.sopt.bofit.domain.comment.entity.CommentStatus;
@@ -8,18 +12,14 @@ import org.sopt.bofit.domain.comment.repository.CommentRepository;
 import org.sopt.bofit.domain.post.dto.response.PostDetailResponse;
 import org.sopt.bofit.domain.post.dto.response.PostSummaryResponse;
 import org.sopt.bofit.domain.post.entity.Post;
+import org.sopt.bofit.domain.post.entity.constant.PostStatus;
 import org.sopt.bofit.domain.post.repository.PostRepository;
-import org.sopt.bofit.global.dto.response.SliceResponse;
 import org.sopt.bofit.domain.user.entity.User;
+import org.sopt.bofit.global.dto.response.SliceResponse;
 import org.sopt.bofit.global.exception.customexception.NotFoundException;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
-
-import static org.sopt.bofit.domain.post.dto.response.PostDetailResponse.*;
-import static org.sopt.bofit.global.exception.constant.PostErrorCode.POST_NOT_FOUND;
 
 @Service
 @RequiredArgsConstructor
@@ -37,7 +37,7 @@ public class PostReader {
 
     @Transactional(readOnly = true)
     public PostDetailResponse getPostById(Long postId) {
-        Post post = findById(postId);
+        Post post = getActiveById(postId);
         User writer = post.getUser();
 
         List<Comment> activeComments = commentRepository.findAllByPostIdAndStatus(postId, CommentStatus.ACTIVE);
@@ -58,5 +58,9 @@ public class PostReader {
 
     public Post findById(Long postId) {
         return postRepository.findById(postId).orElseThrow(() -> new NotFoundException(POST_NOT_FOUND));
+    }
+
+    public Post getActiveById(Long postId) {
+        return postRepository.findByIdAndStatus(postId, PostStatus.ACTIVE).orElseThrow(() -> new NotFoundException(POST_NOT_FOUND));
     }
 }

--- a/src/main/java/org/sopt/bofit/domain/post/service/PostService.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/PostService.java
@@ -1,16 +1,15 @@
 package org.sopt.bofit.domain.post.service;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.sopt.bofit.domain.post.dto.request.NewImageRequest;
-import org.sopt.bofit.domain.post.dto.request.UpdateImageRequest;
 import org.sopt.bofit.domain.post.dto.response.PostCreateResponse;
 import org.sopt.bofit.domain.post.dto.response.PostDetailResponse;
 import org.sopt.bofit.domain.post.dto.response.PostSummaryResponse;
 import org.sopt.bofit.global.dto.response.SliceResponse;
+import org.sopt.bofit.global.file.dto.request.NewImageRequest;
+import org.sopt.bofit.global.file.dto.request.UpdateImageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/org/sopt/bofit/domain/post/service/PostWriter.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/PostWriter.java
@@ -41,7 +41,7 @@ public class PostWriter {
 
     @Transactional
     public PostCreateResponse createPost(Long userId, String title, String content, List<String> imageUrls) {
-        User user = userReader.findById(userId);
+        User user = userReader.getActiveById(userId);
         Post newPost = Post.create(user, title, content);
         postRepository.save(newPost);
 
@@ -63,7 +63,7 @@ public class PostWriter {
     public PostCreateResponse updatePost (Long userId, Long postId, String newTitle, String newContent,
                                           List<NewImageRequest> newImages, List<UpdateImageRequest> updateImages,
                                           List<Long> deleteImageIds) {
-        User user = userReader.findById(userId);
+        User user = userReader.getActiveById(userId);
         Post post = postReader.findById(postId);
 
         post.getUser().checkIsWriter(userId, POST_UNAUTHORIZED);
@@ -154,7 +154,7 @@ public class PostWriter {
 
     @Transactional
     public void deletePost(Long userId, Long postId) {
-        User user = userReader.findById(userId);
+        User user = userReader.getActiveById(userId);
         Post post = postReader.findById(postId);
         post.getUser().checkIsWriter(userId, POST_UNAUTHORIZED);
 

--- a/src/main/java/org/sopt/bofit/domain/post/service/PostWriter.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/PostWriter.java
@@ -1,11 +1,16 @@
 package org.sopt.bofit.domain.post.service;
 
+import static org.sopt.bofit.global.exception.constant.PostErrorCode.POST_IMAGE_MISMATCH;
+import static org.sopt.bofit.global.exception.constant.PostErrorCode.POST_UNAUTHORIZED;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.sopt.bofit.domain.comment.entity.Comment;
 import org.sopt.bofit.domain.comment.entity.CommentStatus;
 import org.sopt.bofit.domain.comment.repository.CommentRepository;
-import org.sopt.bofit.domain.post.dto.request.NewImageRequest;
-import org.sopt.bofit.domain.post.dto.request.UpdateImageRequest;
 import org.sopt.bofit.domain.post.dto.response.PostCreateResponse;
 import org.sopt.bofit.domain.post.entity.Post;
 import org.sopt.bofit.domain.post.entity.PostImage;
@@ -14,16 +19,10 @@ import org.sopt.bofit.domain.post.repository.PostRepository;
 import org.sopt.bofit.domain.user.entity.User;
 import org.sopt.bofit.domain.user.service.UserReader;
 import org.sopt.bofit.global.exception.customexception.BadRequestException;
+import org.sopt.bofit.global.file.dto.request.NewImageRequest;
+import org.sopt.bofit.global.file.dto.request.UpdateImageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import static org.sopt.bofit.global.exception.constant.PostErrorCode.POST_IMAGE_MISMATCH;
-import static org.sopt.bofit.global.exception.constant.PostErrorCode.POST_UNAUTHORIZED;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/org/sopt/bofit/domain/post/service/PostWriter.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/PostWriter.java
@@ -64,7 +64,7 @@ public class PostWriter {
                                           List<NewImageRequest> newImages, List<UpdateImageRequest> updateImages,
                                           List<Long> deleteImageIds) {
         User user = userReader.getActiveById(userId);
-        Post post = postReader.findById(postId);
+        Post post = postReader.getActiveById(postId);
 
         post.getUser().checkIsWriter(userId, POST_UNAUTHORIZED);
         post.updateTitleAndContent(newTitle, newContent);
@@ -155,7 +155,7 @@ public class PostWriter {
     @Transactional
     public void deletePost(Long userId, Long postId) {
         User user = userReader.getActiveById(userId);
-        Post post = postReader.findById(postId);
+        Post post = postReader.getActiveById(postId);
         post.getUser().checkIsWriter(userId, POST_UNAUTHORIZED);
 
         postRepository.deletePostByPostId(postId);

--- a/src/main/java/org/sopt/bofit/domain/user/repository/UserRepository.java
+++ b/src/main/java/org/sopt/bofit/domain/user/repository/UserRepository.java
@@ -1,10 +1,11 @@
 package org.sopt.bofit.domain.user.repository;
 
-import org.sopt.bofit.domain.user.entity.User;
-import org.springframework.data.jpa.repository.JpaRepository;
-
 import java.util.Optional;
+import org.sopt.bofit.domain.user.entity.User;
+import org.sopt.bofit.domain.user.entity.constant.UserStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository  extends JpaRepository<User, Long> {
     Optional<User> findByOauthId(String oauthId);
+    Optional<User> findByIdAndStatus(Long id, UserStatus userStatus);
 }

--- a/src/main/java/org/sopt/bofit/domain/user/service/UserReader.java
+++ b/src/main/java/org/sopt/bofit/domain/user/service/UserReader.java
@@ -1,5 +1,7 @@
 package org.sopt.bofit.domain.user.service;
 
+import static org.sopt.bofit.global.exception.constant.UserErrorCode.USER_NOT_FOUND;
+
 import lombok.RequiredArgsConstructor;
 import org.sopt.bofit.domain.comment.repository.CommentRepository;
 import org.sopt.bofit.domain.post.repository.PostRepository;
@@ -7,13 +9,12 @@ import org.sopt.bofit.domain.user.dto.response.MyCommentSummaryResponse;
 import org.sopt.bofit.domain.user.dto.response.MyPostSummaryResponse;
 import org.sopt.bofit.domain.user.dto.response.UserProfileResponse;
 import org.sopt.bofit.domain.user.entity.User;
+import org.sopt.bofit.domain.user.entity.constant.UserStatus;
 import org.sopt.bofit.domain.user.repository.UserRepository;
 import org.sopt.bofit.global.dto.response.SliceResponse;
 import org.sopt.bofit.global.exception.customexception.NotFoundException;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
-
-import static org.sopt.bofit.global.exception.constant.UserErrorCode.USER_NOT_FOUND;
 
 @Service
 @RequiredArgsConstructor
@@ -44,6 +45,11 @@ public class UserReader {
 
     public User findById(Long userId) {
         return userRepository.findById(userId).orElseThrow(() -> new NotFoundException(USER_NOT_FOUND));
+    }
+
+    public User getActiveById(Long userId) {
+        return userRepository.findByIdAndStatus(userId, UserStatus.ACTIVE)
+            .orElseThrow(() -> new NotFoundException(USER_NOT_FOUND));
     }
 
     public SliceResponse<MyCommentSummaryResponse, Long> getMyComments(Long userId, Long cursorId, int size) {

--- a/src/main/java/org/sopt/bofit/global/config/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/org/sopt/bofit/global/config/swagger/SwaggerResponseDescription.java
@@ -1,23 +1,34 @@
 package org.sopt.bofit.global.config.swagger;
 
-import lombok.Getter;
-import org.sopt.bofit.global.exception.constant.ErrorCode;
-import org.sopt.bofit.global.exception.constant.GlobalErrorCode;
-
-import java.util.LinkedHashSet;
-import java.util.Set;
-
 import static org.sopt.bofit.domain.insurancereport.errorcode.InsuranceReportErrorCode.INVALID_REPORT_SECTION;
 import static org.sopt.bofit.domain.insurancereport.errorcode.InsuranceReportErrorCode.NOT_FOUND_INSURANCE_REPORT;
 import static org.sopt.bofit.global.exception.constant.CommentErrorCode.COMMENT_ALREADY_DELETED;
 import static org.sopt.bofit.global.exception.constant.CommentErrorCode.COMMENT_NOT_FOUND;
+import static org.sopt.bofit.global.exception.constant.CommentErrorCode.UNMATCHED_COMMENT_POST;
 import static org.sopt.bofit.global.exception.constant.InsuranceErrorCode.NOT_FOUND_INSURANCE_TOTAL_AVERAGE;
 import static org.sopt.bofit.global.exception.constant.InsuranceErrorCode.NOT_FOUND_RECOMMENDED_STATUS_INSURANCE;
-import static org.sopt.bofit.global.exception.constant.OAuthErrorCode.*;
-import static org.sopt.bofit.global.exception.constant.PostErrorCode.*;
+import static org.sopt.bofit.global.exception.constant.OAuthErrorCode.JWT_REFRESH_NOT_FOUND;
+import static org.sopt.bofit.global.exception.constant.OAuthErrorCode.JWT_REFRESH_TOKEN_MISMATCH;
+import static org.sopt.bofit.global.exception.constant.OAuthErrorCode.KAKAO_TOKEN_REQUEST_FAILED;
+import static org.sopt.bofit.global.exception.constant.OAuthErrorCode.KAKAO_USER_INFO_REQUEST_FAILED;
+import static org.sopt.bofit.global.exception.constant.PostErrorCode.POST_CONTENT_BLANK;
+import static org.sopt.bofit.global.exception.constant.PostErrorCode.POST_CONTENT_LONG;
+import static org.sopt.bofit.global.exception.constant.PostErrorCode.POST_IMAGE_MISMATCH;
+import static org.sopt.bofit.global.exception.constant.PostErrorCode.POST_LIKE_CREATE_CONFLICT;
+import static org.sopt.bofit.global.exception.constant.PostErrorCode.POST_LIKE_NOT_FOUND;
+import static org.sopt.bofit.global.exception.constant.PostErrorCode.POST_NOT_FOUND;
+import static org.sopt.bofit.global.exception.constant.PostErrorCode.POST_TITLE_BLANK;
+import static org.sopt.bofit.global.exception.constant.PostErrorCode.POST_TITLE_LONG;
+import static org.sopt.bofit.global.exception.constant.PostErrorCode.POST_UNAUTHORIZED;
 import static org.sopt.bofit.global.exception.constant.S3ErrorCode.UNSUPPORTED_IMAGE_TYPE;
 import static org.sopt.bofit.global.exception.constant.S3ErrorCode.UNSUPPORTED_MEDIA_TYPE;
 import static org.sopt.bofit.global.exception.constant.UserErrorCode.USER_NOT_FOUND;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+import lombok.Getter;
+import org.sopt.bofit.global.exception.constant.ErrorCode;
+import org.sopt.bofit.global.exception.constant.GlobalErrorCode;
 
 
 @Getter
@@ -98,6 +109,12 @@ public enum SwaggerResponseDescription {
     UPLOAD_IMAGE(new LinkedHashSet<>(Set.of(
             UNSUPPORTED_MEDIA_TYPE,
             UNSUPPORTED_IMAGE_TYPE
+    ))),
+    CREATE_COMMENT_REPLY(new LinkedHashSet<>(Set.of(
+        USER_NOT_FOUND,
+        COMMENT_NOT_FOUND,
+        POST_NOT_FOUND,
+        UNMATCHED_COMMENT_POST
     )))
     ;
     private final Set<ErrorCode> errorCodeList;

--- a/src/main/java/org/sopt/bofit/global/file/constant/ContentTypeConstants.java
+++ b/src/main/java/org/sopt/bofit/global/file/constant/ContentTypeConstants.java
@@ -1,12 +1,11 @@
-package org.sopt.bofit.global.s3.constant;
+package org.sopt.bofit.global.file.constant;
 
+import static org.sopt.bofit.global.exception.constant.S3ErrorCode.UNSUPPORTED_MEDIA_TYPE;
+
+import java.util.Arrays;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.sopt.bofit.global.exception.customexception.BadRequestException;
-
-import java.util.Arrays;
-
-import static org.sopt.bofit.global.exception.constant.S3ErrorCode.UNSUPPORTED_MEDIA_TYPE;
 
 @Getter
 @AllArgsConstructor

--- a/src/main/java/org/sopt/bofit/global/file/constant/ImageConstant.java
+++ b/src/main/java/org/sopt/bofit/global/file/constant/ImageConstant.java
@@ -1,0 +1,11 @@
+package org.sopt.bofit.global.file.constant;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ImageConstant {
+
+    public final static int MAX_IMAGE_URL_LENGTH = 3000;
+
+}

--- a/src/main/java/org/sopt/bofit/global/file/controller/FileController.java
+++ b/src/main/java/org/sopt/bofit/global/file/controller/FileController.java
@@ -1,19 +1,19 @@
-package org.sopt.bofit.global.s3.controller;
+package org.sopt.bofit.global.file.controller;
+
+import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.UPLOAD_IMAGE;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.sopt.bofit.global.annotation.CustomExceptionDescription;
 import org.sopt.bofit.global.dto.response.BaseResponse;
-import org.sopt.bofit.global.s3.dto.request.PresignedUrlRequest;
-import org.sopt.bofit.global.s3.dto.response.PresignedUrlResponse;
-import org.sopt.bofit.global.s3.service.FileService;
+import org.sopt.bofit.global.file.dto.request.PresignedUrlRequest;
+import org.sopt.bofit.global.file.dto.response.PresignedUrlResponse;
+import org.sopt.bofit.global.file.service.FileService;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.UPLOAD_IMAGE;
 
 @RestController
 @RequiredArgsConstructor

--- a/src/main/java/org/sopt/bofit/global/file/dto/request/NewImageRequest.java
+++ b/src/main/java/org/sopt/bofit/global/file/dto/request/NewImageRequest.java
@@ -9,7 +9,7 @@ import org.hibernate.validator.constraints.Length;
 
 public record NewImageRequest(
         @Schema(description = "이미지 URL")
-        @Length(max = MAX_IMAGE_URL_LENGTH, message = "이미지 url 의 최대 길이를 초과했습니다.")
+        @Length(max = MAX_IMAGE_URL_LENGTH, message = "이미지 url 의 최대 길이 ({max}) 를 초과했습니다.")
         @NotBlank
         String imageUrl,
 

--- a/src/main/java/org/sopt/bofit/global/file/dto/request/NewImageRequest.java
+++ b/src/main/java/org/sopt/bofit/global/file/dto/request/NewImageRequest.java
@@ -1,4 +1,4 @@
-package org.sopt.bofit.domain.post.dto.request;
+package org.sopt.bofit.global.file.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;

--- a/src/main/java/org/sopt/bofit/global/file/dto/request/NewImageRequest.java
+++ b/src/main/java/org/sopt/bofit/global/file/dto/request/NewImageRequest.java
@@ -1,11 +1,15 @@
 package org.sopt.bofit.global.file.dto.request;
 
+import static org.sopt.bofit.global.file.constant.ImageConstant.MAX_IMAGE_URL_LENGTH;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Positive;
+import org.hibernate.validator.constraints.Length;
 
 public record NewImageRequest(
         @Schema(description = "이미지 URL")
+        @Length(max = MAX_IMAGE_URL_LENGTH, message = "이미지 url 의 최대 길이를 초과했습니다.")
         @NotBlank
         String imageUrl,
 

--- a/src/main/java/org/sopt/bofit/global/file/dto/request/PresignedUrlRequest.java
+++ b/src/main/java/org/sopt/bofit/global/file/dto/request/PresignedUrlRequest.java
@@ -1,7 +1,6 @@
-package org.sopt.bofit.global.s3.dto.request;
+package org.sopt.bofit.global.file.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import java.util.List;
 
 public record PresignedUrlRequest(

--- a/src/main/java/org/sopt/bofit/global/file/dto/request/UpdateImageRequest.java
+++ b/src/main/java/org/sopt/bofit/global/file/dto/request/UpdateImageRequest.java
@@ -1,4 +1,4 @@
-package org.sopt.bofit.domain.post.dto.request;
+package org.sopt.bofit.global.file.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;

--- a/src/main/java/org/sopt/bofit/global/file/dto/request/UpdateImageRequest.java
+++ b/src/main/java/org/sopt/bofit/global/file/dto/request/UpdateImageRequest.java
@@ -12,7 +12,7 @@ public record UpdateImageRequest(
         @NotNull
         Long id,
 
-        @Length(max = MAX_IMAGE_URL_LENGTH, message = "이미지 url 의 최대 길이를 초과했습니다.")
+        @Length(max = MAX_IMAGE_URL_LENGTH, message = "이미지 url 의 최대 길이 ({max}) 를 초과했습니다.")
         @Schema(description = "새 이미지 URL (변경 없으면 null)")
         String newImageUrl,
 

--- a/src/main/java/org/sopt/bofit/global/file/dto/request/UpdateImageRequest.java
+++ b/src/main/java/org/sopt/bofit/global/file/dto/request/UpdateImageRequest.java
@@ -1,14 +1,18 @@
 package org.sopt.bofit.global.file.dto.request;
 
+import static org.sopt.bofit.global.file.constant.ImageConstant.MAX_IMAGE_URL_LENGTH;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
+import org.hibernate.validator.constraints.Length;
 
 public record UpdateImageRequest(
         @Schema(description = "수정할 이미지 ID")
         @NotNull
         Long id,
 
+        @Length(max = MAX_IMAGE_URL_LENGTH, message = "이미지 url 의 최대 길이를 초과했습니다.")
         @Schema(description = "새 이미지 URL (변경 없으면 null)")
         String newImageUrl,
 

--- a/src/main/java/org/sopt/bofit/global/file/dto/response/PresignedUrlResponse.java
+++ b/src/main/java/org/sopt/bofit/global/file/dto/response/PresignedUrlResponse.java
@@ -1,4 +1,4 @@
-package org.sopt.bofit.global.s3.dto.response;
+package org.sopt.bofit.global.file.dto.response;
 
 import java.util.List;
 

--- a/src/main/java/org/sopt/bofit/global/file/service/FileService.java
+++ b/src/main/java/org/sopt/bofit/global/file/service/FileService.java
@@ -1,14 +1,13 @@
-package org.sopt.bofit.global.s3.service;
-
-import lombok.RequiredArgsConstructor;
-import org.sopt.bofit.global.s3.constant.ContentTypeConstants;
-import org.sopt.bofit.global.s3.dto.response.PresignedUrlResponse;
-import org.sopt.bofit.global.s3.util.ContentTypeUtil;
-import org.sopt.bofit.global.s3.util.KeyGenerator;
-import org.sopt.bofit.global.s3.util.PresignedUrlCreator;
-import org.springframework.stereotype.Service;
+package org.sopt.bofit.global.file.service;
 
 import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.sopt.bofit.global.file.constant.ContentTypeConstants;
+import org.sopt.bofit.global.file.dto.response.PresignedUrlResponse;
+import org.sopt.bofit.global.file.util.ContentTypeUtil;
+import org.sopt.bofit.global.file.util.KeyGenerator;
+import org.sopt.bofit.global.file.util.PresignedUrlCreator;
+import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/org/sopt/bofit/global/file/util/ContentTypeUtil.java
+++ b/src/main/java/org/sopt/bofit/global/file/util/ContentTypeUtil.java
@@ -1,13 +1,12 @@
-package org.sopt.bofit.global.s3.util;
-
-import org.sopt.bofit.global.exception.customexception.BadRequestException;
-import org.sopt.bofit.global.s3.constant.ContentTypeConstants;
-
-import java.util.Locale;
-import java.util.Set;
+package org.sopt.bofit.global.file.util;
 
 import static org.sopt.bofit.global.exception.constant.S3ErrorCode.UNSUPPORTED_IMAGE_TYPE;
 import static org.sopt.bofit.global.exception.constant.S3ErrorCode.UNSUPPORTED_MEDIA_TYPE;
+
+import java.util.Locale;
+import java.util.Set;
+import org.sopt.bofit.global.exception.customexception.BadRequestException;
+import org.sopt.bofit.global.file.constant.ContentTypeConstants;
 
 public class ContentTypeUtil {
     private static final Set<String> ALLOWED_IMAGES = Set.of(

--- a/src/main/java/org/sopt/bofit/global/file/util/KeyGenerator.java
+++ b/src/main/java/org/sopt/bofit/global/file/util/KeyGenerator.java
@@ -1,9 +1,8 @@
-package org.sopt.bofit.global.s3.util;
-
-import org.sopt.bofit.global.s3.constant.ContentTypeConstants;
-import org.springframework.stereotype.Component;
+package org.sopt.bofit.global.file.util;
 
 import java.util.UUID;
+import org.sopt.bofit.global.file.constant.ContentTypeConstants;
+import org.springframework.stereotype.Component;
 
 @Component
 public class KeyGenerator {

--- a/src/main/java/org/sopt/bofit/global/file/util/PresignedUrlCreator.java
+++ b/src/main/java/org/sopt/bofit/global/file/util/PresignedUrlCreator.java
@@ -1,13 +1,12 @@
-package org.sopt.bofit.global.s3.util;
+package org.sopt.bofit.global.file.util;
 
+import java.time.Duration;
 import lombok.RequiredArgsConstructor;
 import org.sopt.bofit.global.config.S3Config;
 import org.springframework.stereotype.Component;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
-
-import java.time.Duration;
 
 @Component
 @RequiredArgsConstructor


### PR DESCRIPTION
## Related issue 🛠
- closed #136   


## Work Description 📝
- Reply 엔티티 작성 
- 대댓글 작성 API 구현
- 댓글 작성 시 이미지 추가
- 댓글 작성 및 대댓글 작성 시 Dto를 Presentation Layer, Service Layer를 분리하도록 작성했습니다.

## Uncompleted Tasks 😅

## To Reviewers 📢
- 확장성을 위해 Dto에 image를 List 타입으로 받을지를 고민중입니다.
