### PR TITLE
[Feat] 게시물 생성 시 카테고리 지정 기능 구현

### DIFF
--- a/src/main/java/org/sopt/bofit/domain/post/controller/PostController.java
+++ b/src/main/java/org/sopt/bofit/domain/post/controller/PostController.java
@@ -1,24 +1,9 @@
 package org.sopt.bofit.domain.post.controller;
 
-import static org.sopt.bofit.domain.comment.constant.CommentConstant.COMMENTS_DEFAULT_SIZE;
-import static org.sopt.bofit.domain.post.constant.PostConstant.POSTS_DEFAULT_SIZE;
-import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.CREATE_COMMENT;
-import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.CREATE_COMMENT_REPLY;
-import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.CREATE_POST;
-import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.CREATE_POST_LIKE;
-import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.DELETE_COMMENT;
-import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.DELETE_POST;
-import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.DELETE_POST_LIKE;
-import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.POST_DETAIL;
-import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.UPDATE_POST;
-import static org.sopt.bofit.global.constant.SwaggerConstant.TAG_DESCRIPTION_COMMUNITY;
-import static org.sopt.bofit.global.constant.SwaggerConstant.TAG_NAME_COMMUNITY;
-
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.sopt.bofit.domain.comment.dto.request.CommentCreateRequest;
 import org.sopt.bofit.domain.comment.dto.response.CommentResponse;
@@ -36,15 +21,15 @@ import org.sopt.bofit.global.annotation.CustomExceptionDescription;
 import org.sopt.bofit.global.annotation.LoginUserId;
 import org.sopt.bofit.global.dto.response.BaseResponse;
 import org.sopt.bofit.global.dto.response.SliceResponse;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Optional;
+
+import static org.sopt.bofit.domain.comment.constant.CommentConstant.COMMENTS_DEFAULT_SIZE;
+import static org.sopt.bofit.domain.post.constant.PostConstant.POSTS_DEFAULT_SIZE;
+import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.*;
+import static org.sopt.bofit.global.constant.SwaggerConstant.TAG_DESCRIPTION_COMMUNITY;
+import static org.sopt.bofit.global.constant.SwaggerConstant.TAG_NAME_COMMUNITY;
 
 @RestController
 @RequiredArgsConstructor
@@ -64,7 +49,7 @@ public class PostController {
             @RequestBody @Valid PostCreateRequest request,
             @Parameter(hidden = true) @LoginUserId Long userId
     ){
-        return BaseResponse.create(postService.createPost(userId, request.title(), request.content(), request.imageUrls()),"게시물 생성 완료");
+        return BaseResponse.create(postService.createPost(userId, request.title(), request.content(),request.category(), request.imageUrls()),"게시물 생성 완료");
     }
 
     @Tag(name = TAG_NAME_COMMUNITY, description = TAG_DESCRIPTION_COMMUNITY)

--- a/src/main/java/org/sopt/bofit/domain/post/controller/PostController.java
+++ b/src/main/java/org/sopt/bofit/domain/post/controller/PostController.java
@@ -61,8 +61,7 @@ public class PostController {
             @Parameter(hidden = true) @LoginUserId Long userId,
             @PathVariable(name = "post-id") Long postId
     ){
-        return BaseResponse.ok(postService.updatePost(userId, postId, request.newTitle(), request.newContent(), request.newCategory(), request.newImages(),
-                request.updateImages(), request.deleteImageIds()),"게시물 수정 완료");
+        return BaseResponse.ok(postService.updatePost(userId, postId, request.toCommand()),"게시물 수정 완료");
     }
 
     @Tag(name = TAG_NAME_COMMUNITY, description = TAG_DESCRIPTION_COMMUNITY)

