### PR TITLE
[Feat] 댓글 수정 API 구현

### DIFF
--- a/src/main/java/org/sopt/bofit/domain/comment/dto/request/CommentUpdateRequest.java
+++ b/src/main/java/org/sopt/bofit/domain/comment/dto/request/CommentUpdateRequest.java
@@ -1,0 +1,41 @@
+package org.sopt.bofit.domain.comment.dto.request;
+
+import static org.sopt.bofit.domain.comment.constant.CommentConstant.COMMENT_CONTENT_MAX_SIZE;
+import static org.sopt.bofit.domain.comment.constant.CommentConstant.MAX_IMAGE_COUNT;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+import java.util.Optional;
+import org.hibernate.validator.constraints.Length;
+import org.sopt.bofit.domain.comment.service.dto.request.CommentUpdateCommand;
+import org.sopt.bofit.global.file.dto.request.UpdateImageRequest;
+
+public record CommentUpdateRequest(
+    @Schema(description = "수정할 댓글 내용", example = "좋은 글이네요")
+    @Length(max = COMMENT_CONTENT_MAX_SIZE, message = "content 의 최대 길이인 {max}을 초과했습니다.")
+    String content,
+
+    @Schema(description = "수정된 이미지 목록")
+    @Size(max = MAX_IMAGE_COUNT, message = "이미지 url 의 최대 개수({max}) 를 초과했습니다.")
+    @NotNull(message = "url 목록은  null 일 수 없습니다.")
+    @Valid
+    List<UpdateImageRequest> updateImages,
+
+    @Schema(description = "삭제할 이미지 ID 목록")
+    @Size(max = MAX_IMAGE_COUNT, message = "이미지 url 의 최대 개수({max}) 를 초과했습니다.")
+    @NotNull(message = "url 목록은  null 일 수 없습니다.")
+    @Valid
+    List<@NotNull Long> deleteImageIds
+) {
+    public CommentUpdateCommand toCommand(){
+        return new CommentUpdateCommand(
+            Optional.of(content),
+            updateImages,
+            deleteImageIds
+        );
+    }
+
+}

--- a/src/main/java/org/sopt/bofit/domain/comment/dto/request/CommentUpdateRequest.java
+++ b/src/main/java/org/sopt/bofit/domain/comment/dto/request/CommentUpdateRequest.java
@@ -20,20 +20,20 @@ public record CommentUpdateRequest(
 
     @Schema(description = "수정된 이미지 목록")
     @Size(max = MAX_IMAGE_COUNT, message = "이미지 url 의 최대 개수({max}) 를 초과했습니다.")
-    @NotNull(message = "url 목록은  null 일 수 없습니다.")
+    @NotNull(message = "수정된 url 목록은  null 일 수 없습니다.")
     @Valid
-    List<UpdateImageRequest> updateImages,
+    List<UpdateImageRequest> updatedImages,
 
     @Schema(description = "삭제할 이미지 ID 목록")
     @Size(max = MAX_IMAGE_COUNT, message = "이미지 url 의 최대 개수({max}) 를 초과했습니다.")
-    @NotNull(message = "url 목록은  null 일 수 없습니다.")
+    @NotNull(message = "삭제된 url 목록은  null 일 수 없습니다.")
     @Valid
     List<@NotNull Long> deleteImageIds
 ) {
     public CommentUpdateCommand toCommand(){
         return new CommentUpdateCommand(
             Optional.of(content),
-            updateImages,
+            updatedImages,
             deleteImageIds
         );
     }

--- a/src/main/java/org/sopt/bofit/domain/comment/entity/Comment.java
+++ b/src/main/java/org/sopt/bofit/domain/comment/entity/Comment.java
@@ -1,8 +1,18 @@
 package org.sopt.bofit.domain.comment.entity;
 
-import static org.sopt.bofit.global.exception.constant.CommentErrorCode.*;
+import static org.sopt.bofit.global.exception.constant.CommentErrorCode.COMMENT_ALREADY_DELETED;
+import static org.sopt.bofit.global.exception.constant.CommentErrorCode.UNMATCHED_COMMENT_POST;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -74,6 +84,10 @@ public class Comment extends BaseEntity {
         this.status = CommentStatus.INACTIVE;
 
         return this;
+    }
+
+    public void updateContent (String content){
+        this.content = content;
     }
 
 }

