### PR TITLE
[Feat] 회원 탈퇴 API 구현

### DIFF
--- a/src/main/java/org/sopt/bofit/domain/post/repository/PostCustomRepository.java
+++ b/src/main/java/org/sopt/bofit/domain/post/repository/PostCustomRepository.java
@@ -12,4 +12,5 @@ public interface PostCustomRepository {
     Slice<PostSummaryResponse> findAllByCursorId(Long userId, Long cursorId, int size);
 
     Slice<PostSummaryResponse> findAllByKeywordAndCursorId(Long userId, String keyword, Long cursorId, int size);
+
 }

--- a/src/main/java/org/sopt/bofit/domain/post/repository/PostRepository.java
+++ b/src/main/java/org/sopt/bofit/domain/post/repository/PostRepository.java
@@ -54,4 +54,13 @@ public interface PostRepository extends PostJpaRepository, PostCustomRepository{
     void decreaseCommentCount(@Param("requestPost") Post post);
 
     boolean existsByIdAndUser(Long postId, User user);
+
+    @Modifying
+    @Query("""
+        UPDATE Post p
+        SET p.writerNickname = :nickname
+        WHERE p.user.id = :userId"""
+
+    )
+    void updateWriterNicknameByUserId(@Param("userId") Long userId, @Param("nickname") String nickname);
 }

--- a/src/main/java/org/sopt/bofit/domain/user/entity/User.java
+++ b/src/main/java/org/sopt/bofit/domain/user/entity/User.java
@@ -104,6 +104,10 @@ public class User extends BaseEntity {
         this.isRecommendInsurance = true;
     }
 