--- a/src/main/java/org/sopt/bofit/domain/post/controller/PostController.java
+++ b/src/main/java/org/sopt/bofit/domain/post/controller/PostController.java
@@ -61,7 +61,7 @@ public class PostController {
             @Parameter(hidden = true) @LoginUserId Long userId,
             @PathVariable(name = "post-id") Long postId
     ){
-        return BaseResponse.ok(postService.updatePost(userId, postId, request.newTitle(), request.newContent(), request.newImages(),
+        return BaseResponse.ok(postService.updatePost(userId, postId, request.newTitle(), request.newContent(), request.newCategory(), request.newImages(),
                 request.updateImages(), request.deleteImageIds()),"게시물 수정 완료");
     }
 

--- a/src/main/java/org/sopt/bofit/domain/post/dto/request/PostCreateRequest.java
+++ b/src/main/java/org/sopt/bofit/domain/post/dto/request/PostCreateRequest.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import org.hibernate.validator.constraints.Length;
 import org.sopt.bofit.domain.post.entity.constant.PostInfoConstant;
+import org.sopt.bofit.global.annotation.ValidPostCategory;
 
 import java.util.List;
 
@@ -17,6 +18,11 @@ public record PostCreateRequest(
         @NotBlank(message = "본문은 비어있을 수 없습니다.")
         @Length(max = PostInfoConstant.MAX_CONTENT_LENGTH, message = "내용은 {max}자 미만으로 작성해주세요.")
         String content,
+
+        @Schema(description = "카테고리", example = "QNA")
+        @NotBlank(message = "카테고리는 비어있을 수 없습니다.")
+        @ValidPostCategory
+        String category,
 
         @Schema(description = "이미지 url")
         List<String> imageUrls

--- a/src/main/java/org/sopt/bofit/domain/post/dto/request/PostUpdateRequest.java
+++ b/src/main/java/org/sopt/bofit/domain/post/dto/request/PostUpdateRequest.java
@@ -4,11 +4,13 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import java.util.List;
 import org.hibernate.validator.constraints.Length;
 import org.sopt.bofit.domain.post.entity.constant.PostInfoConstant;
+import org.sopt.bofit.global.annotation.ValidPostCategory;
 import org.sopt.bofit.global.file.dto.request.NewImageRequest;
 import org.sopt.bofit.global.file.dto.request.UpdateImageRequest;
+
+import java.util.List;
 
 public record PostUpdateRequest(
         @Schema(description = "제목", example = "ㅇㅇ")
@@ -20,6 +22,11 @@ public record PostUpdateRequest(
         @NotBlank(message = "본문은 비어있을 수 없습니다.")
         @Length(max = PostInfoConstant.MAX_CONTENT_LENGTH, message = "내용은 {max}자 미만으로 작성해주세요.")
         String newContent,
+
+        @Schema(description = "카테고리", example = "INFORMATION")
+        @NotBlank(message = "카테고리는 비어있을 수 없습니다.")
+        @ValidPostCategory
+        String newCategory,
 
         @Schema(description = "추가할 이미지 목록")
         @Valid

--- a/src/main/java/org/sopt/bofit/domain/post/dto/request/PostUpdateRequest.java
+++ b/src/main/java/org/sopt/bofit/domain/post/dto/request/PostUpdateRequest.java
@@ -6,6 +6,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import org.hibernate.validator.constraints.Length;
 import org.sopt.bofit.domain.post.entity.constant.PostInfoConstant;
+import org.sopt.bofit.domain.post.service.dto.request.PostUpdateCommand;
 import org.sopt.bofit.global.annotation.ValidPostCategory;
 import org.sopt.bofit.global.file.dto.request.NewImageRequest;
 import org.sopt.bofit.global.file.dto.request.UpdateImageRequest;
@@ -41,4 +42,7 @@ public record PostUpdateRequest(
         List<@NotNull Long> deleteImageIds
 
 ) {
+   public PostUpdateCommand toCommand(){
+        return new PostUpdateCommand(this.newTitle, this.newContent, this.newCategory, this.newImages, this.updateImages, this.deleteImageIds);
+   }
 }

--- a/src/main/java/org/sopt/bofit/domain/post/entity/Post.java
+++ b/src/main/java/org/sopt/bofit/domain/post/entity/Post.java
@@ -2,6 +2,7 @@ package org.sopt.bofit.domain.post.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.sopt.bofit.domain.post.entity.constant.PostCategory;
 import org.sopt.bofit.domain.post.entity.constant.PostStatus;
 import org.sopt.bofit.domain.user.entity.User;
 import org.sopt.bofit.global.entity.BaseEntity;
@@ -39,12 +40,17 @@ public class Post extends BaseEntity {
     @Column(nullable = false, columnDefinition = "BIGINT DEFAULT 0")
     private Long likeCount;
 
-    public static Post create(User user, String title, String content) {
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private PostCategory postCategory;
+
+    public static Post create(User user, String title, String content, String category) {
         return Post.builder()
                 .user(user)
                 .title(title)
                 .content(content)
                 .likeCount(0L)
+                .postCategory(Enum.valueOf(PostCategory.class, category))
                 .status(PostStatus.ACTIVE)
                 .build();
     }

--- a/src/main/java/org/sopt/bofit/domain/post/entity/Post.java
+++ b/src/main/java/org/sopt/bofit/domain/post/entity/Post.java
@@ -55,9 +55,10 @@ public class Post extends BaseEntity {
                 .build();
     }
 
-    public void updateTitleAndContent(String title, String content){
+    public void updatePost(String title, String content, String category){
         this.title = title;
         this.content = content;
+        this.postCategory = Enum.valueOf(PostCategory.class, category);
     }
 
     @Override

--- a/src/main/java/org/sopt/bofit/domain/post/entity/constant/PostCategory.java
+++ b/src/main/java/org/sopt/bofit/domain/post/entity/constant/PostCategory.java
@@ -1,0 +1,9 @@
+package org.sopt.bofit.domain.post.entity.constant;
+
+public enum PostCategory {
+    QNA,
+    INFORMATION,
+    CONVERSATION
+    ;
+
+}

--- a/src/main/java/org/sopt/bofit/domain/post/service/PostService.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/PostService.java
@@ -4,9 +4,8 @@ import lombok.RequiredArgsConstructor;
 import org.sopt.bofit.domain.post.dto.response.PostCreateResponse;
 import org.sopt.bofit.domain.post.dto.response.PostDetailResponse;
 import org.sopt.bofit.domain.post.dto.response.PostSummaryResponse;
+import org.sopt.bofit.domain.post.service.dto.request.PostUpdateCommand;
 import org.sopt.bofit.global.dto.response.SliceResponse;
-import org.sopt.bofit.global.file.dto.request.NewImageRequest;
-import org.sopt.bofit.global.file.dto.request.UpdateImageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -25,10 +24,8 @@ public class PostService {
     }
 
     @Transactional
-    public PostCreateResponse updatePost (Long userId, Long postId, String title, String content, String newCategory,
-                                          List<NewImageRequest> newImages, List<UpdateImageRequest> updateImages,
-                                          List<Long> deleteImageIds) {
-        return postWriter.updatePost(userId, postId, title, content, newCategory, newImages, updateImages, deleteImageIds);
+    public PostCreateResponse updatePost (Long userId, Long postId, PostUpdateCommand command) {
+        return postWriter.updatePost(userId, postId, command);
     }
 
     @Transactional

--- a/src/main/java/org/sopt/bofit/domain/post/service/PostService.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/PostService.java
@@ -1,6 +1,5 @@
 package org.sopt.bofit.domain.post.service;
 
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.sopt.bofit.domain.post.dto.response.PostCreateResponse;
 import org.sopt.bofit.domain.post.dto.response.PostDetailResponse;
@@ -11,6 +10,8 @@ import org.sopt.bofit.global.file.dto.request.UpdateImageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class PostService {
@@ -19,8 +20,8 @@ public class PostService {
 
     private final PostWriter postWriter;
 
-    public PostCreateResponse createPost(Long userId, String title, String content, List<String> imageUrls) {
-        return postWriter.createPost(userId, title, content, imageUrls);
+    public PostCreateResponse createPost(Long userId, String title, String content, String category, List<String> imageUrls) {
+        return postWriter.createPost(userId, title, content, category, imageUrls);
     }
 
     @Transactional

--- a/src/main/java/org/sopt/bofit/domain/post/service/PostService.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/PostService.java
@@ -25,10 +25,10 @@ public class PostService {
     }
 
     @Transactional
-    public PostCreateResponse updatePost (Long userId, Long postId, String title, String content,
+    public PostCreateResponse updatePost (Long userId, Long postId, String title, String content, String newCategory,
                                           List<NewImageRequest> newImages, List<UpdateImageRequest> updateImages,
                                           List<Long> deleteImageIds) {
-        return postWriter.updatePost(userId, postId, title, content, newImages, updateImages, deleteImageIds);
+        return postWriter.updatePost(userId, postId, title, content, newCategory, newImages, updateImages, deleteImageIds);
     }
 
     @Transactional

--- a/src/main/java/org/sopt/bofit/domain/post/service/PostWriter.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/PostWriter.java
@@ -1,12 +1,5 @@
 package org.sopt.bofit.domain.post.service;
 
-import static org.sopt.bofit.global.exception.constant.PostErrorCode.POST_IMAGE_MISMATCH;
-import static org.sopt.bofit.global.exception.constant.PostErrorCode.POST_UNAUTHORIZED;
-
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.sopt.bofit.domain.comment.entity.Comment;
 import org.sopt.bofit.domain.comment.entity.CommentStatus;
@@ -24,6 +17,14 @@ import org.sopt.bofit.global.file.dto.request.UpdateImageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.sopt.bofit.global.exception.constant.PostErrorCode.POST_IMAGE_MISMATCH;
+import static org.sopt.bofit.global.exception.constant.PostErrorCode.POST_UNAUTHORIZED;
+
 @Service
 @RequiredArgsConstructor
 public class PostWriter {
@@ -40,9 +41,9 @@ public class PostWriter {
 
 
     @Transactional
-    public PostCreateResponse createPost(Long userId, String title, String content, List<String> imageUrls) {
+    public PostCreateResponse createPost(Long userId, String title, String content, String category, List<String> imageUrls) {
         User user = userReader.getActiveById(userId);
-        Post newPost = Post.create(user, title, content);
+        Post newPost = Post.create(user, title, content, category);
         postRepository.save(newPost);
 
         int sequence = 1;

--- a/src/main/java/org/sopt/bofit/domain/post/service/PostWriter.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/PostWriter.java
@@ -9,6 +9,7 @@ import org.sopt.bofit.domain.post.entity.Post;
 import org.sopt.bofit.domain.post.entity.PostImage;
 import org.sopt.bofit.domain.post.repository.PostImageRepository;
 import org.sopt.bofit.domain.post.repository.PostRepository;
+import org.sopt.bofit.domain.post.service.dto.request.PostUpdateCommand;
 import org.sopt.bofit.domain.user.entity.User;
 import org.sopt.bofit.domain.user.service.UserReader;
 import org.sopt.bofit.global.exception.customexception.BadRequestException;
@@ -61,22 +62,20 @@ public class PostWriter {
     }
 
     @Transactional
-    public PostCreateResponse updatePost (Long userId, Long postId, String newTitle, String newContent, String newCategory,
-                                          List<NewImageRequest> newImages, List<UpdateImageRequest> updateImages,
-                                          List<Long> deleteImageIds) {
+    public PostCreateResponse updatePost (Long userId, Long postId, PostUpdateCommand command) {
         User user = userReader.getActiveById(userId);
         Post post = postReader.getActiveById(postId);
 
         post.getUser().checkIsWriter(userId, POST_UNAUTHORIZED);
-        post.updatePost(newTitle, newContent, newCategory);
+        post.updatePost(command.newTitle(), command.newContent(), command.newCategory());
 
         List<PostImage> currentImages = postImageRepository.findByPostIdOrderBySequenceAsc(postId);
 
-        deleteImages(postId, deleteImageIds, currentImages);
+        deleteImages(postId, command.deleteImageIds(), currentImages);
 
-        updateImages(updateImages, currentImages);
+        updateImages(command.updateImages(), currentImages);
 
-        addImages(newImages, currentImages, post);
+        addImages(command.newImages(), currentImages, post);
 
         int seq = 1;
         for(PostImage pi : currentImages) {

--- a/src/main/java/org/sopt/bofit/domain/post/service/PostWriter.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/PostWriter.java
@@ -61,14 +61,14 @@ public class PostWriter {
     }
 
     @Transactional
-    public PostCreateResponse updatePost (Long userId, Long postId, String newTitle, String newContent,
+    public PostCreateResponse updatePost (Long userId, Long postId, String newTitle, String newContent, String newCategory,
                                           List<NewImageRequest> newImages, List<UpdateImageRequest> updateImages,
                                           List<Long> deleteImageIds) {
         User user = userReader.getActiveById(userId);
         Post post = postReader.getActiveById(postId);
 
         post.getUser().checkIsWriter(userId, POST_UNAUTHORIZED);
-        post.updateTitleAndContent(newTitle, newContent);
+        post.updatePost(newTitle, newContent, newCategory);
 
         List<PostImage> currentImages = postImageRepository.findByPostIdOrderBySequenceAsc(postId);
 

--- a/src/main/java/org/sopt/bofit/domain/post/service/dto/request/PostUpdateCommand.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/dto/request/PostUpdateCommand.java
@@ -1,0 +1,16 @@
+package org.sopt.bofit.domain.post.service.dto.request;
+
+import org.sopt.bofit.global.file.dto.request.NewImageRequest;
+import org.sopt.bofit.global.file.dto.request.UpdateImageRequest;
+
+import java.util.List;
+
+public record PostUpdateCommand(
+        String newTitle,
+        String newContent,
+        String newCategory,
+        List<NewImageRequest> newImages,
+        List<UpdateImageRequest> updateImages,
+        List<Long> deleteImageIds
+) {
+}

--- a/src/main/java/org/sopt/bofit/domain/user/controller/UserController.java
+++ b/src/main/java/org/sopt/bofit/domain/user/controller/UserController.java
@@ -92,7 +92,7 @@ public class UserController {
     @Tag(name = TAG_NAME_USER_INFO, description = TAG_DESCRIPTION_USER_INFO)
     @CustomExceptionDescription(UPDATE_PROFILE_IMAGE)
     @Operation(summary = "유저 프로필 이미지 수정", description = "유저의 프로필 이미지를 수정합니다.")
-    @PatchMapping("profile_image")
+    @PatchMapping("profile-image")
     public BaseResponse<Void> updateProfileImage(
             @Parameter(hidden = true) @LoginUserId Long userId,
             UpdateProfileImageRequest req

--- a/src/main/java/org/sopt/bofit/global/annotation/ValidPostCategory.java
+++ b/src/main/java/org/sopt/bofit/global/annotation/ValidPostCategory.java
@@ -12,7 +12,7 @@ import java.lang.annotation.*;
 @Constraint(validatedBy = PostCategoryValidator.class)
 @Documented
 public @interface ValidPostCategory {
-    String message() default "게시물 카테고리는 QNA, CONVERSATION, INFORMATION 중에서 선택해주세요.";
+    String message() default "유효한 게시물 카테고리가 아닙니다.";
     Class<?>[] groups() default {};
     Class<? extends Payload>[] payload() default {};
 }

--- a/src/main/java/org/sopt/bofit/global/annotation/ValidPostCategory.java
+++ b/src/main/java/org/sopt/bofit/global/annotation/ValidPostCategory.java
@@ -1,0 +1,18 @@
+package org.sopt.bofit.global.annotation;
+
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import org.sopt.bofit.global.util.validator.PostCategoryValidator;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = PostCategoryValidator.class)
+@Documented
+public @interface ValidPostCategory {
+    String message() default "게시물 카테고리는 QNA, CONVERSATION, INFORMATION 중에서 선택해주세요.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/org/sopt/bofit/global/util/validator/PostCategoryValidator.java
+++ b/src/main/java/org/sopt/bofit/global/util/validator/PostCategoryValidator.java
@@ -1,0 +1,17 @@
+package org.sopt.bofit.global.util.validator;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import org.sopt.bofit.domain.post.entity.constant.PostCategory;
+import org.sopt.bofit.global.annotation.ValidPostCategory;
+
+import java.util.Arrays;
+
+public class PostCategoryValidator implements ConstraintValidator<ValidPostCategory, String> {
+
+    @Override
+    public boolean isValid(String category, ConstraintValidatorContext context) {
+        return Arrays.stream(PostCategory.values())
+                .anyMatch(postCategory -> postCategory.name().equalsIgnoreCase(category));
+    }
+}


### PR DESCRIPTION
## Related issue 🛠
- closed #144
  

## Work Description 📝
- 게시물 생성 시에 카테고리를 지정할 수 있도록 구현했습니다. Post 테이블에 Category 필드를 추가하고, 생성 시에 PostCategory Enum에 속하지 않는 값이 들어올 경우 예외처리할 수 있도록 검증을 DTO단에서 커스텀 어노테이션을 통해 수행하도록 했습니다.
- 게시물 수정 시에도 마찬가지로 카테고리를 새로 지정할 수 있도록 했습니다.
- 지난 번에 논의한 대로 Service 단에서 사용하는 DTO를 생성하여 분리하였습니다.
