### PR TITLE
[Feat] Full Text Search 이용한 게시물 검색 기능 구현

### DIFF
--- a/src/main/java/org/sopt/bofit/domain/comment/service/CommentService.java
+++ b/src/main/java/org/sopt/bofit/domain/comment/service/CommentService.java
@@ -17,6 +17,7 @@ import org.sopt.bofit.domain.comment.service.dto.request.CommentCreateCommand;
 import org.sopt.bofit.domain.comment.service.dto.request.CommentUpdateCommand;
 import org.sopt.bofit.domain.post.entity.Post;
 import org.sopt.bofit.domain.post.service.PostReader;
+import org.sopt.bofit.domain.post.service.PostWriter;
 import org.sopt.bofit.domain.user.entity.User;
 import org.sopt.bofit.domain.user.service.UserReader;
 import org.sopt.bofit.global.dto.response.SliceResponse;
@@ -27,11 +28,20 @@ import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.sopt.bofit.domain.comment.constant.CommentConstant.MAX_IMAGE_COUNT;
+import static org.sopt.bofit.global.exception.constant.CommentErrorCode.COMMENT_UNAUTHORIZED;
+
 
 @Service
 @RequiredArgsConstructor
 public class CommentService {
 	private final CommentReader commentReader;
+
 	private final CommentWriter commentWriter;
 
 	private final PostReader postReader;
@@ -40,6 +50,9 @@ public class CommentService {
 
 	private final CommentImageWriter commentImageWriter;
     private final CommentImageReader commentImageReader;
+
+	private final PostWriter postWriter;
+
 
 	@Transactional
 	public Comment createComment(Long userId, Long postId, CommentCreateCommand command){
@@ -51,6 +64,8 @@ public class CommentService {
         IntStream.range(0, command.imageUrls().size())
                 .forEach(sequence -> commentImageWriter
                     .create(comment, command.imageUrls().get(sequence), sequence + 1));
+
+		postWriter.increaseCommentCount(post);
 
 		return comment;
 	}
@@ -84,6 +99,8 @@ public class CommentService {
 
 		comment.getUser().checkIsWriter(userId, COMMENT_UNAUTHORIZED);
 		comment.checkPost(post);
+
+		postWriter.decreaseCommentCount(post);
 
 		commentWriter.softDelete(comment);
 	}

--- a/src/main/java/org/sopt/bofit/domain/post/controller/PostController.java
+++ b/src/main/java/org/sopt/bofit/domain/post/controller/PostController.java
@@ -98,9 +98,10 @@ public class PostController {
     @Operation(summary = "게시물 전체 조회", description = "커뮤니티에서 모든 글을 조회합니다.")
     @GetMapping()
     public BaseResponse<SliceResponse<PostSummaryResponse, Long>> getAllPosts(
+            @Parameter(hidden = true) @LoginUserId Long userId,
             @RequestParam(required = false, name = "cursor") Long cursorId,
             @RequestParam(required = false, defaultValue = POSTS_DEFAULT_SIZE) int size){
-        return BaseResponse.ok(postService.getAllPosts(cursorId, size), "게시물 전체 조회 성공");
+        return BaseResponse.ok(postService.getAllPosts(userId, cursorId, size), "게시물 전체 조회 성공");
     }
 
     @Tag(name = TAG_NAME_COMMUNITY, description = TAG_DESCRIPTION_COMMUNITY)
@@ -108,9 +109,10 @@ public class PostController {
     @CustomExceptionDescription(POST_DETAIL)
     @GetMapping("{post-id}")
     public BaseResponse<PostDetailResponse> getPostDetail(
-            @PathVariable(name = "post-id") Long postId
+            @PathVariable(name = "post-id") Long postId,
+             @Parameter(hidden = true) @LoginUserId Long userId
     ){
-        return BaseResponse.ok(postService.getPostDetail(postId),"글 상세 조회 성공");
+        return BaseResponse.ok(postService.getPostDetail(userId, postId),"글 상세 조회 성공");
     }
 
     @Tag(name = TAG_NAME_COMMUNITY, description = TAG_DESCRIPTION_COMMUNITY)
@@ -211,10 +213,11 @@ public class PostController {
     @GetMapping("search")
     public BaseResponse<SliceResponse<PostSummaryResponse, Long>> searchPosts(
             @RequestParam(name = "keyword") String keyword,
+            @Parameter(hidden = true) @LoginUserId Long userId,
             @RequestParam(required = false, name = "cursor") Long cursorId,
             @RequestParam(required = false, defaultValue = POSTS_DEFAULT_SIZE) int size
     ){
-        return BaseResponse.ok(postService.searchPosts(keyword, cursorId, size),"게시물 검색 성공");
+        return BaseResponse.ok(postService.searchPosts(userId, keyword, cursorId, size),"게시물 검색 성공");
     }
 
 }

--- a/src/main/java/org/sopt/bofit/domain/post/controller/PostController.java
+++ b/src/main/java/org/sopt/bofit/domain/post/controller/PostController.java
@@ -205,4 +205,16 @@ public class PostController {
         return BaseResponse.create("대댓글 작성 성공");
     }
 
+    @Tag(name = TAG_NAME_COMMUNITY, description = TAG_DESCRIPTION_COMMUNITY)
+    @Operation(summary = "게시물 검색", description = "검색 키워드를 기반으로 게시물을 검색합니다.")
+    @CustomExceptionDescription(DEFAULT)
+    @GetMapping("search")
+    public BaseResponse<SliceResponse<PostSummaryResponse, Long>> searchPosts(
+            @RequestParam(name = "keyword") String keyword,
+            @RequestParam(required = false, name = "cursor") Long cursorId,
+            @RequestParam(required = false, defaultValue = POSTS_DEFAULT_SIZE) int size
+    ){
+        return BaseResponse.ok(postService.searchPosts(keyword, cursorId, size),"게시물 검색 성공");
+    }
+
 }

--- a/src/main/java/org/sopt/bofit/domain/post/dto/response/PostDetailResponse.java
+++ b/src/main/java/org/sopt/bofit/domain/post/dto/response/PostDetailResponse.java
@@ -29,8 +29,16 @@ public record PostDetailResponse(
         @Schema(description = "생성 시간")
         LocalDateTime createdAt,
 
+        @Schema(description = "좋아요 수")
+        Long likeCount,
+
+        @Schema(description = "사용자 좋아요 여부")
+        boolean likedByCurrentUser,
+
         @Schema(description = "이미지 url")
         List<PostDetailImageResponse> imageUrl
+
+
 ) {
         public record PostDetailImageResponse(
                 @Schema(description = "이미지 ID")

--- a/src/main/java/org/sopt/bofit/domain/post/dto/response/PostSummaryResponse.java
+++ b/src/main/java/org/sopt/bofit/domain/post/dto/response/PostSummaryResponse.java
@@ -28,7 +28,13 @@ public record PostSummaryResponse (
         int commentCount,
 
         @Schema(description = "게시물 작성 시각")
-        LocalDateTime createdAt
+        LocalDateTime createdAt,
+
+        @Schema(description = "좋아요 수")
+        Long likeCount,
+
+        @Schema(description = "사용자의 좋아요 여부")
+        boolean likedByCurrentUser
 
 ) implements CursorProvider<Long>{
         @Override

--- a/src/main/java/org/sopt/bofit/domain/post/entity/Post.java
+++ b/src/main/java/org/sopt/bofit/domain/post/entity/Post.java
@@ -47,6 +47,9 @@ public class Post extends BaseEntity {
     @Column(nullable = false)
     private PostCategory postCategory;
 
+    @Column(nullable = false, columnDefinition = "BIGINT DEFAULT 0")
+    private int commentCount;
+
     public static Post create(User user, String title, String content, String category, String writerNickname) {
         return Post.builder()
                 .user(user)

--- a/src/main/java/org/sopt/bofit/domain/post/entity/Post.java
+++ b/src/main/java/org/sopt/bofit/domain/post/entity/Post.java
@@ -28,6 +28,9 @@ public class Post extends BaseEntity {
     @Column(nullable = false, length = 3000)
     private String content;
 
+    @Column(nullable = false)
+    private String writerNickname;
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     @Builder.Default
@@ -44,7 +47,7 @@ public class Post extends BaseEntity {
     @Column(nullable = false)
     private PostCategory postCategory;
 
-    public static Post create(User user, String title, String content, String category) {
+    public static Post create(User user, String title, String content, String category, String writerNickname) {
         return Post.builder()
                 .user(user)
                 .title(title)
@@ -52,6 +55,7 @@ public class Post extends BaseEntity {
                 .likeCount(0L)
                 .postCategory(Enum.valueOf(PostCategory.class, category))
                 .status(PostStatus.ACTIVE)
+                .writerNickname(writerNickname)
                 .build();
     }
 

--- a/src/main/java/org/sopt/bofit/domain/post/repository/PostCustomRepository.java
+++ b/src/main/java/org/sopt/bofit/domain/post/repository/PostCustomRepository.java
@@ -9,7 +9,7 @@ public interface PostCustomRepository {
 
     void deletePostByPostId(Long postId);
 
-    Slice<PostSummaryResponse> findAllByCursorId(Long cursorId, int size);
+    Slice<PostSummaryResponse> findAllByCursorId(Long userId, Long cursorId, int size);
 
-    Slice<PostSummaryResponse> findAllByKeywordAndCursorId(String keyword, Long cursorId, int size);
+    Slice<PostSummaryResponse> findAllByKeywordAndCursorId(Long userId, String keyword, Long cursorId, int size);
 }

--- a/src/main/java/org/sopt/bofit/domain/post/repository/PostCustomRepository.java
+++ b/src/main/java/org/sopt/bofit/domain/post/repository/PostCustomRepository.java
@@ -10,4 +10,6 @@ public interface PostCustomRepository {
     void deletePostByPostId(Long postId);
 
     Slice<PostSummaryResponse> findAllByCursorId(Long cursorId, int size);
+
+    Slice<PostSummaryResponse> findAllByKeywordAndCursorId(String keyword, Long cursorId, int size);
 }

--- a/src/main/java/org/sopt/bofit/domain/post/repository/PostCustomRepositoryImpl.java
+++ b/src/main/java/org/sopt/bofit/domain/post/repository/PostCustomRepositoryImpl.java
@@ -1,13 +1,15 @@
 package org.sopt.bofit.domain.post.repository;
 
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
-import org.sopt.bofit.domain.comment.entity.QComment;
 import org.sopt.bofit.domain.post.dto.response.PostSummaryResponse;
 import org.sopt.bofit.domain.post.entity.QPost;
+import org.sopt.bofit.domain.post.entity.QPostLike;
 import org.sopt.bofit.domain.post.entity.constant.PostStatus;
 import org.sopt.bofit.domain.user.dto.response.MyPostSummaryResponse;
 import org.springframework.data.domain.PageRequest;
@@ -27,7 +29,9 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
     @Override
     public Slice<MyPostSummaryResponse> findPostsByCursorId(Long userId, Long cursorId, int size) {
         QPost post = QPost.post;
-        QComment comment = QComment.comment;
+        QPostLike postLike = QPostLike.postLike;
+
+        BooleanExpression likedByCurrentUser = getLikedByCurrentUser(userId, postLike, post);
 
         List<MyPostSummaryResponse> content = queryFactory
                 .select(Projections.constructor(MyPostSummaryResponse.class,
@@ -35,7 +39,9 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
                         post.title,
                         post.content,
                         post.commentCount,
-                        post.createdAt
+                        post.createdAt,
+                        post.likeCount,
+                        likedByCurrentUser
                 ))
                 .from(post)
                 .where(
@@ -65,9 +71,11 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
     }
 
     @Override
-    public Slice<PostSummaryResponse> findAllByCursorId(Long cursorId, int size) {
+    public Slice<PostSummaryResponse> findAllByCursorId(Long userId, Long cursorId, int size) {
         QPost post = QPost.post;
-        QComment comment = QComment.comment;
+        QPostLike postLike = QPostLike.postLike;
+
+        BooleanExpression likedByCurrentUser = getLikedByCurrentUser(userId, postLike, post);
 
         List<PostSummaryResponse> content = queryFactory
                 .select(Projections.constructor(PostSummaryResponse.class,
@@ -78,7 +86,9 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
                         post.user.nickname,
                         post.user.profileImage,
                         post.commentCount,
-                        post.createdAt
+                        post.createdAt,
+                        post.likeCount,
+                        likedByCurrentUser
                 ))
                 .from(post)
                 .where(
@@ -95,10 +105,21 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
         return new SliceImpl<>(content, PageRequest.of(0, size), hasNext);
     }
 
+    private BooleanExpression getLikedByCurrentUser(Long userId, QPostLike postLike, QPost post) {
+        return JPAExpressions
+                .selectOne()
+                .from(postLike)
+                .where(postLike.post.eq(post),
+                        postLike.user.id.eq(userId))
+                .exists();
+    }
+
     @Override
-    public Slice<PostSummaryResponse> findAllByKeywordAndCursorId(String keyword, Long cursorId, int size) {
+    public Slice<PostSummaryResponse> findAllByKeywordAndCursorId(Long userId, String keyword, Long cursorId, int size) {
         QPost post = QPost.post;
-        QComment comment = QComment.comment;
+        QPostLike postLike = QPostLike.postLike;
+
+        BooleanExpression likedByCurrentUser = getLikedByCurrentUser(userId, postLike, post);
 
         NumberExpression<Double> relevanceScore = getRelevanceScore(keyword, post);
 
@@ -111,7 +132,9 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
                         post.user.nickname,
                         post.user.profileImage,
                         post.commentCount,
-                        post.createdAt
+                        post.createdAt,
+                        post.likeCount,
+                        likedByCurrentUser
                 ))
                 .from(post)
                 .where(relevanceScore.gt(0),

--- a/src/main/java/org/sopt/bofit/domain/post/repository/PostCustomRepositoryImpl.java
+++ b/src/main/java/org/sopt/bofit/domain/post/repository/PostCustomRepositoryImpl.java
@@ -5,7 +5,6 @@ import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
-import org.sopt.bofit.domain.comment.entity.CommentStatus;
 import org.sopt.bofit.domain.comment.entity.QComment;
 import org.sopt.bofit.domain.post.dto.response.PostSummaryResponse;
 import org.sopt.bofit.domain.post.entity.QPost;
@@ -35,17 +34,15 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
                         post.id,
                         post.title,
                         post.content,
-                        comment.id.count().intValue(),
+                        post.commentCount,
                         post.createdAt
                 ))
                 .from(post)
-                .leftJoin(comment).on(comment.post.eq(post), comment.status.eq(CommentStatus.ACTIVE))
                 .where(
                         post.user.id.eq(userId),
                         post.status.eq(PostStatus.ACTIVE),
                         cursorId != null ? post.id.lt(cursorId) : null
                 )
-                .groupBy(post.id)
                 .orderBy(post.id.desc())
                 .limit(size + 1)
                 .fetch();
@@ -80,16 +77,14 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
                         post.content,
                         post.user.nickname,
                         post.user.profileImage,
-                        comment.id.count().intValue(),
+                        post.commentCount,
                         post.createdAt
                 ))
                 .from(post)
-                .leftJoin(comment).on(comment.post.eq(post), comment.status.eq(CommentStatus.ACTIVE))
                 .where(
                         post.status.eq(PostStatus.ACTIVE),
                         cursorId != null ? post.id.lt(cursorId) : null
                 )
-                .groupBy(post.id)
                 .orderBy(post.id.desc())
                 .limit(size + 1)
                 .fetch();
@@ -115,16 +110,14 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
                         post.content,
                         post.user.nickname,
                         post.user.profileImage,
-                        comment.id.count().intValue(),
+                        post.commentCount,
                         post.createdAt
                 ))
                 .from(post)
-                .leftJoin(comment).on(comment.post.eq(post), comment.status.eq(CommentStatus.ACTIVE))
                 .where(relevanceScore.gt(0),
                         post.status.eq(PostStatus.ACTIVE),
                         cursorId != null ? post.id.lt(cursorId) : null
                         )
-                .groupBy(post.id)
                 .orderBy(relevanceScore.desc())
                 .limit(size + 1)
                 .fetch();

--- a/src/main/java/org/sopt/bofit/domain/post/repository/PostCustomRepositoryImpl.java
+++ b/src/main/java/org/sopt/bofit/domain/post/repository/PostCustomRepositoryImpl.java
@@ -1,6 +1,8 @@
 package org.sopt.bofit.domain.post.repository;
 
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.sopt.bofit.domain.comment.entity.CommentStatus;
@@ -97,5 +99,48 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
 
         return new SliceImpl<>(content, PageRequest.of(0, size), hasNext);
     }
+
+    @Override
+    public Slice<PostSummaryResponse> findAllByKeywordAndCursorId(String keyword, Long cursorId, int size) {
+        QPost post = QPost.post;
+        QComment comment = QComment.comment;
+
+        NumberExpression<Double> relevanceScore = getFullTextTemplate(keyword, post);
+
+        List<PostSummaryResponse> content = queryFactory
+                .select(Projections.constructor(PostSummaryResponse.class,
+                        post.id,
+                        post.user.id,
+                        post.title,
+                        post.content,
+                        post.user.nickname,
+                        post.user.profileImage,
+                        comment.id.count().intValue(),
+                        post.createdAt
+                ))
+                .from(post)
+                .leftJoin(comment).on(comment.post.eq(post), comment.status.eq(CommentStatus.ACTIVE))
+                .where(relevanceScore.gt(0),
+                        post.status.eq(PostStatus.ACTIVE),
+                        cursorId != null ? post.id.lt(cursorId) : null
+                        )
+                .groupBy(post.id)
+                .orderBy(relevanceScore.desc())
+                .limit(size + 1)
+                .fetch();
+
+        boolean hasNext = content.size() > size;
+        if (hasNext) content.remove(size);
+
+        return new SliceImpl<>(content, PageRequest.of(0, size), hasNext);
+    }
+
+    private NumberExpression<Double> getFullTextTemplate(String keyword, QPost post) {
+        return Expressions.numberTemplate(Double.class,
+                "function('match_language_mode',{0},{1},{2},{3})",
+                post.title, post.content, post.writerNickname, keyword
+        );
+    }
+
 }
 

--- a/src/main/java/org/sopt/bofit/domain/post/repository/PostCustomRepositoryImpl.java
+++ b/src/main/java/org/sopt/bofit/domain/post/repository/PostCustomRepositoryImpl.java
@@ -105,7 +105,7 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
         QPost post = QPost.post;
         QComment comment = QComment.comment;
 
-        NumberExpression<Double> relevanceScore = getFullTextTemplate(keyword, post);
+        NumberExpression<Double> relevanceScore = getRelevanceScore(keyword, post);
 
         List<PostSummaryResponse> content = queryFactory
                 .select(Projections.constructor(PostSummaryResponse.class,
@@ -135,7 +135,7 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
         return new SliceImpl<>(content, PageRequest.of(0, size), hasNext);
     }
 
-    private NumberExpression<Double> getFullTextTemplate(String keyword, QPost post) {
+    private NumberExpression<Double> getRelevanceScore(String keyword, QPost post) {
         return Expressions.numberTemplate(Double.class,
                 "function('match_language_mode',{0},{1},{2},{3})",
                 post.title, post.content, post.writerNickname, keyword

--- a/src/main/java/org/sopt/bofit/domain/post/repository/PostRepository.java
+++ b/src/main/java/org/sopt/bofit/domain/post/repository/PostRepository.java
@@ -24,4 +24,14 @@ public interface PostRepository extends PostJpaRepository, PostCustomRepository{
         WHERE p = :requestPost
         """)
     void decreaseLikeCount(@Param("requestPost") Post post);
+
+    @Modifying
+    @Query("""
+        UPDATE Post p
+        SET p.writerNickname = :writerNickname
+        WHERE p.user.id = :userId""")
+    void updateWriterNicknameByUserId(@Param("writerNickname") String writerNickname,
+                                      @Param("userId") Long userId
+    );
+
 }

--- a/src/main/java/org/sopt/bofit/domain/post/repository/PostRepository.java
+++ b/src/main/java/org/sopt/bofit/domain/post/repository/PostRepository.java
@@ -34,4 +34,22 @@ public interface PostRepository extends PostJpaRepository, PostCustomRepository{
                                       @Param("userId") Long userId
     );
 
+    @Modifying
+    @Query("""
+        UPDATE Post p
+        SET p.commentCount = p.commentCount + 1
+        WHERE p = :requestPost
+        """
+    )
+    void increaseCommentCount(@Param("requestPost") Post post);
+
+    @Modifying
+    @Query("""
+        UPDATE Post p
+        SET p.commentCount = p.commentCount - 1
+        WHERE p = :requestPost
+        """
+    )
+    void decreaseCommentCount(@Param("requestPost") Post post);
+
 }

--- a/src/main/java/org/sopt/bofit/domain/post/repository/PostRepository.java
+++ b/src/main/java/org/sopt/bofit/domain/post/repository/PostRepository.java
@@ -1,6 +1,7 @@
 package org.sopt.bofit.domain.post.repository;
 
 import org.sopt.bofit.domain.post.entity.Post;
+import org.sopt.bofit.domain.user.entity.User;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -52,4 +53,5 @@ public interface PostRepository extends PostJpaRepository, PostCustomRepository{
     )
     void decreaseCommentCount(@Param("requestPost") Post post);
 
+    boolean existsByIdAndUser(Long postId, User user);
 }

--- a/src/main/java/org/sopt/bofit/domain/post/service/PostReader.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/PostReader.java
@@ -75,4 +75,10 @@ public class PostReader {
         return postRepository.findByIdAndStatus(postId, PostStatus.ACTIVE)
             .orElseThrow(() -> new NotFoundException(POST_NOT_FOUND));
     }
+
+    public SliceResponse<PostSummaryResponse, Long> findPostsByKeywordAndCursorId(String keyword, Long cursorId, int size) {
+        Slice<PostSummaryResponse> postList = postRepository.findAllByKeywordAndCursorId(keyword, cursorId, size);
+
+        return SliceResponse.from(postList);
+    }
 }

--- a/src/main/java/org/sopt/bofit/domain/post/service/PostReader.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/PostReader.java
@@ -32,15 +32,15 @@ public class PostReader {
 
     private final PostImageRepository postImageRepository;
 
-    public SliceResponse<PostSummaryResponse, Long> getAllPosts(Long cursorId, int size){
+    public SliceResponse<PostSummaryResponse, Long> getAllPosts(Long userId, Long cursorId, int size){
 
-        Slice<PostSummaryResponse> postList = postRepository.findAllByCursorId(cursorId, size);
+        Slice<PostSummaryResponse> postList = postRepository.findAllByCursorId(userId, cursorId, size);
 
         return SliceResponse.from(postList);
     }
 
     @Transactional(readOnly = true)
-    public PostDetailResponse getPostById(Long postId) {
+    public PostDetailResponse getPostById(Long userId, Long postId) {
         Post post = getActiveById(postId);
         User writer = post.getUser();
 
@@ -50,7 +50,7 @@ public class PostReader {
                 .map(image -> new PostDetailImageResponse(image.getId(), image.getImageUrl()))
                 .toList();
 
-
+        boolean isLike = postRepository.existsByIdAndUser(postId, writer);
 
         long postCommentCount = activeComments.size();
 
@@ -63,6 +63,8 @@ public class PostReader {
                 .commentCount(postCommentCount)
                 .createdAt(post.getCreatedAt())
                 .imageUrl(imageUrls)
+                .likeCount(post.getLikeCount())
+                .likedByCurrentUser(isLike)
                 .build();
 
     }
@@ -76,8 +78,8 @@ public class PostReader {
             .orElseThrow(() -> new NotFoundException(POST_NOT_FOUND));
     }
 
-    public SliceResponse<PostSummaryResponse, Long> findPostsByKeywordAndCursorId(String keyword, Long cursorId, int size) {
-        Slice<PostSummaryResponse> postList = postRepository.findAllByKeywordAndCursorId(keyword, cursorId, size);
+    public SliceResponse<PostSummaryResponse, Long> findPostsByKeywordAndCursorId(Long userId, String keyword, Long cursorId, int size) {
+        Slice<PostSummaryResponse> postList = postRepository.findAllByKeywordAndCursorId(userId, keyword, cursorId, size);
 
         return SliceResponse.from(postList);
     }

--- a/src/main/java/org/sopt/bofit/domain/post/service/PostService.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/PostService.java
@@ -41,4 +41,8 @@ public class PostService {
         return postReader.getPostById(postId);
     }
 
+    public SliceResponse<PostSummaryResponse, Long> searchPosts(String keyword, Long cursorId, int size){
+        return postReader.findPostsByKeywordAndCursorId(keyword, cursorId, size);
+    }
+
 }

--- a/src/main/java/org/sopt/bofit/domain/post/service/PostService.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/PostService.java
@@ -33,16 +33,16 @@ public class PostService {
         postWriter.deletePost(userId, postId);
     }
 
-    public SliceResponse<PostSummaryResponse, Long> getAllPosts(Long cursorId, int size){
-        return postReader.getAllPosts(cursorId, size);
+    public SliceResponse<PostSummaryResponse, Long> getAllPosts(Long userId, Long cursorId, int size){
+        return postReader.getAllPosts(userId, cursorId, size);
     }
 
-    public PostDetailResponse getPostDetail(Long postId){
-        return postReader.getPostById(postId);
+    public PostDetailResponse getPostDetail(Long userId, Long postId){
+        return postReader.getPostById(userId, postId);
     }
 
-    public SliceResponse<PostSummaryResponse, Long> searchPosts(String keyword, Long cursorId, int size){
-        return postReader.findPostsByKeywordAndCursorId(keyword, cursorId, size);
+    public SliceResponse<PostSummaryResponse, Long> searchPosts(Long userId, String keyword, Long cursorId, int size){
+        return postReader.findPostsByKeywordAndCursorId(userId, keyword, cursorId, size);
     }
 
 }

--- a/src/main/java/org/sopt/bofit/domain/post/service/PostWriter.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/PostWriter.java
@@ -172,4 +172,14 @@ public class PostWriter {
     public void decreaseLikeCount(Post post){
         postRepository.decreaseLikeCount(post);
     }
+
+    @Transactional
+    public void increaseCommentCount(Post post){
+        postRepository.increaseCommentCount(post);
+    }
+
+    @Transactional
+    public void decreaseCommentCount(Post post){
+        postRepository.decreaseCommentCount(post);
+    }
 }

--- a/src/main/java/org/sopt/bofit/domain/post/service/PostWriter.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/PostWriter.java
@@ -44,7 +44,7 @@ public class PostWriter {
     @Transactional
     public PostCreateResponse createPost(Long userId, String title, String content, String category, List<String> imageUrls) {
         User user = userReader.getActiveById(userId);
-        Post newPost = Post.create(user, title, content, category);
+        Post newPost = Post.create(user, title, content, category, user.getNickname());
         postRepository.save(newPost);
 
         int sequence = 1;

--- a/src/main/java/org/sopt/bofit/domain/user/dto/response/MyPostSummaryResponse.java
+++ b/src/main/java/org/sopt/bofit/domain/user/dto/response/MyPostSummaryResponse.java
@@ -20,7 +20,13 @@ public record MyPostSummaryResponse(
         int commentCount,
 
         @Schema(description = "작성 시간")
-        LocalDateTime createdAt
+        LocalDateTime createdAt,
+
+        @Schema(description = "좋아요 수")
+        Long likeCount,
+
+        @Schema(description = "사용자 좋아요 여부")
+        boolean isLike
 ) implements CursorProvider<Long> {
 
         @Override

--- a/src/main/java/org/sopt/bofit/domain/user/service/UserWriter.java
+++ b/src/main/java/org/sopt/bofit/domain/user/service/UserWriter.java
@@ -1,6 +1,7 @@
 package org.sopt.bofit.domain.user.service;
 
 import lombok.RequiredArgsConstructor;
+import org.sopt.bofit.domain.post.repository.PostRepository;
 import org.sopt.bofit.domain.user.entity.User;
 import org.sopt.bofit.domain.user.entity.constant.Gender;
 import org.sopt.bofit.domain.user.entity.constant.Job;
@@ -15,6 +16,8 @@ import java.time.LocalDate;
 public class UserWriter {
 
     private final UserRepository userRepository;
+
+	private final PostRepository postRepository;
 
 	private final UserReader userReader;
 
@@ -43,6 +46,8 @@ public class UserWriter {
 	@Transactional
 	public void updateUserNickname(Long userId, String newNickname) {
 		User user = userReader.findById(userId);
+
+		postRepository.updateWriterNicknameByUserId(newNickname, user.getId());
 
 		user.updateNickname(newNickname);
 	}

--- a/src/main/java/org/sopt/bofit/global/config/FullTextFunctions.java
+++ b/src/main/java/org/sopt/bofit/global/config/FullTextFunctions.java
@@ -1,0 +1,25 @@
+package org.sopt.bofit.global.config;
+
+import org.hibernate.boot.model.FunctionContributions;
+import org.hibernate.boot.model.FunctionContributor;
+import org.hibernate.query.sqm.function.SqmFunctionRegistry;
+import org.hibernate.type.StandardBasicTypes;
+
+
+public class FullTextFunctions implements FunctionContributor {
+
+    @Override
+    public void contributeFunctions(FunctionContributions contributions) {
+        SqmFunctionRegistry registry = contributions.getFunctionRegistry();
+
+        registry.registerPattern(
+                "match_language_mode",
+                "match (?1, ?2, ?3) against (?4 in natural language mode)",
+                contributions.getTypeConfiguration()
+                        .getBasicTypeRegistry()
+                        .resolve(StandardBasicTypes.DOUBLE)
+
+        );
+
+    }
+}

--- a/src/main/java/org/sopt/bofit/global/config/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/org/sopt/bofit/global/config/swagger/SwaggerResponseDescription.java
@@ -34,6 +34,9 @@ import org.sopt.bofit.global.exception.constant.GlobalErrorCode;
 
 @Getter
 public enum SwaggerResponseDescription {
+    DEFAULT(new LinkedHashSet<>(Set.of(
+    )))
+    ,
     KAKAO_TOKEN_REQUEST(new LinkedHashSet<>(Set.of(
             KAKAO_TOKEN_REQUEST_FAILED,
             KAKAO_USER_INFO_REQUEST_FAILED

--- a/src/main/resources/META-INF/services/org.hibernate.boot.model.FunctionContributor
+++ b/src/main/resources/META-INF/services/org.hibernate.boot.model.FunctionContributor
@@ -1,0 +1,1 @@
+org.sopt.bofit.global.config.FullTextFunctions


### PR DESCRIPTION
## Related issue 🛠
- closed #149
  
## Work Description 📝
- Full Text Search를 이용하여 검색 기능을 구현하였습니다.
- Full Text Search 전용 인덱스를 생성해야 하는데, 기획 정책 상 `제목 + 내용 + 작성자`로 검색이 가능하기 때문에 인덱스를 생성하려면 Post 테이블에 작성자 컬럼이 존재해야 해서 생성했습니다.
- 컬럼이 새로 생성됨에 따라, 유저 닉네임 수정 시 게시물 작성자도 동기화할 수 있도록 로직을 추가했습니다.
## Uncompleted Tasks 😅
Ngram Parser가 토큰을 파싱하는 기본 사이즈가 2여서 현재는 검색어가 2자 이상일 때만 검색 기능이 작동하는데, 검색어가 한 글자인 경우에 대해서, 이를 like를 통해 검색하는 것이 나을지, `ngram_token_size`를 1로 설정할지 고민입니다. 사이즈를 1로 설정하게 되면 문자 하나하나가 별개의 토큰이 되어서 검색 결과의 정확성이 떨어진다고 하는데, 한 글자인 경우 그냥 Like를 통한 검색을 해도 된다고 보시나요?

