### PR TITLE
[Refactor] 이미지 수정 로직 리팩토링

### DIFF
--- a/src/main/java/org/sopt/bofit/domain/comment/entity/CommentImage.java
+++ b/src/main/java/org/sopt/bofit/domain/comment/entity/CommentImage.java
@@ -64,4 +64,5 @@ public class CommentImage extends BaseEntity {
     public void updateSequence(Integer newSequence){
         this.sequence = newSequence;
     }
+
 }

--- a/src/main/java/org/sopt/bofit/domain/comment/service/CommentImageWriter.java
+++ b/src/main/java/org/sopt/bofit/domain/comment/service/CommentImageWriter.java
@@ -1,14 +1,15 @@
 package org.sopt.bofit.domain.comment.service;
 
 import jakarta.transaction.Transactional;
-import java.util.List;
-import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.sopt.bofit.domain.comment.entity.Comment;
 import org.sopt.bofit.domain.comment.entity.CommentImage;
 import org.sopt.bofit.domain.comment.repository.CommentImageRepository;
 import org.sopt.bofit.global.file.dto.request.UpdateImageRequest;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/org/sopt/bofit/domain/comment/service/CommentService.java
+++ b/src/main/java/org/sopt/bofit/domain/comment/service/CommentService.java
@@ -1,14 +1,5 @@
 package org.sopt.bofit.domain.comment.service;
 
-import static org.sopt.bofit.domain.comment.constant.CommentConstant.MAX_IMAGE_COUNT;
-import static org.sopt.bofit.global.exception.constant.CommentErrorCode.COMMENT_UNAUTHORIZED;
-
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
 import org.sopt.bofit.domain.comment.dto.response.CommentResponse;
 import org.sopt.bofit.domain.comment.entity.Comment;
@@ -24,14 +15,13 @@ import org.sopt.bofit.global.dto.response.SliceResponse;
 import org.sopt.bofit.global.exception.constant.CommentErrorCode;
 import org.sopt.bofit.global.exception.customexception.BadRequestException;
 import org.sopt.bofit.global.file.dto.request.UpdateImageRequest;
+import org.sopt.bofit.global.file.util.ImageValidator;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.HashSet;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
+import java.util.stream.IntStream;
 
 import static org.sopt.bofit.domain.comment.constant.CommentConstant.MAX_IMAGE_COUNT;
 import static org.sopt.bofit.global.exception.constant.CommentErrorCode.COMMENT_UNAUTHORIZED;
@@ -80,9 +70,10 @@ public class CommentService {
 
         Map<Long, CommentImage> commentImageMap = commentImageReader.getActiveImagesAsMap(comment);
         validImageCount(command.updatedImages().size());
-        validImageIds(commentImageMap.keySet(), command.updatedImages().stream()
-            .filter(image -> image.id() != null).map(UpdateImageRequest::id).toList(),
-            command.deleteImageIds());
+
+        ImageValidator.validImageIds(commentImageMap.keySet(), command.updatedImages().stream()
+                        .filter(image -> image.id() != null).map(UpdateImageRequest::id).toList(),
+                command.deleteImageIds());
 
         commentImageWriter.softDelete(commentImageMap, command.deleteImageIds());
         commentImageWriter.updateAll(comment, commentImageMap, command.updatedImages());
@@ -118,17 +109,6 @@ public class CommentService {
         }
     }
 