+    public void updateOauthId(String oauthId) {
+        this.oauthId = oauthId;
+    }
+
     public void checkIsWriter(User writer, ErrorCode errorCode) {
         if (!this.equals(writer)) {
             throw new ForbiddenException(errorCode);
@@ -114,6 +118,13 @@ public class User extends BaseEntity {
         if (!this.getId().equals(writerId)) {
             throw new ForbiddenException(errorCode);
         }
+    }
+
+    public void deactivate() {
+        final String UNKNOWN_NICKNAME = "알 수 없음";
+        this.status = UserStatus.INACTIVE;
+        this.nickname = UNKNOWN_NICKNAME;
+        this.profileImage = null;
     }
 
     @Override

--- a/src/main/java/org/sopt/bofit/domain/user/entity/User.java
+++ b/src/main/java/org/sopt/bofit/domain/user/entity/User.java
@@ -2,10 +2,7 @@ package org.sopt.bofit.domain.user.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
-import org.sopt.bofit.domain.user.entity.constant.Gender;
-import org.sopt.bofit.domain.user.entity.constant.Job;
-import org.sopt.bofit.domain.user.entity.constant.LoginProvider;
-import org.sopt.bofit.domain.user.entity.constant.UserStatus;
+import org.sopt.bofit.domain.user.entity.constant.*;
 import org.sopt.bofit.global.entity.BaseEntity;
 import org.sopt.bofit.global.exception.constant.ErrorCode;
 import org.sopt.bofit.global.exception.customexception.ForbiddenException;
@@ -121,9 +118,8 @@ public class User extends BaseEntity {
     }
 
     public void deactivate() {
-        final String UNKNOWN_NICKNAME = "알 수 없음";
         this.status = UserStatus.INACTIVE;
-        this.nickname = UNKNOWN_NICKNAME;
+        this.nickname = UserNicknameConstant.ANONYMOUS_NICKNAME;
         this.profileImage = null;
     }
 

--- a/src/main/java/org/sopt/bofit/domain/user/entity/constant/UserNicknameConstant.java
+++ b/src/main/java/org/sopt/bofit/domain/user/entity/constant/UserNicknameConstant.java
@@ -1,0 +1,10 @@
+package org.sopt.bofit.domain.user.entity.constant;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class UserNicknameConstant {
+
+    public final static String ANONYMOUS_NICKNAME = "알 수 없음";
+}

--- a/src/main/java/org/sopt/bofit/domain/user/service/UserWriter.java
+++ b/src/main/java/org/sopt/bofit/domain/user/service/UserWriter.java
@@ -59,4 +59,11 @@ public class UserWriter {
 		user.updateProfileImageUrl(newProfileImageUrl);
 	}
 
+	@Transactional
+	public void unlinkUser(User user) {
+		user.deactivate();
+
+		postRepository.updateWriterNicknameByUserId(user.getId(), user.getNickname());
+	}
+
 }

--- a/src/main/java/org/sopt/bofit/global/config/properties/KakaoProperties.java
+++ b/src/main/java/org/sopt/bofit/global/config/properties/KakaoProperties.java
@@ -9,5 +9,7 @@ public record KakaoProperties(
         String tokenUri,
         String redirectUri,
         String userInfoUri,
-        String logoutUri
+        String logoutUri,
+        String adminKey,
+        String unlinkUri
 ) { }

--- a/src/main/java/org/sopt/bofit/global/exception/constant/OAuthErrorCode.java
+++ b/src/main/java/org/sopt/bofit/global/exception/constant/OAuthErrorCode.java
@@ -8,7 +8,8 @@ public enum OAuthErrorCode implements ErrorCode {
     KAKAO_TOKEN_REQUEST_FAILED(HttpStatus.BAD_REQUEST.value(), "카카오 토큰 요청에 실패했습니다."),
     KAKAO_USER_INFO_REQUEST_FAILED(HttpStatus.BAD_REQUEST.value(), "카카오 계정 정보가 존재하지 않습니다."),
     JWT_REFRESH_NOT_FOUND(HttpStatus.UNAUTHORIZED.value(), "RefreshToken 정보가 존재하지 않습니다."),
-    JWT_REFRESH_TOKEN_MISMATCH(HttpStatus.UNAUTHORIZED.value(), "RefreshToken이 일치하지 않습니다.")
+    JWT_REFRESH_TOKEN_MISMATCH(HttpStatus.UNAUTHORIZED.value(), "RefreshToken이 일치하지 않습니다."),
+    UNLINKED_FAILED(HttpStatus.BAD_REQUEST.value(), "카카오 연결 해제 요청에 실패하였습니다"),
     ;
     private final int httpStatus;
     private final String message;

--- a/src/main/java/org/sopt/bofit/global/oauth/controller/OAuthController.java
+++ b/src/main/java/org/sopt/bofit/global/oauth/controller/OAuthController.java
@@ -62,5 +62,15 @@ public class OAuthController {
         return BaseResponse.ok(oAuthService.logout(userId, redirectUrl), "카카오 로그아웃 성공, 반환된 URL로 리다이렉트 시켜주세요");
     }
 
+    @Tag(name = TAG_NAME_KAKAO_LOGIN, description = TAG_DESCRIPTION_KAKAO_LOGIN)
+    @Operation(summary = "회원 탈퇴")
+    @DeleteMapping("/kakao/unlink")
+    public BaseResponse<Void> unlink(
+            @LoginUserId @Parameter(hidden = true) Long userId
+    ){
+        oAuthService.unlink(userId);
+        return BaseResponse.ok("회원 탈퇴 성공");
+    }
+
 
 }

--- a/src/main/java/org/sopt/bofit/global/oauth/service/OAuthService.java
+++ b/src/main/java/org/sopt/bofit/global/oauth/service/OAuthService.java
@@ -18,13 +18,11 @@ import org.sopt.bofit.global.oauth.entity.RefreshToken;
 import org.sopt.bofit.global.oauth.jwt.JwtProvider;
 import org.sopt.bofit.global.oauth.jwt.JwtUtil;
 import org.sopt.bofit.global.oauth.repository.RefreshTokenRepository;
+import org.sopt.bofit.global.oauth.util.OAuthClient;
 import org.sopt.bofit.global.oauth.util.OAuthUtil;
-import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.client.RestClient;
 
-import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 
 import static org.sopt.bofit.global.exception.constant.GlobalErrorCode.JWT_INVALID;
@@ -47,36 +45,10 @@ public class OAuthService {
 
     private final KakaoProperties properties;
 
-    private final RestClient restClient = RestClient.builder().baseUrl("").build();
-
-    private KaKaoTokenResponse requestToken(String code, Optional<String> redirectUrl) {
-        String body = OAuthUtil.buildTokenRequestBody(code, properties.clientId(),
-            redirectUrl.orElseGet(properties::redirectUri));
-
-        return restClient.post()
-                .uri(properties.tokenUri())
-                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                .body(body)
-                .retrieve()
-                .onStatus(status -> status.is4xxClientError() || status.is5xxServerError(),
-                        (req, res) -> {
-                            String errorBody = new String(res.getBody().readAllBytes(), StandardCharsets.UTF_8);
-                            log.error("❌ Kakao 토큰 요청 실패: {}", errorBody);
-                            throw new BadRequestException(KAKAO_TOKEN_REQUEST_FAILED);
-                        })
-                .body(KaKaoTokenResponse.class);
-    }
-
-    private KakaoUserResponse getUserInfo(String accessToken) {
-        return restClient.get()
-                .uri(properties.userInfoUri())
-                .headers(h -> h.setBearerAuth(accessToken))
-                .retrieve()
-                .body(KakaoUserResponse.class);
-    }
+    private final OAuthClient oAuthClient;
 
     private User registerOrLogin(String accessToken) {
-        KakaoUserResponse kakaoUser = getUserInfo(accessToken);
+        KakaoUserResponse kakaoUser = oAuthClient.getUserInfo(accessToken);
         KakaoAccount account = kakaoUser.kakaoAccount();
         if (account == null) {
             throw new BadRequestException(KAKAO_USER_INFO_REQUEST_FAILED);
@@ -100,7 +72,7 @@ public class OAuthService {
 
     @Transactional
     public KaKaoLoginResponse login(String code, Optional<String> redirectUrl) {
-        KaKaoTokenResponse token = requestToken(code, redirectUrl);
+        KaKaoTokenResponse token = oAuthClient.requestToken(code, redirectUrl);
         User user = registerOrLogin(token.accessToken());
 
         String accessToken = jwtProvider.generateAccessToken(user.getId());
@@ -116,7 +88,7 @@ public class OAuthService {
 
     @Transactional
     public KaKaoLoginResponse login(OAuthLoginRequest request) {
-        KaKaoTokenResponse token = requestToken(request.code(), Optional.ofNullable(request.redirectUrl()));
+        KaKaoTokenResponse token = oAuthClient.requestToken(request.code(), Optional.ofNullable(request.redirectUrl()));
         User user = registerOrLogin(token.accessToken());
 
         String accessToken = jwtProvider.generateAccessToken(user.getId());

--- a/src/main/java/org/sopt/bofit/global/oauth/service/OAuthService.java
+++ b/src/main/java/org/sopt/bofit/global/oauth/service/OAuthService.java
@@ -5,6 +5,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.sopt.bofit.domain.user.entity.User;
 import org.sopt.bofit.domain.user.entity.constant.LoginProvider;
 import org.sopt.bofit.domain.user.repository.UserRepository;
+import org.sopt.bofit.domain.user.service.UserReader;
+import org.sopt.bofit.domain.user.service.UserWriter;
 import org.sopt.bofit.global.config.properties.KakaoProperties;
 import org.sopt.bofit.global.exception.customexception.BadRequestException;
 import org.sopt.bofit.global.exception.customexception.UnAuthorizedException;
@@ -38,6 +40,10 @@ public class OAuthService {
     private final RefreshTokenRepository refreshTokenRepository;
 
     private final UserRepository userRepository;
+
+    private final UserReader userReader;
+
+    private final UserWriter userWriter;
 
     private final JwtProvider jwtProvider;
 
@@ -132,6 +138,20 @@ public class OAuthService {
                 .ifPresent(refreshTokenRepository::delete);
 
         return OAuthUtil.buildKakaoLogoutRedirectUrl(properties.logoutUri(), properties.clientId(), redirectUri).toString();
+    }
+
+    @Transactional
+    public void unlink(Long userId){
+        User user = userReader.getActiveById(userId);
+
+        oAuthClient.unlinkByAdminKey(user.getOauthId());
+
+        userWriter.unlinkUser(user);
+
+        //재가입 대비 oauthId 충돌 방지
+        user.updateOauthId(user.getOauthId() + ":INACTIVE");
+
+        refreshTokenRepository.findByUserId(userId).ifPresent(refreshTokenRepository::delete);
     }
 }
 

--- a/src/main/java/org/sopt/bofit/global/oauth/service/OAuthService.java
+++ b/src/main/java/org/sopt/bofit/global/oauth/service/OAuthService.java
@@ -140,7 +140,6 @@ public class OAuthService {
         return OAuthUtil.buildKakaoLogoutRedirectUrl(properties.logoutUri(), properties.clientId(), redirectUri).toString();
     }
 
-    @Transactional
     public void unlink(Long userId){
         User user = userReader.getActiveById(userId);
 

--- a/src/main/java/org/sopt/bofit/global/oauth/util/OAuthClient.java
+++ b/src/main/java/org/sopt/bofit/global/oauth/util/OAuthClient.java
@@ -8,12 +8,16 @@ import org.sopt.bofit.global.oauth.dto.response.KaKaoTokenResponse;
 import org.sopt.bofit.global.oauth.dto.response.KakaoUserResponse;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestClient;
 
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 
 import static org.sopt.bofit.global.exception.constant.OAuthErrorCode.KAKAO_TOKEN_REQUEST_FAILED;
+import static org.sopt.bofit.global.exception.constant.OAuthErrorCode.UNLINKED_FAILED;
 
 @Component
 @RequiredArgsConstructor
@@ -36,7 +40,7 @@ public class OAuthClient {
                         (req, res) -> {
                             String errorBody = new String(res.getBody().readAllBytes(), StandardCharsets.UTF_8);
                             log.error("❌ Kakao 토큰 요청 실패: {}", errorBody);
-                            throw new BadRequestException(KAKAO_TOKEN_REQUEST_FAILED);
+                            throw new BadRequestException(KAKAO_TOKEN_REQUEST_FAILED, errorBody);
                         })
                 .body(KaKaoTokenResponse.class);
     }
@@ -49,4 +53,27 @@ public class OAuthClient {
                 .body(KakaoUserResponse.class);
     }
 
+    public void unlinkByAdminKey(String kakaoUserId) {
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("target_id_type", "user_id");
+        body.add("target_id", kakaoUserId);
+
+        URI uri = OAuthUtil.buildKakaoUnlinkUri(properties.unlinkUri());
+
+        restClient.post()
+                .uri(uri)
+                .header("Authorization", "KakaoAK " + properties.adminKey())
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .body(body)
+                .retrieve()
+                .onStatus(
+                        status -> status.is4xxClientError() || status.is5xxServerError(),
+                        (req, res) -> {
+                            String errorBody = new String(res.getBody().readAllBytes(), StandardCharsets.UTF_8);
+                            log.error(" Kakao 연결 해제 실패 : {} ", errorBody);
+                            throw new BadRequestException(UNLINKED_FAILED, errorBody);
+                        }
+                )
+                .toBodilessEntity();
+    }
 }

--- a/src/main/java/org/sopt/bofit/global/oauth/util/OAuthClient.java
+++ b/src/main/java/org/sopt/bofit/global/oauth/util/OAuthClient.java
@@ -1,0 +1,52 @@
+package org.sopt.bofit.global.oauth.util;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.sopt.bofit.global.config.properties.KakaoProperties;
+import org.sopt.bofit.global.exception.customexception.BadRequestException;
+import org.sopt.bofit.global.oauth.dto.response.KaKaoTokenResponse;
+import org.sopt.bofit.global.oauth.dto.response.KakaoUserResponse;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+
+import static org.sopt.bofit.global.exception.constant.OAuthErrorCode.KAKAO_TOKEN_REQUEST_FAILED;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class OAuthClient {
+    private final RestClient restClient = RestClient.builder().baseUrl("").build();
+
+    private final KakaoProperties properties;
+
+    public KaKaoTokenResponse requestToken(String code, Optional<String> redirectUrl) {
+        String body = OAuthUtil.buildTokenRequestBody(code, properties.clientId(),
+                redirectUrl.orElseGet(properties::redirectUri));
+
+        return restClient.post()
+                .uri(properties.tokenUri())
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .body(body)
+                .retrieve()
+                .onStatus(status -> status.is4xxClientError() || status.is5xxServerError(),
+                        (req, res) -> {
+                            String errorBody = new String(res.getBody().readAllBytes(), StandardCharsets.UTF_8);
+                            log.error("❌ Kakao 토큰 요청 실패: {}", errorBody);
+                            throw new BadRequestException(KAKAO_TOKEN_REQUEST_FAILED);
+                        })
+                .body(KaKaoTokenResponse.class);
+    }
+
+    public KakaoUserResponse getUserInfo(String accessToken) {
+        return restClient.get()
+                .uri(properties.userInfoUri())
+                .headers(h -> h.setBearerAuth(accessToken))
+                .retrieve()
+                .body(KakaoUserResponse.class);
+    }
+
+}

--- a/src/main/java/org/sopt/bofit/global/oauth/util/OAuthUtil.java
+++ b/src/main/java/org/sopt/bofit/global/oauth/util/OAuthUtil.java
@@ -22,4 +22,11 @@ public class OAuthUtil {
                 .build(true)
                 .toUri();
     }
+
+    public static URI buildKakaoUnlinkUri(String unlinkBaseUri) {
+        return UriComponentsBuilder
+                .fromHttpUrl(unlinkBaseUri)
+                .build(true)
+                .toUri();
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -43,6 +43,7 @@ kakao:
   token-uri: https://kauth.kakao.com/oauth/token
   user-info-uri: https://kapi.kakao.com/v2/user/me
   logout-uri: https://kauth.kakao.com/oauth/logout
+  unlink-uri: https://kapi.kakao.com/v1/user/unlink
 jwt:
   secret: ${JWT_SECRET}
   accessTokenExpiration: ${ACCESS_EXPIRED_AT}
@@ -101,6 +102,8 @@ spring:
 kakao:
   client-id: ${KAKAO_CLIENT_ID}
   redirect-uri: ${KAKAO_REDIRECT_URI}
+  admin-key: ${KAKAO_ADMIN_KEY}
+
 ---
 spring:
   config:
@@ -125,6 +128,7 @@ spring:
 kakao:
   client-id: ${KAKAO_CLIENT_ID}
   redirect-uri: ${KAKAO_REDIRECT_URI}
+  admin-key: ${KAKAO_ADMIN_KEY}
 
 ---
 spring:

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -45,8 +45,10 @@ openai:
 
 kakao:
   client-id: test-client-id
+  admin-key: test-admin-key
   redirect-uri: http://localhost:8080/test
   logout-uri: https://kauth.kakao.com/oauth/logout
+  unlink-uri: https://kapi.kakao.com/v1/user/unlink
 
 cloud:
   aws:


### PR DESCRIPTION
## Related issue 🛠
- closed #139
  


## Work Description 📝
- 회원 탈퇴 API를 구현하였습니다. 요구사항에 맞게 소프트 딜리트 방식과 닉네임, 프로필 사진 등을 처리하였습니다.
- oauthId를 업데이트하는 부분이 있는데, 이는 탈퇴 후 동일한 카카오 계정 로그인 시 새로운 계정으로 회원가입을 하기 위해 oauthId의 unique 제약 때문에 탈퇴한 회원의 oauthId를 업데이트하여 중복을 방지하기 위함입니다.
- 또한 기존에 OauthService에서 RestClient를 통해 Http 요청을 보내는 로직까지 담당하고 있었는데, 이 책임을 분리하여 RestClient에 요청을 보내는 부분은 OauthClient가 담당하도록 하였습니다.