--- a/src/main/java/org/sopt/bofit/domain/comment/entity/CommentImage.java
+++ b/src/main/java/org/sopt/bofit/domain/comment/entity/CommentImage.java
@@ -11,12 +11,14 @@ import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.sopt.bofit.global.entity.BaseEntity;
 import org.sopt.bofit.global.file.constant.ImageConstant;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
 public class CommentImage extends BaseEntity {
 
     @Id
@@ -33,6 +35,8 @@ public class CommentImage extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private CommentImageStatus status;
 
+    private Integer sequence;
+
     public static CommentImage create(Comment comment, String imageUrl){
         return CommentImage.builder()
             .comment(comment)
@@ -46,5 +50,14 @@ public class CommentImage extends BaseEntity {
         this.comment = comment;
         this.imageUrl = imageUrl;
         this.status = status;
+    }
+
+    public void softDelete(){
+        this.status = CommentImageStatus.INACTIVE;
+        this.sequence = null;
+    }
+
+    public void updateSequence(Integer newSequence){
+        this.sequence = newSequence;
     }
 }

--- a/src/main/java/org/sopt/bofit/domain/comment/entity/CommentImage.java
+++ b/src/main/java/org/sopt/bofit/domain/comment/entity/CommentImage.java
@@ -8,6 +8,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -27,6 +28,7 @@ public class CommentImage extends BaseEntity {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "comment_id")
     private Comment comment;
 
     @Column(length = ImageConstant.MAX_IMAGE_URL_LENGTH)

--- a/src/main/java/org/sopt/bofit/domain/comment/entity/CommentImage.java
+++ b/src/main/java/org/sopt/bofit/domain/comment/entity/CommentImage.java
@@ -2,6 +2,8 @@ package org.sopt.bofit.domain.comment.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -28,16 +30,21 @@ public class CommentImage extends BaseEntity {
     @Column(length = ImageConstant.MAX_IMAGE_URL_LENGTH)
     private String imageUrl;
 
+    @Enumerated(EnumType.STRING)
+    private CommentImageStatus status;
+
     public static CommentImage create(Comment comment, String imageUrl){
         return CommentImage.builder()
             .comment(comment)
             .imageUrl(imageUrl)
+            .status(CommentImageStatus.ACTIVE)
             .build();
     }
 
     @Builder
-    private CommentImage(Comment comment, String imageUrl) {
+    private CommentImage(Comment comment, String imageUrl, CommentImageStatus status) {
         this.comment = comment;
         this.imageUrl = imageUrl;
+        this.status = status;
     }
 }

--- a/src/main/java/org/sopt/bofit/domain/comment/entity/CommentImageStatus.java
+++ b/src/main/java/org/sopt/bofit/domain/comment/entity/CommentImageStatus.java
@@ -1,0 +1,9 @@
+package org.sopt.bofit.domain.comment.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum CommentImageStatus {
+    ACTIVE,
+    INACTIVE
+}

--- a/src/main/java/org/sopt/bofit/domain/comment/repository/CommentImageRepository.java
+++ b/src/main/java/org/sopt/bofit/domain/comment/repository/CommentImageRepository.java
@@ -1,10 +1,21 @@
 package org.sopt.bofit.domain.comment.repository;
 
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.sopt.bofit.domain.comment.entity.Comment;
 import org.sopt.bofit.domain.comment.entity.CommentImage;
+import org.sopt.bofit.domain.comment.entity.CommentImageStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface CommentImageRepository extends JpaRepository<CommentImage, Long> {
+    List<CommentImage> findAllByCommentAndStatus(Comment comment, CommentImageStatus status);
 
+    default Map<Long, CommentImage> findAllByCommentAndStatusAsMap(Comment comment, CommentImageStatus status){
+        return findAllByCommentAndStatus(comment, status).stream()
+            .collect(Collectors.toMap(CommentImage::getId, Function.identity()));
+    }
 }

--- a/src/main/java/org/sopt/bofit/domain/comment/service/CommentImageReader.java
+++ b/src/main/java/org/sopt/bofit/domain/comment/service/CommentImageReader.java
@@ -1,0 +1,19 @@
+package org.sopt.bofit.domain.comment.service;
+
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.sopt.bofit.domain.comment.entity.Comment;
+import org.sopt.bofit.domain.comment.entity.CommentImage;
+import org.sopt.bofit.domain.comment.entity.CommentImageStatus;
+import org.sopt.bofit.domain.comment.repository.CommentImageRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CommentImageReader {
+    private final CommentImageRepository commentImageRepository;
+
+    public Map<Long, CommentImage> getActiveImagesAsMap(Comment comment){
+        return commentImageRepository.findAllByCommentAndStatusAsMap(comment, CommentImageStatus.ACTIVE);
+    }
+}

--- a/src/main/java/org/sopt/bofit/domain/comment/service/CommentImageWriter.java
+++ b/src/main/java/org/sopt/bofit/domain/comment/service/CommentImageWriter.java
@@ -1,9 +1,13 @@
 package org.sopt.bofit.domain.comment.service;
 
+import jakarta.transaction.Transactional;
+import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.sopt.bofit.domain.comment.entity.Comment;
 import org.sopt.bofit.domain.comment.entity.CommentImage;
 import org.sopt.bofit.domain.comment.repository.CommentImageRepository;
+import org.sopt.bofit.global.file.dto.request.UpdateImageRequest;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -11,8 +15,32 @@ import org.springframework.stereotype.Service;
 public class CommentImageWriter {
     private final CommentImageRepository commentImageRepository;
 
-    public CommentImage create(Comment comment, String url){
+    public CommentImage create(Comment comment, String url, Integer sequence){
         CommentImage commentImage = CommentImage.create(comment, url);
         return commentImageRepository.save(commentImage);
     }
+
+    @Transactional
+    public void updateAll(
+        Comment comment,
+        Map<Long, CommentImage> currentImages,
+        List<UpdateImageRequest> updatedImages
+    ){
+        updatedImages.forEach(image -> {
+                if(image.id() == null){
+                    create(comment, image.imageUrl(), image.sequence());
+                }else {
+                    currentImages.get(image.id()).updateSequence(image.sequence());
+                }
+            });
+    }
+
+    @Transactional
+    public void softDelete(Map<Long, CommentImage> commentImages, List<Long> deleteImageIds){
+        deleteImageIds.forEach(id -> {
+            commentImages.get(id).softDelete();
+        });
+    }
+
+
 }

--- a/src/main/java/org/sopt/bofit/domain/comment/service/CommentService.java
+++ b/src/main/java/org/sopt/bofit/domain/comment/service/CommentService.java
@@ -51,6 +51,25 @@ public class CommentService {
 		return comment;
 	}
 
+    @Transactional
+    public Comment updateComment(Long userId, Long postId, Long commentId, CommentUpdateCommand command){
+        Post post = postReader.getActiveById(postId);
+        User user = userReader.getActiveById(userId);
+        Comment comment = commentReader.getActiveById(commentId);
+
+        comment.getUser().checkIsWriter(userId, COMMENT_UNAUTHORIZED);
+        comment.checkPost(post);
+
+        Map<Long, CommentImage> commentImageMap = commentImageReader.getActiveImagesAsMap(comment);
+        checkImageCount(command.updatedImages().size());
+
+        commentImageWriter.softDelete(commentImageMap, command.deleteImageIds());
+        commentImageWriter.updateAll(comment, commentImageMap, command.updatedImages());
+        command.content().ifPresent(comment::updateContent);
+
+        return comment;
+    }
+
 	@Transactional
 	public void deleteComment(Long userId, Long postId, Long commentId) {
 		Comment comment = commentReader.getActiveById(commentId);
@@ -69,4 +88,11 @@ public class CommentService {
 
 		return SliceResponse.from(commentsByCursorId);
 	}
+
+    private void checkImageCount(int existImageCount){
+        if(MAX_IMAGE_COUNT < existImageCount){
+            throw new BadRequestException(CommentErrorCode.COMMENT_IMAGE_EXCEED);
+        }
+    }
+
 }

--- a/src/main/java/org/sopt/bofit/domain/comment/service/CommentService.java
+++ b/src/main/java/org/sopt/bofit/domain/comment/service/CommentService.java
@@ -1,17 +1,24 @@
 package org.sopt.bofit.domain.comment.service;
 
+import static org.sopt.bofit.domain.comment.constant.CommentConstant.MAX_IMAGE_COUNT;
 import static org.sopt.bofit.global.exception.constant.CommentErrorCode.COMMENT_UNAUTHORIZED;
 
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
 import org.sopt.bofit.domain.comment.dto.response.CommentResponse;
 import org.sopt.bofit.domain.comment.entity.Comment;
+import org.sopt.bofit.domain.comment.entity.CommentImage;
 import org.sopt.bofit.domain.comment.service.dto.request.CommentCreateCommand;
+import org.sopt.bofit.domain.comment.service.dto.request.CommentUpdateCommand;
 import org.sopt.bofit.domain.post.entity.Post;
 import org.sopt.bofit.domain.post.service.PostReader;
 import org.sopt.bofit.domain.user.entity.User;
 import org.sopt.bofit.domain.user.service.UserReader;
 import org.sopt.bofit.global.dto.response.SliceResponse;
+import org.sopt.bofit.global.exception.constant.CommentErrorCode;
+import org.sopt.bofit.global.exception.customexception.BadRequestException;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,6 +35,7 @@ public class CommentService {
 	private final UserReader userReader;
 
 	private final CommentImageWriter commentImageWriter;
+    private final CommentImageReader commentImageReader;
 
 	@Transactional
 	public Comment createComment(Long userId, Long postId, CommentCreateCommand command){
@@ -35,8 +43,10 @@ public class CommentService {
 		User user = userReader.getActiveById(userId);
 
 		Comment comment = commentWriter.create(post, user, command.content());
-		command.imageUrls()
-			.forEach(url -> commentImageWriter.create(comment, url));
+
+        IntStream.range(0, command.imageUrls().size())
+                .forEach(sequence -> commentImageWriter
+                    .create(comment, command.imageUrls().get(sequence), sequence + 1));
 
 		return comment;
 	}

--- a/src/main/java/org/sopt/bofit/domain/comment/service/CommentService.java
+++ b/src/main/java/org/sopt/bofit/domain/comment/service/CommentService.java
@@ -3,6 +3,7 @@ package org.sopt.bofit.domain.comment.service;
 import static org.sopt.bofit.domain.comment.constant.CommentConstant.MAX_IMAGE_COUNT;
 import static org.sopt.bofit.global.exception.constant.CommentErrorCode.COMMENT_UNAUTHORIZED;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -65,9 +66,9 @@ public class CommentService {
 
         Map<Long, CommentImage> commentImageMap = commentImageReader.getActiveImagesAsMap(comment);
         validImageCount(command.updatedImages().size());
-        validImageIds(commentImageMap.keySet(), command.deleteImageIds());
         validImageIds(commentImageMap.keySet(), command.updatedImages().stream()
-            .filter(image -> image.id() != null).map(UpdateImageRequest::id).toList());
+            .filter(image -> image.id() != null).map(UpdateImageRequest::id).toList(),
+            command.deleteImageIds());
 
         commentImageWriter.softDelete(commentImageMap, command.deleteImageIds());
         commentImageWriter.updateAll(comment, commentImageMap, command.updatedImages());
@@ -101,10 +102,15 @@ public class CommentService {
         }
     }
 
-    private void validImageIds(Set<Long> currentImageIds, List<Long> imageIds){
-        if (!currentImageIds.containsAll(imageIds)){
+    /**
+     * 기존 comment의 이미지가 수정 + 삭제하려는 이미지와 동일한지 검증
+     */
+    private void validImageIds(Set<Long> currentImageIds, List<Long> existIds, List<Long> deletedIds){
+        Set<Long> expectedIds = new HashSet<>(existIds);
+        expectedIds.addAll(deletedIds);
+
+        if(!currentImageIds.equals(expectedIds)){
             throw new BadRequestException(CommentErrorCode.UNMATCHED_COMMENT_IMAGE);
         }
-
     }
 }

--- a/src/main/java/org/sopt/bofit/domain/comment/service/CommentService.java
+++ b/src/main/java/org/sopt/bofit/domain/comment/service/CommentService.java
@@ -3,8 +3,10 @@ package org.sopt.bofit.domain.comment.service;
 import static org.sopt.bofit.domain.comment.constant.CommentConstant.MAX_IMAGE_COUNT;
 import static org.sopt.bofit.global.exception.constant.CommentErrorCode.COMMENT_UNAUTHORIZED;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
 import org.sopt.bofit.domain.comment.dto.response.CommentResponse;
@@ -19,6 +21,7 @@ import org.sopt.bofit.domain.user.service.UserReader;
 import org.sopt.bofit.global.dto.response.SliceResponse;
 import org.sopt.bofit.global.exception.constant.CommentErrorCode;
 import org.sopt.bofit.global.exception.customexception.BadRequestException;
+import org.sopt.bofit.global.file.dto.request.UpdateImageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -61,7 +64,10 @@ public class CommentService {
         comment.checkPost(post);
 
         Map<Long, CommentImage> commentImageMap = commentImageReader.getActiveImagesAsMap(comment);
-        checkImageCount(command.updatedImages().size());
+        validImageCount(command.updatedImages().size());
+        validImageIds(commentImageMap.keySet(), command.deleteImageIds());
+        validImageIds(commentImageMap.keySet(), command.updatedImages().stream()
+            .filter(image -> image.id() != null).map(UpdateImageRequest::id).toList());
 
         commentImageWriter.softDelete(commentImageMap, command.deleteImageIds());
         commentImageWriter.updateAll(comment, commentImageMap, command.updatedImages());
@@ -89,10 +95,16 @@ public class CommentService {
 		return SliceResponse.from(commentsByCursorId);
 	}
 
-    private void checkImageCount(int existImageCount){
+    private void validImageCount(int existImageCount){
         if(MAX_IMAGE_COUNT < existImageCount){
             throw new BadRequestException(CommentErrorCode.COMMENT_IMAGE_EXCEED);
         }
     }
 
+    private void validImageIds(Set<Long> currentImageIds, List<Long> imageIds){
+        if (!currentImageIds.containsAll(imageIds)){
+            throw new BadRequestException(CommentErrorCode.UNMATCHED_COMMENT_IMAGE);
+        }
+
+    }
 }

--- a/src/main/java/org/sopt/bofit/domain/comment/service/dto/request/CommentUpdateCommand.java
+++ b/src/main/java/org/sopt/bofit/domain/comment/service/dto/request/CommentUpdateCommand.java
@@ -1,0 +1,13 @@
+package org.sopt.bofit.domain.comment.service.dto.request;
+
+import java.util.List;
+import java.util.Optional;
+import org.sopt.bofit.global.file.dto.request.UpdateImageRequest;
+
+public record CommentUpdateCommand(
+    Optional<String> content,
+    List<UpdateImageRequest> updatedImages,
+    List<Long> deleteImageIds
+) {
+
+}

--- a/src/main/java/org/sopt/bofit/domain/post/controller/PostController.java
+++ b/src/main/java/org/sopt/bofit/domain/post/controller/PostController.java
@@ -40,6 +40,7 @@ import org.sopt.bofit.global.dto.response.BaseResponse;
 import org.sopt.bofit.global.dto.response.SliceResponse;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -128,7 +129,7 @@ public class PostController {
     @Tag(name = TAG_NAME_COMMUNITY, description = TAG_DESCRIPTION_COMMUNITY)
     @Operation(summary = "댓글 수정", description = "커뮤니티 게시글의 댓글을 수정합니다.")
     @CustomExceptionDescription(UPDATE_COMMENT)
-    @PutMapping("/{post-id}/comments/{comment-id}")
+    @PatchMapping("/{post-id}/comments/{comment-id}")
     public BaseResponse<PostCreateResponse> updateComment(
         @RequestBody @Valid CommentUpdateRequest request,
         @PathVariable(name = "post-id") Long postId,

--- a/src/main/java/org/sopt/bofit/domain/post/controller/PostController.java
+++ b/src/main/java/org/sopt/bofit/domain/post/controller/PostController.java
@@ -10,6 +10,7 @@ import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.DE
 import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.DELETE_POST;
 import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.DELETE_POST_LIKE;
 import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.POST_DETAIL;
+import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.UPDATE_COMMENT;
 import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.UPDATE_POST;
 import static org.sopt.bofit.global.constant.SwaggerConstant.TAG_DESCRIPTION_COMMUNITY;
 import static org.sopt.bofit.global.constant.SwaggerConstant.TAG_NAME_COMMUNITY;
@@ -21,6 +22,7 @@ import jakarta.validation.Valid;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.sopt.bofit.domain.comment.dto.request.CommentCreateRequest;
+import org.sopt.bofit.domain.comment.dto.request.CommentUpdateRequest;
 import org.sopt.bofit.domain.comment.dto.response.CommentResponse;
 import org.sopt.bofit.domain.comment.service.CommentService;
 import org.sopt.bofit.domain.commentreply.dto.request.CommentReplyCreateRequest;
@@ -122,6 +124,20 @@ public class PostController {
     ){
         commentService.createComment(userId, postId, request.toCommand());
         return BaseResponse.create("댓글 생성 성공");
+    }
+
+    @Tag(name = TAG_NAME_COMMUNITY, description = TAG_DESCRIPTION_COMMUNITY)
+    @Operation(summary = "댓글 수정", description = "커뮤니티 게시글의 댓글을 수정합니다.")
+    @CustomExceptionDescription(UPDATE_COMMENT)
+    @PostMapping("/{post-id}/comments/{comment-id}")
+    public BaseResponse<PostCreateResponse> updateComment(
+        @RequestBody @Valid CommentUpdateRequest request,
+        @PathVariable(name = "post-id") Long postId,
+        @PathVariable(name = "comment-id") Long commentId,
+        @Parameter(hidden = true) @LoginUserId Long userId
+    ){
+        commentService.updateComment(userId, postId, commentId, request.toCommand());
+        return BaseResponse.create("댓글 수정 성공");
     }
 
     @Tag(name = TAG_NAME_COMMUNITY, description = TAG_DESCRIPTION_COMMUNITY)

--- a/src/main/java/org/sopt/bofit/domain/post/controller/PostController.java
+++ b/src/main/java/org/sopt/bofit/domain/post/controller/PostController.java
@@ -19,6 +19,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.sopt.bofit.domain.comment.dto.request.CommentCreateRequest;
 import org.sopt.bofit.domain.comment.dto.request.CommentUpdateRequest;
@@ -37,15 +38,15 @@ import org.sopt.bofit.global.annotation.CustomExceptionDescription;
 import org.sopt.bofit.global.annotation.LoginUserId;
 import org.sopt.bofit.global.dto.response.BaseResponse;
 import org.sopt.bofit.global.dto.response.SliceResponse;
-import org.springframework.web.bind.annotation.*;
-
-import java.util.Optional;
-
-import static org.sopt.bofit.domain.comment.constant.CommentConstant.COMMENTS_DEFAULT_SIZE;
-import static org.sopt.bofit.domain.post.constant.PostConstant.POSTS_DEFAULT_SIZE;
-import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.*;
-import static org.sopt.bofit.global.constant.SwaggerConstant.TAG_DESCRIPTION_COMMUNITY;
-import static org.sopt.bofit.global.constant.SwaggerConstant.TAG_NAME_COMMUNITY;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
@@ -127,7 +128,7 @@ public class PostController {
     @Tag(name = TAG_NAME_COMMUNITY, description = TAG_DESCRIPTION_COMMUNITY)
     @Operation(summary = "댓글 수정", description = "커뮤니티 게시글의 댓글을 수정합니다.")
     @CustomExceptionDescription(UPDATE_COMMENT)
-    @PostMapping("/{post-id}/comments/{comment-id}")
+    @PutMapping("/{post-id}/comments/{comment-id}")
     public BaseResponse<PostCreateResponse> updateComment(
         @RequestBody @Valid CommentUpdateRequest request,
         @PathVariable(name = "post-id") Long postId,

--- a/src/main/java/org/sopt/bofit/domain/post/service/PostWriter.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/PostWriter.java
@@ -60,7 +60,7 @@ public class PostWriter {
     }
 
     @Transactional
-    public PostCreateResponse updatePost (Long userId, Long postId, String newTitle, String newContent,
+    public PostCreateResponse  updatePost (Long userId, Long postId, String newTitle, String newContent,
                                           List<NewImageRequest> newImages, List<UpdateImageRequest> updateImages,
                                           List<Long> deleteImageIds) {
         User user = userReader.getActiveById(userId);
@@ -117,12 +117,12 @@ public class PostWriter {
 
                 PostImage img = currentImages.get(from);
 
-                if (req.newImageUrl() != null && !req.newImageUrl().isBlank()) {
-                    img.updateImageUrl(req.newImageUrl());
+                if (req.imageUrl() != null && !req.imageUrl().isBlank()) {
+                    img.updateImageUrl(req.imageUrl());
                 }
 
-                if (req.newSequence() != null) {
-                    int to = Math.max(0, Math.min(req.newSequence() - 1, currentImages.size() - 1));
+                if (req.sequence() != null) {
+                    int to = Math.max(0, Math.min(req.sequence() - 1, currentImages.size() - 1));
                     moveSequence(currentImages, from, to);
 
                     indexById.clear();

--- a/src/main/java/org/sopt/bofit/global/config/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/org/sopt/bofit/global/config/swagger/SwaggerResponseDescription.java
@@ -4,6 +4,7 @@ import static org.sopt.bofit.domain.insurancereport.errorcode.InsuranceReportErr
 import static org.sopt.bofit.domain.insurancereport.errorcode.InsuranceReportErrorCode.NOT_FOUND_INSURANCE_REPORT;
 import static org.sopt.bofit.global.exception.constant.CommentErrorCode.COMMENT_ALREADY_DELETED;
 import static org.sopt.bofit.global.exception.constant.CommentErrorCode.COMMENT_NOT_FOUND;
+import static org.sopt.bofit.global.exception.constant.CommentErrorCode.UNMATCHED_COMMENT_IMAGE;
 import static org.sopt.bofit.global.exception.constant.CommentErrorCode.UNMATCHED_COMMENT_POST;
 import static org.sopt.bofit.global.exception.constant.InsuranceErrorCode.NOT_FOUND_INSURANCE_TOTAL_AVERAGE;
 import static org.sopt.bofit.global.exception.constant.InsuranceErrorCode.NOT_FOUND_RECOMMENDED_STATUS_INSURANCE;
@@ -93,7 +94,9 @@ public enum SwaggerResponseDescription {
     UPDATE_COMMENT(new LinkedHashSet<>(Set.of(
         USER_NOT_FOUND,
         POST_NOT_FOUND,
-        COMMENT_NOT_FOUND
+        COMMENT_NOT_FOUND,
+        UNMATCHED_COMMENT_POST,
+        UNMATCHED_COMMENT_IMAGE
     ))),
     DELETE_COMMENT(new LinkedHashSet<>(Set.of(
         USER_NOT_FOUND,

--- a/src/main/java/org/sopt/bofit/global/config/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/org/sopt/bofit/global/config/swagger/SwaggerResponseDescription.java
@@ -1,22 +1,34 @@
 package org.sopt.bofit.global.config.swagger;
 
-import lombok.Getter;
-import org.sopt.bofit.global.exception.constant.ErrorCode;
-import org.sopt.bofit.global.exception.constant.GlobalErrorCode;
-
-import java.util.LinkedHashSet;
-import java.util.Set;
-
 import static org.sopt.bofit.domain.insurancereport.errorcode.InsuranceReportErrorCode.INVALID_REPORT_SECTION;
 import static org.sopt.bofit.domain.insurancereport.errorcode.InsuranceReportErrorCode.NOT_FOUND_INSURANCE_REPORT;
-import static org.sopt.bofit.global.exception.constant.CommentErrorCode.*;
+import static org.sopt.bofit.global.exception.constant.CommentErrorCode.COMMENT_ALREADY_DELETED;
+import static org.sopt.bofit.global.exception.constant.CommentErrorCode.COMMENT_NOT_FOUND;
+import static org.sopt.bofit.global.exception.constant.CommentErrorCode.UNMATCHED_COMMENT_POST;
 import static org.sopt.bofit.global.exception.constant.InsuranceErrorCode.NOT_FOUND_INSURANCE_TOTAL_AVERAGE;
 import static org.sopt.bofit.global.exception.constant.InsuranceErrorCode.NOT_FOUND_RECOMMENDED_STATUS_INSURANCE;
-import static org.sopt.bofit.global.exception.constant.OAuthErrorCode.*;
-import static org.sopt.bofit.global.exception.constant.PostErrorCode.*;
+import static org.sopt.bofit.global.exception.constant.OAuthErrorCode.JWT_REFRESH_NOT_FOUND;
+import static org.sopt.bofit.global.exception.constant.OAuthErrorCode.JWT_REFRESH_TOKEN_MISMATCH;
+import static org.sopt.bofit.global.exception.constant.OAuthErrorCode.KAKAO_TOKEN_REQUEST_FAILED;
+import static org.sopt.bofit.global.exception.constant.OAuthErrorCode.KAKAO_USER_INFO_REQUEST_FAILED;
+import static org.sopt.bofit.global.exception.constant.PostErrorCode.POST_CONTENT_BLANK;
+import static org.sopt.bofit.global.exception.constant.PostErrorCode.POST_CONTENT_LONG;
+import static org.sopt.bofit.global.exception.constant.PostErrorCode.POST_IMAGE_MISMATCH;
+import static org.sopt.bofit.global.exception.constant.PostErrorCode.POST_LIKE_CREATE_CONFLICT;
+import static org.sopt.bofit.global.exception.constant.PostErrorCode.POST_LIKE_NOT_FOUND;
+import static org.sopt.bofit.global.exception.constant.PostErrorCode.POST_NOT_FOUND;
+import static org.sopt.bofit.global.exception.constant.PostErrorCode.POST_TITLE_BLANK;
+import static org.sopt.bofit.global.exception.constant.PostErrorCode.POST_TITLE_LONG;
+import static org.sopt.bofit.global.exception.constant.PostErrorCode.POST_UNAUTHORIZED;
 import static org.sopt.bofit.global.exception.constant.S3ErrorCode.UNSUPPORTED_IMAGE_TYPE;
 import static org.sopt.bofit.global.exception.constant.S3ErrorCode.UNSUPPORTED_MEDIA_TYPE;
 import static org.sopt.bofit.global.exception.constant.UserErrorCode.USER_NOT_FOUND;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+import lombok.Getter;
+import org.sopt.bofit.global.exception.constant.ErrorCode;
+import org.sopt.bofit.global.exception.constant.GlobalErrorCode;
 
 
 @Getter
@@ -77,6 +89,11 @@ public enum SwaggerResponseDescription {
     CREATE_COMMENT(new LinkedHashSet<>(Set.of(
         USER_NOT_FOUND,
         POST_NOT_FOUND
+    ))),
+    UPDATE_COMMENT(new LinkedHashSet<>(Set.of(
+        USER_NOT_FOUND,
+        POST_NOT_FOUND,
+        COMMENT_NOT_FOUND
     ))),
     DELETE_COMMENT(new LinkedHashSet<>(Set.of(
         USER_NOT_FOUND,

--- a/src/main/java/org/sopt/bofit/global/exception/constant/CommentErrorCode.java
+++ b/src/main/java/org/sopt/bofit/global/exception/constant/CommentErrorCode.java
@@ -1,21 +1,21 @@
 package org.sopt.bofit.global.exception.constant;
 
-import org.springframework.http.HttpStatus;
-
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 
 @Getter
 @RequiredArgsConstructor
 public enum CommentErrorCode implements ErrorCode{
 
 	UNMATCHED_COMMENT_POST(HttpStatus.BAD_REQUEST.value(), "댓글의 게시글이 일치하지 않습니다"),
+    COMMENT_IMAGE_EXCEED(HttpStatus.BAD_REQUEST.value(), "댓글의 이미지 개수를 초과했습니다."),
 
 	COMMENT_UNAUTHORIZED(HttpStatus.FORBIDDEN.value(), "본인의 댓글만 수정/삭제할 수 있습니다."),
 
 	COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "존재하지 않는 댓글입니다."),
 
-	COMMENT_ALREADY_DELETED(HttpStatus.CONFLICT.value(), "이미 삭제된 댓글입니다.")
+	COMMENT_ALREADY_DELETED(HttpStatus.CONFLICT.value(), "이미 삭제된 댓글입니다."),
 
 	;
 

--- a/src/main/java/org/sopt/bofit/global/exception/constant/CommentErrorCode.java
+++ b/src/main/java/org/sopt/bofit/global/exception/constant/CommentErrorCode.java
@@ -10,6 +10,7 @@ public enum CommentErrorCode implements ErrorCode{
 
 	UNMATCHED_COMMENT_POST(HttpStatus.BAD_REQUEST.value(), "댓글의 게시글이 일치하지 않습니다"),
     COMMENT_IMAGE_EXCEED(HttpStatus.BAD_REQUEST.value(), "댓글의 이미지 개수를 초과했습니다."),
+    UNMATCHED_COMMENT_IMAGE(HttpStatus.BAD_REQUEST.value(), "요청한 댓글과 이미지가 일치하지 않습니다."),
 
 	COMMENT_UNAUTHORIZED(HttpStatus.FORBIDDEN.value(), "본인의 댓글만 수정/삭제할 수 있습니다."),
 

--- a/src/main/java/org/sopt/bofit/global/file/dto/request/UpdateImageRequest.java
+++ b/src/main/java/org/sopt/bofit/global/file/dto/request/UpdateImageRequest.java
@@ -3,21 +3,19 @@ package org.sopt.bofit.global.file.dto.request;
 import static org.sopt.bofit.global.file.constant.ImageConstant.MAX_IMAGE_URL_LENGTH;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import org.hibernate.validator.constraints.Length;
 
 public record UpdateImageRequest(
-        @Schema(description = "수정할 이미지 ID")
-        @NotNull
+        @Schema(description = "이미지 ID")
         Long id,
 
         @Length(max = MAX_IMAGE_URL_LENGTH, message = "이미지 url 의 최대 길이 ({max}) 를 초과했습니다.")
         @Schema(description = "새 이미지 URL (변경 없으면 null)")
-        String newImageUrl,
+        String imageUrl,
 
-        @Schema(description = "새 순서, 1부터 시작")
+        @Schema(description = "순서, 1부터 시작")
         @Positive
-        Integer newSequence
+        Integer sequence
 ) {
 }


### PR DESCRIPTION
## Related issue 🛠
- closed #147
  

## Work Description 📝
- 논의했던 것처럼 업데이트 시 현재 활성화되어야 하는 image, 삭제될 image id를 받아오도록 구현했습니다.
- 사실 현재 요구사항은 이미지 개수가 1개여서 로직적으로 불필요할 수 있지만, 추후 확장성을 고려해 설계했습니다.

## Uncompleted Tasks 😅

## To Reviewers 📢