-    /**
-     * 기존 comment의 이미지가 수정 + 삭제하려는 이미지와 동일한지 검증
-     */
-    private void validImageIds(Set<Long> currentImageIds, List<Long> existIds, List<Long> deletedIds){
-        Set<Long> expectedIds = new HashSet<>(existIds);
-        expectedIds.addAll(deletedIds);
-
-        if(!currentImageIds.equals(expectedIds)){
-            throw new BadRequestException(CommentErrorCode.UNMATCHED_COMMENT_IMAGE);
-        }
-    }
 
     private void validRelation(User user, Post post, Comment comment){
         comment.getUser().checkIsWriter(user, COMMENT_UNAUTHORIZED);

--- a/src/main/java/org/sopt/bofit/domain/comment/service/dto/request/CommentCreateCommand.java
+++ b/src/main/java/org/sopt/bofit/domain/comment/service/dto/request/CommentCreateCommand.java
@@ -6,5 +6,4 @@ public record CommentCreateCommand(
     String content,
     List<String> imageUrls
 ) {
-
 }

--- a/src/main/java/org/sopt/bofit/domain/commentreply/entity/CommentReplyImage.java
+++ b/src/main/java/org/sopt/bofit/domain/commentreply/entity/CommentReplyImage.java
@@ -63,4 +63,5 @@ public class CommentReplyImage extends BaseEntity {
     public void updateSequence(Integer sequence){
         this.sequence = sequence;
     }
+
 }

--- a/src/main/java/org/sopt/bofit/domain/commentreply/service/CommentReplyImageWriter.java
+++ b/src/main/java/org/sopt/bofit/domain/commentreply/service/CommentReplyImageWriter.java
@@ -1,14 +1,15 @@
 package org.sopt.bofit.domain.commentreply.service;
 
 import jakarta.transaction.Transactional;
-import java.util.List;
-import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.sopt.bofit.domain.commentreply.entity.CommentReply;
 import org.sopt.bofit.domain.commentreply.entity.CommentReplyImage;
 import org.sopt.bofit.domain.commentreply.repository.CommentReplyImageRepository;
 import org.sopt.bofit.global.file.dto.request.UpdateImageRequest;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/org/sopt/bofit/domain/commentreply/service/CommentReplyService.java
+++ b/src/main/java/org/sopt/bofit/domain/commentreply/service/CommentReplyService.java
@@ -1,11 +1,6 @@
 package org.sopt.bofit.domain.commentreply.service;
 
 
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
 import org.sopt.bofit.domain.comment.entity.Comment;
 import org.sopt.bofit.domain.comment.service.CommentReader;
@@ -17,12 +12,14 @@ import org.sopt.bofit.domain.post.entity.Post;
 import org.sopt.bofit.domain.post.service.PostReader;
 import org.sopt.bofit.domain.user.entity.User;
 import org.sopt.bofit.domain.user.service.UserReader;
-import org.sopt.bofit.global.exception.constant.CommentErrorCode;
 import org.sopt.bofit.global.exception.constant.CommentReplyErrorCode;
-import org.sopt.bofit.global.exception.customexception.BadRequestException;
 import org.sopt.bofit.global.file.dto.request.UpdateImageRequest;
+import org.sopt.bofit.global.file.util.ImageValidator;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
+import java.util.stream.IntStream;
 
 @Service
 @RequiredArgsConstructor
@@ -73,11 +70,10 @@ public class CommentReplyService {
 
         Map<Long, CommentReplyImage> commentReplyImageMap = commentReplyImageReader.getActiveImagesAsMap(commentReply);
 
-        validImageIds(commentReplyImageMap.keySet(),
-            command.updatedImages().stream()
-                .filter(image -> image.id() != null)
-                .map(UpdateImageRequest::id).toList(),
-            command.deleteImageIds());
+        ImageValidator.validImageIds(commentReplyImageMap.keySet(), command.updatedImages().stream()
+                        .filter(image -> image.id() != null).map(UpdateImageRequest::id).toList(),
+                command.deleteImageIds());
+
         commentReplyImageWriter.softDelete(commentReplyImageMap, command.deleteImageIds());
         commentReplyImageWriter.updateAll(commentReply, commentReplyImageMap, command.updatedImages());
         command.content().ifPresent(commentReply::updateContent);
@@ -91,15 +87,4 @@ public class CommentReplyService {
         commentReply.getUser().checkIsWriter(requestUser, CommentReplyErrorCode.COMMENT_REPLY_UNAUTHORIZED);
     }
 
-    /**
-     * 기존 comment의 이미지가 수정 + 삭제하려는 이미지와 동일한지 검증
-     */
-    private void validImageIds(Set<Long> currentImageIds, List<Long> existIds, List<Long> deletedIds){
-        Set<Long> expectedIds = new HashSet<>(existIds);
-        expectedIds.addAll(deletedIds);
-
-        if(!currentImageIds.equals(expectedIds)){
-            throw new BadRequestException(CommentErrorCode.UNMATCHED_COMMENT_IMAGE);
-        }
-    }
 }

--- a/src/main/java/org/sopt/bofit/domain/post/controller/PostController.java
+++ b/src/main/java/org/sopt/bofit/domain/post/controller/PostController.java
@@ -1,21 +1,5 @@
 package org.sopt.bofit.domain.post.controller;
 
-import static org.sopt.bofit.domain.comment.constant.CommentConstant.COMMENTS_DEFAULT_SIZE;
-import static org.sopt.bofit.domain.post.constant.PostConstant.POSTS_DEFAULT_SIZE;
-import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.CREATE_COMMENT;
-import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.CREATE_COMMENT_REPLY;
-import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.CREATE_POST;
-import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.CREATE_POST_LIKE;
-import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.DELETE_COMMENT;
-import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.DELETE_POST;
-import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.DELETE_POST_LIKE;
-import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.POST_DETAIL;
-import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.UPDATE_COMMENT;
-import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.UPDATE_COMMENT_REPLY;
-import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.UPDATE_POST;
-import static org.sopt.bofit.global.constant.SwaggerConstant.TAG_DESCRIPTION_COMMUNITY;
-import static org.sopt.bofit.global.constant.SwaggerConstant.TAG_NAME_COMMUNITY;
-
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -67,7 +51,7 @@ public class PostController {
             @RequestBody @Valid PostCreateRequest request,
             @Parameter(hidden = true) @LoginUserId Long userId
     ){
-        return BaseResponse.create(postService.createPost(userId, request.title(), request.content(),request.category(), request.imageUrls()),"게시물 생성 완료");
+        return BaseResponse.create(postService.createPost(userId, request.toCommand()),"게시물 생성 완료");
     }
 
     @Tag(name = TAG_NAME_COMMUNITY, description = TAG_DESCRIPTION_COMMUNITY)

--- a/src/main/java/org/sopt/bofit/domain/post/dto/request/PostCreateRequest.java
+++ b/src/main/java/org/sopt/bofit/domain/post/dto/request/PostCreateRequest.java
@@ -27,5 +27,4 @@ public record PostCreateRequest(
         @Schema(description = "이미지 url")
         List<String> imageUrls
 ) {
-
 }

--- a/src/main/java/org/sopt/bofit/domain/post/dto/request/PostCreateRequest.java
+++ b/src/main/java/org/sopt/bofit/domain/post/dto/request/PostCreateRequest.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import org.hibernate.validator.constraints.Length;
 import org.sopt.bofit.domain.post.entity.constant.PostInfoConstant;
+import org.sopt.bofit.domain.post.service.dto.request.PostCreateCommand;
 import org.sopt.bofit.global.annotation.ValidPostCategory;
 
 import java.util.List;
@@ -27,4 +28,7 @@ public record PostCreateRequest(
         @Schema(description = "이미지 url")
         List<String> imageUrls
 ) {
+    public PostCreateCommand toCommand() {
+        return new PostCreateCommand(title, content, category, imageUrls);
+    }
 }

--- a/src/main/java/org/sopt/bofit/domain/post/dto/request/PostUpdateRequest.java
+++ b/src/main/java/org/sopt/bofit/domain/post/dto/request/PostUpdateRequest.java
@@ -4,7 +4,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
 import org.hibernate.validator.constraints.Length;
 import org.sopt.bofit.domain.post.entity.constant.PostInfoConstant;
 import org.sopt.bofit.domain.post.service.dto.request.PostUpdateCommand;
@@ -12,8 +11,6 @@ import org.sopt.bofit.global.annotation.ValidPostCategory;
 import org.sopt.bofit.global.file.dto.request.UpdateImageRequest;
 
 import java.util.List;
-
-import static org.sopt.bofit.domain.comment.constant.CommentConstant.MAX_IMAGE_COUNT;
 
 public record PostUpdateRequest(
         @Schema(description = "제목", example = "ㅇㅇ")
@@ -32,13 +29,11 @@ public record PostUpdateRequest(
         String newCategory,
 
         @Schema(description = "수정된 이미지 목록")
-        @Size(max = MAX_IMAGE_COUNT, message = "이미지 url 의 최대 개수({max}) 를 초과했습니다.")
         @NotNull(message = "수정된 url 목록은  null 일 수 없습니다.")
         @Valid
         List<UpdateImageRequest> updatedImages,
 
         @Schema(description = "삭제할 이미지 ID 목록")
-        @Size(max = MAX_IMAGE_COUNT, message = "이미지 url 의 최대 개수({max}) 를 초과했습니다.")
         @NotNull(message = "삭제된 url 목록은  null 일 수 없습니다.")
         @Valid
         List<@NotNull Long> deleteImageIds

--- a/src/main/java/org/sopt/bofit/domain/post/dto/request/PostUpdateRequest.java
+++ b/src/main/java/org/sopt/bofit/domain/post/dto/request/PostUpdateRequest.java
@@ -4,14 +4,16 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import org.hibernate.validator.constraints.Length;
 import org.sopt.bofit.domain.post.entity.constant.PostInfoConstant;
 import org.sopt.bofit.domain.post.service.dto.request.PostUpdateCommand;
 import org.sopt.bofit.global.annotation.ValidPostCategory;
-import org.sopt.bofit.global.file.dto.request.NewImageRequest;
 import org.sopt.bofit.global.file.dto.request.UpdateImageRequest;
 
 import java.util.List;
+
+import static org.sopt.bofit.domain.comment.constant.CommentConstant.MAX_IMAGE_COUNT;
 
 public record PostUpdateRequest(
         @Schema(description = "제목", example = "ㅇㅇ")
@@ -29,20 +31,20 @@ public record PostUpdateRequest(
         @ValidPostCategory
         String newCategory,
 
-        @Schema(description = "추가할 이미지 목록")
+        @Schema(description = "수정된 이미지 목록")
+        @Size(max = MAX_IMAGE_COUNT, message = "이미지 url 의 최대 개수({max}) 를 초과했습니다.")
+        @NotNull(message = "수정된 url 목록은  null 일 수 없습니다.")
         @Valid
-        List<NewImageRequest> newImages,
-
-        @Schema(description = "수정할 이미지 목록")
-        @Valid
-        List<UpdateImageRequest> updateImages,
+        List<UpdateImageRequest> updatedImages,
 
         @Schema(description = "삭제할 이미지 ID 목록")
+        @Size(max = MAX_IMAGE_COUNT, message = "이미지 url 의 최대 개수({max}) 를 초과했습니다.")
+        @NotNull(message = "삭제된 url 목록은  null 일 수 없습니다.")
         @Valid
         List<@NotNull Long> deleteImageIds
 
 ) {
    public PostUpdateCommand toCommand(){
-        return new PostUpdateCommand(this.newTitle, this.newContent, this.newCategory, this.newImages, this.updateImages, this.deleteImageIds);
+        return new PostUpdateCommand(this.newTitle, this.newContent, this.newCategory, this.updatedImages, this.deleteImageIds);
    }
 }

--- a/src/main/java/org/sopt/bofit/domain/post/entity/PostImage.java
+++ b/src/main/java/org/sopt/bofit/domain/post/entity/PostImage.java
@@ -25,7 +25,7 @@ public class PostImage {
     private String imageUrl;
 
     @Column(nullable = false)
-    private int sequence;
+    private Integer sequence;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
@@ -46,5 +46,10 @@ public class PostImage {
 
     public void updateSequence(int sequence){
         this.sequence = sequence;
+    }
+
+    public void softDelete(){
+        this.status = PostImageStatus.INACTIVE;
+        this.sequence = null;
     }
 }

--- a/src/main/java/org/sopt/bofit/domain/post/entity/PostImage.java
+++ b/src/main/java/org/sopt/bofit/domain/post/entity/PostImage.java
@@ -1,20 +1,10 @@
 package org.sopt.bofit.domain.post.entity;
 
-import static org.sopt.bofit.global.file.constant.ImageConstant.MAX_IMAGE_URL_LENGTH;
+import jakarta.persistence.*;
+import lombok.*;
+import org.sopt.bofit.domain.post.entity.constant.PostImageStatus;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import static org.sopt.bofit.global.file.constant.ImageConstant.MAX_IMAGE_URL_LENGTH;
 
 @Entity
 @Getter
@@ -36,6 +26,11 @@ public class PostImage {
 
     @Column(nullable = false)
     private int sequence;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    @Builder.Default
+    PostImageStatus status = PostImageStatus.ACTIVE;
 
     public static PostImage create(String imageUrl, Post post, int sequence){
         return PostImage.builder()

--- a/src/main/java/org/sopt/bofit/domain/post/entity/constant/PostImageStatus.java
+++ b/src/main/java/org/sopt/bofit/domain/post/entity/constant/PostImageStatus.java
@@ -1,0 +1,9 @@
+package org.sopt.bofit.domain.post.entity.constant;
+
+import lombok.Getter;
+
+@Getter
+public enum PostImageStatus {
+    ACTIVE,
+    INACTIVE
+}

--- a/src/main/java/org/sopt/bofit/domain/post/repository/PostImageRepository.java
+++ b/src/main/java/org/sopt/bofit/domain/post/repository/PostImageRepository.java
@@ -1,6 +1,8 @@
 package org.sopt.bofit.domain.post.repository;
 
+import org.sopt.bofit.domain.post.entity.Post;
 import org.sopt.bofit.domain.post.entity.PostImage;
+import org.sopt.bofit.domain.post.entity.constant.PostStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -16,4 +18,6 @@ public interface PostImageRepository extends JpaRepository<PostImage, Long> {
     void deleteAllByPostIdAndIdIn(@Param("postId") Long postId, @Param("ids") List<Long> ids);
 
     boolean existsByIdAndPostId(Long id, Long postId);
+
+    List<PostImage> findAllByPostAndStatus(Post post, PostStatus status);
 }

--- a/src/main/java/org/sopt/bofit/domain/post/repository/PostImageRepository.java
+++ b/src/main/java/org/sopt/bofit/domain/post/repository/PostImageRepository.java
@@ -2,7 +2,7 @@ package org.sopt.bofit.domain.post.repository;
 
 import org.sopt.bofit.domain.post.entity.Post;
 import org.sopt.bofit.domain.post.entity.PostImage;
-import org.sopt.bofit.domain.post.entity.constant.PostStatus;
+import org.sopt.bofit.domain.post.entity.constant.PostImageStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -19,5 +19,5 @@ public interface PostImageRepository extends JpaRepository<PostImage, Long> {
 
     boolean existsByIdAndPostId(Long id, Long postId);
 
-    List<PostImage> findAllByPostAndStatus(Post post, PostStatus status);
+    List<PostImage> findAllByPostAndStatus(Post post, PostImageStatus status);
 }

--- a/src/main/java/org/sopt/bofit/domain/post/service/PostImageReader.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/PostImageReader.java
@@ -3,6 +3,7 @@ package org.sopt.bofit.domain.post.service;
 import lombok.RequiredArgsConstructor;
 import org.sopt.bofit.domain.post.entity.Post;
 import org.sopt.bofit.domain.post.entity.PostImage;
+import org.sopt.bofit.domain.post.entity.constant.PostImageStatus;
 import org.sopt.bofit.domain.post.entity.constant.PostStatus;
 import org.sopt.bofit.domain.post.repository.PostImageRepository;
 import org.springframework.stereotype.Service;
@@ -18,7 +19,7 @@ public class PostImageReader {
     private final PostImageRepository postImageRepository;
 
     public Map<Long, PostImage> getActiveImageAsMap(Post post){
-        return postImageRepository.findAllByPostAndStatus(post, PostStatus.ACTIVE).stream()
+        return postImageRepository.findAllByPostAndStatus(post, PostImageStatus.ACTIVE).stream()
                 .collect(Collectors.toMap(PostImage::getId, Function.identity()));
     }
 

--- a/src/main/java/org/sopt/bofit/domain/post/service/PostImageReader.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/PostImageReader.java
@@ -1,0 +1,25 @@
+package org.sopt.bofit.domain.post.service;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.bofit.domain.post.entity.Post;
+import org.sopt.bofit.domain.post.entity.PostImage;
+import org.sopt.bofit.domain.post.entity.constant.PostStatus;
+import org.sopt.bofit.domain.post.repository.PostImageRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class PostImageReader {
+
+    private final PostImageRepository postImageRepository;
+
+    public Map<Long, PostImage> getActiveImageAsMap(Post post){
+        return postImageRepository.findAllByPostAndStatus(post, PostStatus.ACTIVE).stream()
+                .collect(Collectors.toMap(PostImage::getId, Function.identity()));
+    }
+
+}

--- a/src/main/java/org/sopt/bofit/domain/post/service/PostImageWriter.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/PostImageWriter.java
@@ -1,0 +1,20 @@
+package org.sopt.bofit.domain.post.service;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.bofit.domain.post.entity.Post;
+import org.sopt.bofit.domain.post.entity.PostImage;
+import org.sopt.bofit.domain.post.repository.PostImageRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PostImageWriter {
+
+    private final PostImageRepository postImageRepository;
+
+    public PostImage create(Post post, String url, Integer sequence) {
+        PostImage postImage = PostImage.create(url, post, sequence);
+        return postImageRepository.save(postImage);
+    }
+
+}

--- a/src/main/java/org/sopt/bofit/domain/post/service/PostImageWriter.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/PostImageWriter.java
@@ -1,10 +1,15 @@
 package org.sopt.bofit.domain.post.service;
 
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.sopt.bofit.domain.post.entity.Post;
 import org.sopt.bofit.domain.post.entity.PostImage;
 import org.sopt.bofit.domain.post.repository.PostImageRepository;
+import org.sopt.bofit.global.file.dto.request.UpdateImageRequest;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -15,6 +20,28 @@ public class PostImageWriter {
     public PostImage create(Post post, String url, Integer sequence) {
         PostImage postImage = PostImage.create(url, post, sequence);
         return postImageRepository.save(postImage);
+    }
+
+    @Transactional
+    public void updateAll(
+            Post post,
+            Map<Long, PostImage> currentImages,
+            List<UpdateImageRequest> updatedImages
+    ){
+        updatedImages.forEach(image -> {
+            if(image.id() == null){
+                create(post, image.imageUrl(), image.sequence());
+            } else {
+                currentImages.get(image.id()).updateSequence(image.sequence());
+            }
+        });
+    }
+
+    @Transactional
+    public void softDelete(Map<Long, PostImage> postImages, List<Long> deleteImageIds){
+        deleteImageIds.forEach(id -> {
+            postImages.get(id).softDelete();
+        });
     }
 
 }

--- a/src/main/java/org/sopt/bofit/domain/post/service/PostService.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/PostService.java
@@ -4,12 +4,16 @@ import lombok.RequiredArgsConstructor;
 import org.sopt.bofit.domain.post.dto.response.PostCreateResponse;
 import org.sopt.bofit.domain.post.dto.response.PostDetailResponse;
 import org.sopt.bofit.domain.post.dto.response.PostSummaryResponse;
+import org.sopt.bofit.domain.post.entity.Post;
+import org.sopt.bofit.domain.post.service.dto.request.PostCreateCommand;
 import org.sopt.bofit.domain.post.service.dto.request.PostUpdateCommand;
+import org.sopt.bofit.domain.user.entity.User;
+import org.sopt.bofit.domain.user.service.UserReader;
 import org.sopt.bofit.global.dto.response.SliceResponse;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
+import java.util.stream.IntStream;
 
 @Service
 @RequiredArgsConstructor
@@ -19,8 +23,21 @@ public class PostService {
 
     private final PostWriter postWriter;
 
-    public PostCreateResponse createPost(Long userId, String title, String content, String category, List<String> imageUrls) {
-        return postWriter.createPost(userId, title, content, category, imageUrls);
+    private final UserReader userReader;
+
+    private final PostImageWriter postImageWriter;
+
+    @Transactional
+    public PostCreateResponse createPost(Long userId, PostCreateCommand command) {
+        User user = userReader.getActiveById(userId);
+
+        Post post = postWriter.createPost(userId, command.title(), command.content(), command.category());
+
+        IntStream.range(0, command.imageUrls().size())
+                .forEach(sequence -> postImageWriter
+                        .create(post, command.imageUrls().get(sequence), sequence + 1));
+
+        return PostCreateResponse.from(post.getId());
     }
 
     @Transactional

--- a/src/main/java/org/sopt/bofit/domain/post/service/PostService.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/PostService.java
@@ -17,7 +17,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Map;
-import java.util.Objects;
 import java.util.stream.IntStream;
 
 import static org.sopt.bofit.global.exception.constant.PostErrorCode.POST_UNAUTHORIZED;
@@ -55,15 +54,16 @@ public class PostService {
 
         post.getUser().checkIsWriter(userId, POST_UNAUTHORIZED);
 
+        post.updatePost(command.title(),command.content(), command.category());
+
         Map<Long, PostImage> postImageMap = postImageReader.getActiveImageAsMap(post);
 
         postImageWriter.softDelete(postImageMap, command.deleteImageIds());
         postImageWriter.updateAll(post, postImageMap, command.updatedImages());
 
         ImageValidator.validImageIds(postImageMap.keySet(), command.updatedImages().stream()
-                .map(UpdateImageRequest::id).filter(Objects::nonNull).toList(),
-                command.deleteImageIds()
-        );
+                        .filter(image -> image.id() != null).map(UpdateImageRequest::id).toList(),
+                command.deleteImageIds());
 
         return PostCreateResponse.from(post.getId());
     }

--- a/src/main/java/org/sopt/bofit/domain/post/service/PostService.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/PostService.java
@@ -5,15 +5,22 @@ import org.sopt.bofit.domain.post.dto.response.PostCreateResponse;
 import org.sopt.bofit.domain.post.dto.response.PostDetailResponse;
 import org.sopt.bofit.domain.post.dto.response.PostSummaryResponse;
 import org.sopt.bofit.domain.post.entity.Post;
+import org.sopt.bofit.domain.post.entity.PostImage;
 import org.sopt.bofit.domain.post.service.dto.request.PostCreateCommand;
 import org.sopt.bofit.domain.post.service.dto.request.PostUpdateCommand;
 import org.sopt.bofit.domain.user.entity.User;
 import org.sopt.bofit.domain.user.service.UserReader;
 import org.sopt.bofit.global.dto.response.SliceResponse;
+import org.sopt.bofit.global.file.dto.request.UpdateImageRequest;
+import org.sopt.bofit.global.file.util.ImageValidator;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Map;
+import java.util.Objects;
 import java.util.stream.IntStream;
+
+import static org.sopt.bofit.global.exception.constant.PostErrorCode.POST_UNAUTHORIZED;
 
 @Service
 @RequiredArgsConstructor
@@ -26,6 +33,7 @@ public class PostService {
     private final UserReader userReader;
 
     private final PostImageWriter postImageWriter;
+    private final PostImageReader postImageReader;
 
     @Transactional
     public PostCreateResponse createPost(Long userId, PostCreateCommand command) {
@@ -42,7 +50,22 @@ public class PostService {
 
     @Transactional
     public PostCreateResponse updatePost (Long userId, Long postId, PostUpdateCommand command) {
-        return postWriter.updatePost(userId, postId, command);
+        User user =  userReader.getActiveById(userId);
+        Post post = postReader.getActiveById(postId);
+
+        post.getUser().checkIsWriter(userId, POST_UNAUTHORIZED);
+
+        Map<Long, PostImage> postImageMap = postImageReader.getActiveImageAsMap(post);
+
+        postImageWriter.softDelete(postImageMap, command.deleteImageIds());
+        postImageWriter.updateAll(post, postImageMap, command.updatedImages());
+
+        ImageValidator.validImageIds(postImageMap.keySet(), command.updatedImages().stream()
+                .map(UpdateImageRequest::id).filter(Objects::nonNull).toList(),
+                command.deleteImageIds()
+        );
+
+        return PostCreateResponse.from(post.getId());
     }
 
     @Transactional

--- a/src/main/java/org/sopt/bofit/domain/post/service/PostWriter.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/PostWriter.java
@@ -42,23 +42,11 @@ public class PostWriter {
 
 
     @Transactional
-    public PostCreateResponse createPost(Long userId, String title, String content, String category, List<String> imageUrls) {
+    public Post createPost(Long userId, String title, String content, String category) {
         User user = userReader.getActiveById(userId);
-        Post newPost = Post.create(user, title, content, category, user.getNickname());
-        postRepository.save(newPost);
+        Post post = Post.create(user, title, content, category, user.getNickname());
 
-        int sequence = 1;
-        List<PostImage> postImages = new ArrayList<>();
-
-        if(imageUrls != null && !imageUrls.isEmpty()) {
-            for (String imageUrl : imageUrls) {
-                postImages.add(PostImage.create(imageUrl, newPost, sequence++));
-            }
-        }
-
-        postImageRepository.saveAll(postImages);
-
-        return PostCreateResponse.from(newPost.getId());
+        return postRepository.save(post);
     }
 
     @Transactional

--- a/src/main/java/org/sopt/bofit/domain/post/service/PostWriter.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/PostWriter.java
@@ -4,26 +4,13 @@ import lombok.RequiredArgsConstructor;
 import org.sopt.bofit.domain.comment.entity.Comment;
 import org.sopt.bofit.domain.comment.entity.CommentStatus;
 import org.sopt.bofit.domain.comment.repository.CommentRepository;
-import org.sopt.bofit.domain.post.dto.response.PostCreateResponse;
 import org.sopt.bofit.domain.post.entity.Post;
-import org.sopt.bofit.domain.post.entity.PostImage;
-import org.sopt.bofit.domain.post.repository.PostImageRepository;
 import org.sopt.bofit.domain.post.repository.PostRepository;
-import org.sopt.bofit.domain.post.service.dto.request.PostUpdateCommand;
 import org.sopt.bofit.domain.user.entity.User;
 import org.sopt.bofit.domain.user.service.UserReader;
-import org.sopt.bofit.global.exception.customexception.BadRequestException;
-import org.sopt.bofit.global.file.dto.request.NewImageRequest;
-import org.sopt.bofit.global.file.dto.request.UpdateImageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import static org.sopt.bofit.global.exception.constant.PostErrorCode.POST_IMAGE_MISMATCH;
 import static org.sopt.bofit.global.exception.constant.PostErrorCode.POST_UNAUTHORIZED;
 
 @Service
@@ -38,9 +25,6 @@ public class PostWriter {
 
     private final CommentRepository commentRepository;
 
-    private final PostImageRepository postImageRepository;
-
-
     @Transactional
     public Post createPost(Long userId, String title, String content, String category) {
         User user = userReader.getActiveById(userId);
@@ -49,96 +33,6 @@ public class PostWriter {
         return postRepository.save(post);
     }
 
-    @Transactional
-    public PostCreateResponse updatePost (Long userId, Long postId, PostUpdateCommand command) {
-        User user = userReader.getActiveById(userId);
-        Post post = postReader.getActiveById(postId);
-
-        post.getUser().checkIsWriter(userId, POST_UNAUTHORIZED);
-        post.updatePost(command.newTitle(), command.newContent(), command.newCategory());
-
-        List<PostImage> currentImages = postImageRepository.findByPostIdOrderBySequenceAsc(postId);
-
-        deleteImages(postId, command.deleteImageIds(), currentImages);
-
-        updateImages(command.updateImages(), currentImages);
-
-        addImages(command.newImages(), currentImages, post);
-
-        int seq = 1;
-        for(PostImage pi : currentImages) {
-            if(pi.getSequence() != seq){
-                pi.updateSequence(seq);
-            }
-            seq++;
-        }
-
-        return PostCreateResponse.from(post.getId());
-    }
-
-    private void addImages(List<NewImageRequest> newImages, List<PostImage> currentImages, Post post) {
-        if(newImages != null){
-            for(NewImageRequest req : newImages) {
-                int sequence = req.sequence() == null ? (currentImages.size() + 1) : req.sequence();
-
-                if(sequence < 1) sequence = 1;
-                if(sequence > currentImages.size() + 1) sequence = currentImages.size() + 1;
-
-                PostImage created = PostImage.create(req.imageUrl(), post, sequence);
-                postImageRepository.save(created);
-
-                currentImages.add(sequence - 1 ,created);
-            }
-        }
-    }
-
-    private void updateImages(List<UpdateImageRequest> updateImages, List<PostImage> currentImages) {
-        if (updateImages != null && !updateImages.isEmpty()) {
-            Map<Long, Integer> indexById = new HashMap<>();
-            for (int i = 0; i < currentImages.size(); i++) {
-                indexById.put(currentImages.get(i).getId(), i);
-            }
-
-            for (UpdateImageRequest req : updateImages) {
-                Integer from = indexById.get(req.id());
-                if (from == null) throw new BadRequestException(POST_IMAGE_MISMATCH);
-
-                PostImage img = currentImages.get(from);
-
-                if (req.imageUrl() != null && !req.imageUrl().isBlank()) {
-                    img.updateImageUrl(req.imageUrl());
-                }
-
-                if (req.sequence() != null) {
-                    int to = Math.max(0, Math.min(req.sequence() - 1, currentImages.size() - 1));
-                    moveSequence(currentImages, from, to);
-
-                    indexById.clear();
-                    for (int i = 0; i < currentImages.size(); i++) {
-                        indexById.put(currentImages.get(i).getId(), i);
-                    }
-                }
-            }
-        }
-    }
-
-    private void deleteImages(Long postId, List<Long> deleteImageIds, List<PostImage> currentImages) {
-        if(deleteImageIds != null && !deleteImageIds.isEmpty()) {
-            for(Long imageId : deleteImageIds) {
-                if(currentImages.stream().noneMatch(image -> image.getId().equals(imageId))) {
-                    throw new BadRequestException(POST_IMAGE_MISMATCH);
-                }
-            }
-            postImageRepository.deleteAllByPostIdAndIdIn(postId, deleteImageIds);
-            currentImages.removeIf(image -> deleteImageIds.contains(image.getId()));
-        }
-    }
-
-    private static <T> void moveSequence(List<T> list, int fromIdx, int toIdx) {
-        if (fromIdx == toIdx) return;
-        T e = list.remove(fromIdx);
-        list.add(toIdx, e);
-    }
 
     @Transactional
     public void deletePost(Long userId, Long postId) {

--- a/src/main/java/org/sopt/bofit/domain/post/service/dto/request/PostCreateCommand.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/dto/request/PostCreateCommand.java
@@ -1,0 +1,11 @@
+package org.sopt.bofit.domain.post.service.dto.request;
+
+import java.util.List;
+
+public record PostCreateCommand(
+        String title,
+        String content,
+        String category,
+        List<String> imageUrls
+) {
+}

--- a/src/main/java/org/sopt/bofit/domain/post/service/dto/request/PostUpdateCommand.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/dto/request/PostUpdateCommand.java
@@ -1,6 +1,5 @@
 package org.sopt.bofit.domain.post.service.dto.request;
 
-import org.sopt.bofit.global.file.dto.request.NewImageRequest;
 import org.sopt.bofit.global.file.dto.request.UpdateImageRequest;
 
 import java.util.List;
@@ -9,8 +8,7 @@ public record PostUpdateCommand(
         String newTitle,
         String newContent,
         String newCategory,
-        List<NewImageRequest> newImages,
-        List<UpdateImageRequest> updateImages,
+        List<UpdateImageRequest> updatedImages,
         List<Long> deleteImageIds
 ) {
 }

--- a/src/main/java/org/sopt/bofit/domain/post/service/dto/request/PostUpdateCommand.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/dto/request/PostUpdateCommand.java
@@ -5,9 +5,9 @@ import org.sopt.bofit.global.file.dto.request.UpdateImageRequest;
 import java.util.List;
 
 public record PostUpdateCommand(
-        String newTitle,
-        String newContent,
-        String newCategory,
+        String title,
+        String content,
+        String category,
         List<UpdateImageRequest> updatedImages,
         List<Long> deleteImageIds
 ) {

--- a/src/main/java/org/sopt/bofit/global/exception/constant/PostErrorCode.java
+++ b/src/main/java/org/sopt/bofit/global/exception/constant/PostErrorCode.java
@@ -14,7 +14,8 @@ public enum PostErrorCode implements ErrorCode {
     POST_LIKE_CREATE_CONFLICT(HttpStatus.CONFLICT.value(), "이미 좋아요를 누른 게시글입니다."),
     POST_LIKE_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "해당 게시글의 좋아요를 찾을 수 없습니다."),
     POST_IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "해당 게시물의 이미지를 찾을 수 없습니다."),
-    POST_IMAGE_MISMATCH(HttpStatus.BAD_REQUEST.value(), "해당 게시물에 속하지 않는 이미지입니다.")
+    POST_IMAGE_MISMATCH(HttpStatus.BAD_REQUEST.value(), "해당 게시물에 속하지 않는 이미지입니다."),
+    UNMATCHED_IMAGE(HttpStatus.BAD_REQUEST.value(), "기존 이미지와 수정/삭제하려는 이미지가 일치하지 않습니다.")
 
     ;
     private final int httpStatus;

--- a/src/main/java/org/sopt/bofit/global/file/util/ImageValidator.java
+++ b/src/main/java/org/sopt/bofit/global/file/util/ImageValidator.java
@@ -1,0 +1,20 @@
+package org.sopt.bofit.global.file.util;
+
+import org.sopt.bofit.global.exception.customexception.BadRequestException;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.sopt.bofit.global.exception.constant.PostErrorCode.UNMATCHED_IMAGE;
+
+public class ImageValidator {
+    public static void validImageIds(Set<Long> currentImageIds, List<Long> existIds, List<Long> deletedIds){
+        Set<Long> expectedIds = new HashSet<>(existIds);
+        expectedIds.addAll(deletedIds);
+
+        if(!currentImageIds.equals(expectedIds)){
+            throw new BadRequestException(UNMATCHED_IMAGE);
+        }
+    }
+}


### PR DESCRIPTION
## Related issue 🛠
- closed #154
  
## Work Description 📝
- 논의한 대로 게시물 수정 시에 이미지 수정 DTO를 두 가지로 분리했습니다.
- 아래의 로직이 대댓글 수정, 댓글 수정 시에 중복되어 나타나는데, 이것이 게시물 수정 시에도 쓰이기 때문에 별도의 클래스로 분리하였습니다. 
```
private void validImageIds(Set<Long> currentImageIds, List<Long> existIds, List<Long> deletedIds){
        Set<Long> expectedIds = new HashSet<>(existIds);
        expectedIds.addAll(deletedIds);

        if(!currentImageIds.equals(expectedIds)){
            throw new BadRequestException(CommentErrorCode.UNMATCHED_COMMENT_IMAGE);
        }
    }
```

