### PR TITLE
[Feat] 게시물 전체 조회 시 정렬 및 카테고리 필터링 구현

### DIFF
--- a/src/main/java/org/sopt/bofit/domain/comment/service/CommentService.java
+++ b/src/main/java/org/sopt/bofit/domain/comment/service/CommentService.java
@@ -1,13 +1,5 @@
 package org.sopt.bofit.domain.comment.service;
 
-import static org.sopt.bofit.domain.comment.constant.CommentConstant.MAX_IMAGE_COUNT;
-import static org.sopt.bofit.global.exception.constant.CommentErrorCode.COMMENT_UNAUTHORIZED;
-
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
 import org.sopt.bofit.domain.comment.dto.response.CommentWithImagesResponse;
 import org.sopt.bofit.domain.comment.entity.Comment;
@@ -29,6 +21,15 @@ import org.sopt.bofit.global.file.util.ImageValidator;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.IntStream;
+
+import static org.sopt.bofit.domain.comment.constant.CommentConstant.MAX_IMAGE_COUNT;
+import static org.sopt.bofit.global.exception.constant.CommentErrorCode.COMMENT_UNAUTHORIZED;
 
 @Service
 @RequiredArgsConstructor
@@ -61,6 +62,7 @@ public class CommentService {
                     .create(comment, command.imageUrls().get(sequence), sequence + 1));
 
 		postWriter.increaseCommentCount(post);
+        postWriter.increaseTrendScore(post);
         postCacheService.increaseCommentCount(postId);
 
 		return comment;
@@ -97,6 +99,7 @@ public class CommentService {
 		comment.checkPost(post);
 
 		postWriter.decreaseCommentCount(post);
+        postWriter.decreaseTrendScore(post);
         postCacheService.decreaseCommentCount(postId);
 
 		commentWriter.softDelete(comment);

--- a/src/main/java/org/sopt/bofit/domain/comment/service/CommentService.java
+++ b/src/main/java/org/sopt/bofit/domain/comment/service/CommentService.java
@@ -62,7 +62,6 @@ public class CommentService {
                     .create(comment, command.imageUrls().get(sequence), sequence + 1));
 
 		postWriter.increaseCommentCount(post);
-        postWriter.increaseTrendScore(post);
         postCacheService.increaseCommentCount(postId);
 
 		return comment;
@@ -99,7 +98,6 @@ public class CommentService {
 		comment.checkPost(post);
 
 		postWriter.decreaseCommentCount(post);
-        postWriter.decreaseTrendScore(post);
         postCacheService.decreaseCommentCount(postId);
 
 		commentWriter.softDelete(comment);

--- a/src/main/java/org/sopt/bofit/domain/commentreply/service/CommentReplyService.java
+++ b/src/main/java/org/sopt/bofit/domain/commentreply/service/CommentReplyService.java
@@ -1,11 +1,6 @@
 package org.sopt.bofit.domain.commentreply.service;
 
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
 import org.sopt.bofit.domain.comment.entity.Comment;
 import org.sopt.bofit.domain.comment.service.CommentReader;
@@ -18,6 +13,7 @@ import org.sopt.bofit.domain.commentreply.service.dto.request.CommentReplyUpdate
 import org.sopt.bofit.domain.commentreply.service.dto.response.CommentReplyResponse;
 import org.sopt.bofit.domain.post.entity.Post;
 import org.sopt.bofit.domain.post.service.PostReader;
+import org.sopt.bofit.domain.post.service.PostWriter;
 import org.sopt.bofit.domain.user.entity.User;
 import org.sopt.bofit.domain.user.service.UserReader;
 import org.sopt.bofit.global.dto.response.SliceResponse;
@@ -27,6 +23,12 @@ import org.sopt.bofit.global.file.util.ImageValidator;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.IntStream;
 
 @Service
 @RequiredArgsConstructor
@@ -42,6 +44,8 @@ public class CommentReplyService {
     private final CommentWriter commentWriter;
     private final UserReader userReader;
     private final PostReader postReader;
+
+    private final PostWriter postWriter;
 
     /**
      *  추후 이미지 개수가 많아지면 AllInBatch 등으로 수정하기
@@ -59,6 +63,7 @@ public class CommentReplyService {
                 .forEach(sequence ->
                     commentReplyImageWriter.create(commentReply, command.imageUrls().get(sequence), sequence+ 1));
         commentWriter.increaseReplyCount(comment);
+        postWriter.increaseTrendScore(post);
         return commentReply;
     }
 

--- a/src/main/java/org/sopt/bofit/domain/post/controller/PostController.java
+++ b/src/main/java/org/sopt/bofit/domain/post/controller/PostController.java
@@ -40,6 +40,7 @@ import org.sopt.bofit.domain.post.dto.request.PostUpdateRequest;
 import org.sopt.bofit.domain.post.dto.response.PostCreateResponse;
 import org.sopt.bofit.domain.post.dto.response.PostDetailResponse;
 import org.sopt.bofit.domain.post.dto.response.PostSummaryResponse;
+import org.sopt.bofit.domain.post.entity.constant.PostCategoryFilter;
 import org.sopt.bofit.domain.post.dto.response.TrendingPostsResponses;
 import org.sopt.bofit.domain.post.service.PostLikeService;
 import org.sopt.bofit.domain.post.service.PostService;
@@ -47,16 +48,16 @@ import org.sopt.bofit.global.annotation.CustomExceptionDescription;
 import org.sopt.bofit.global.annotation.LoginUserId;
 import org.sopt.bofit.global.dto.response.BaseResponse;
 import org.sopt.bofit.global.dto.response.SliceResponse;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Optional;
+
+import static org.sopt.bofit.domain.comment.constant.CommentConstant.COMMENTS_DEFAULT_SIZE;
+import static org.sopt.bofit.domain.commentreply.constant.CommentReplyConstant.COMMENT_REPLY_DEFAULT_SIZE;
+import static org.sopt.bofit.domain.post.constant.PostConstant.POSTS_DEFAULT_SIZE;
+import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.*;
+import static org.sopt.bofit.global.constant.SwaggerConstant.TAG_DESCRIPTION_COMMUNITY;
+import static org.sopt.bofit.global.constant.SwaggerConstant.TAG_NAME_COMMUNITY;
 
 @RestController
 @RequiredArgsConstructor
@@ -108,6 +109,8 @@ public class PostController {
     @GetMapping()
     public BaseResponse<SliceResponse<PostSummaryResponse, Long>> getAllPosts(
             @Parameter(hidden = true) @LoginUserId Long userId,
+            @RequestParam(required = false, defaultValue = "LATEST") String sort,
+            @RequestParam (required = false, defaultValue = "ALL") PostCategoryFilter category,
             @RequestParam(required = false, name = "cursor") Long cursorId,
             @RequestParam(required = false, defaultValue = POSTS_DEFAULT_SIZE) int size){
         return BaseResponse.ok(postService.getAllPosts(userId, cursorId, size), "게시물 전체 조회 성공");

--- a/src/main/java/org/sopt/bofit/domain/post/controller/PostController.java
+++ b/src/main/java/org/sopt/bofit/domain/post/controller/PostController.java
@@ -42,6 +42,7 @@ import org.sopt.bofit.domain.post.dto.response.PostDetailResponse;
 import org.sopt.bofit.domain.post.dto.response.PostSummaryResponse;
 import org.sopt.bofit.domain.post.entity.constant.PostCategoryFilter;
 import org.sopt.bofit.domain.post.dto.response.TrendingPostsResponses;
+import org.sopt.bofit.domain.post.entity.constant.PostSortOrder;
 import org.sopt.bofit.domain.post.service.PostLikeService;
 import org.sopt.bofit.domain.post.service.PostService;
 import org.sopt.bofit.global.annotation.CustomExceptionDescription;
@@ -109,11 +110,11 @@ public class PostController {
     @GetMapping()
     public BaseResponse<SliceResponse<PostSummaryResponse, Long>> getAllPosts(
             @Parameter(hidden = true) @LoginUserId Long userId,
-            @RequestParam(required = false, defaultValue = "LATEST") String sort,
+            @RequestParam(required = false, defaultValue = "LATEST") PostSortOrder sort,
             @RequestParam (required = false, defaultValue = "ALL") PostCategoryFilter category,
             @RequestParam(required = false, name = "cursor") Long cursorId,
             @RequestParam(required = false, defaultValue = POSTS_DEFAULT_SIZE) int size){
-        return BaseResponse.ok(postService.getAllPosts(userId, cursorId, size), "게시물 전체 조회 성공");
+        return BaseResponse.ok(postService.getAllPosts(sort, category, userId, cursorId, size), "게시물 전체 조회 성공");
     }
 
     @Tag(name = TAG_NAME_COMMUNITY, description = TAG_DESCRIPTION_COMMUNITY)

--- a/src/main/java/org/sopt/bofit/domain/post/dto/response/PostSummaryResponse.java
+++ b/src/main/java/org/sopt/bofit/domain/post/dto/response/PostSummaryResponse.java
@@ -1,8 +1,9 @@
 package org.sopt.bofit.domain.post.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.time.LocalDateTime;
 import org.sopt.bofit.global.dto.response.CursorProvider;
+
+import java.time.LocalDateTime;
 
 public record PostSummaryResponse (
         @Schema(description = "게시글 ID")
@@ -30,7 +31,7 @@ public record PostSummaryResponse (
         LocalDateTime createdAt,
 
         @Schema(description = "좋아요 수")
-        Long likeCount,
+        int likeCount,
 
         @Schema(description = "사용자의 좋아요 여부")
         boolean likedByCurrentUser

--- a/src/main/java/org/sopt/bofit/domain/post/entity/Post.java
+++ b/src/main/java/org/sopt/bofit/domain/post/entity/Post.java
@@ -1,26 +1,13 @@
 package org.sopt.bofit.domain.post.entity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import java.util.Objects;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import jakarta.persistence.*;
+import lombok.*;
 import org.sopt.bofit.domain.post.entity.constant.PostCategory;
 import org.sopt.bofit.domain.post.entity.constant.PostStatus;
 import org.sopt.bofit.domain.user.entity.User;
 import org.sopt.bofit.global.entity.BaseEntity;
+
+import java.util.Objects;
 
 @Entity
 @Getter
@@ -62,6 +49,9 @@ public class Post extends BaseEntity {
 
     @Column(nullable = false, columnDefinition = "BIGINT DEFAULT 0")
     private int commentCount;
+
+    @Column(nullable = false, columnDefinition = "BIGINT DEFAULT 0")
+    private int trendScore;
 
     public static Post create(User user, String title, String content, String category, String writerNickname) {
         return Post.builder()

--- a/src/main/java/org/sopt/bofit/domain/post/entity/constant/PostCategoryFilter.java
+++ b/src/main/java/org/sopt/bofit/domain/post/entity/constant/PostCategoryFilter.java
@@ -1,0 +1,5 @@
+package org.sopt.bofit.domain.post.entity.constant;
+
+public enum PostCategoryFilter {
+    ALL, QNA, INFORMATION, CONVERSATION
+}

--- a/src/main/java/org/sopt/bofit/domain/post/entity/constant/PostSortOrder.java
+++ b/src/main/java/org/sopt/bofit/domain/post/entity/constant/PostSortOrder.java
@@ -1,0 +1,5 @@
+package org.sopt.bofit.domain.post.entity.constant;
+
+public enum PostSortOrder {
+    LATEST, POPULAR
+}

--- a/src/main/java/org/sopt/bofit/domain/post/repository/PostCustomRepository.java
+++ b/src/main/java/org/sopt/bofit/domain/post/repository/PostCustomRepository.java
@@ -1,10 +1,14 @@
 package org.sopt.bofit.domain.post.repository;
 
 import org.sopt.bofit.domain.post.dto.response.PostSummaryResponse;
+import org.sopt.bofit.domain.post.entity.Post;
+import org.sopt.bofit.domain.post.entity.constant.PostCategoryFilter;
+import org.sopt.bofit.domain.post.entity.constant.PostSortOrder;
 import org.sopt.bofit.domain.user.dto.response.MyPostSummaryResponse;
 import org.springframework.data.domain.Slice;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public interface PostCustomRepository {
     Slice<MyPostSummaryResponse> findPostsByCursorId(Long userId, Long cursorId, int size);

--- a/src/main/java/org/sopt/bofit/domain/post/repository/PostCustomRepository.java
+++ b/src/main/java/org/sopt/bofit/domain/post/repository/PostCustomRepository.java
@@ -1,18 +1,17 @@
 package org.sopt.bofit.domain.post.repository;
 
-import java.time.LocalDateTime;
-import java.util.List;
 import org.sopt.bofit.domain.post.dto.response.PostSummaryResponse;
-import org.sopt.bofit.domain.post.entity.Post;
 import org.sopt.bofit.domain.user.dto.response.MyPostSummaryResponse;
 import org.springframework.data.domain.Slice;
+
+import java.time.LocalDateTime;
 
 public interface PostCustomRepository {
     Slice<MyPostSummaryResponse> findPostsByCursorId(Long userId, Long cursorId, int size);
 
     void deletePostByPostId(Long postId);
 
-    Slice<PostSummaryResponse> findAllByCursorId(Long userId, Long cursorId, int size);
+    Slice<PostSummaryResponse> findAllByCursorId(PostSortOrder order, PostCategoryFilter category, Long userId, Long cursorId, int size);
 
     Slice<PostSummaryResponse> findAllByKeywordAndCursorId(Long userId, String keyword, Long cursorId, int size);
 

--- a/src/main/java/org/sopt/bofit/domain/post/repository/PostCustomRepositoryImpl.java
+++ b/src/main/java/org/sopt/bofit/domain/post/repository/PostCustomRepositoryImpl.java
@@ -1,5 +1,7 @@
 package org.sopt.bofit.domain.post.repository;
 
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.OrderSpecifier;
 import static org.sopt.bofit.domain.post.constant.TrendPostConstant.TREND_POST_COMMENT_REPLY_WEIGHT;
 import static org.sopt.bofit.domain.post.constant.TrendPostConstant.TREND_POST_COMMENT_WEIGHT;
 import static org.sopt.bofit.domain.post.constant.TrendPostConstant.TREND_POST_LIKE_WEIGHT;
@@ -21,6 +23,8 @@ import org.sopt.bofit.domain.post.dto.response.PostSummaryResponse;
 import org.sopt.bofit.domain.post.entity.Post;
 import org.sopt.bofit.domain.post.entity.QPost;
 import org.sopt.bofit.domain.post.entity.QPostLike;
+import org.sopt.bofit.domain.post.entity.constant.PostCategoryFilter;
+import org.sopt.bofit.domain.post.entity.constant.PostSortOrder;
 import org.sopt.bofit.domain.post.entity.constant.PostStatus;
 import org.sopt.bofit.domain.user.dto.response.MyPostSummaryResponse;
 import org.springframework.data.domain.PageRequest;
@@ -80,9 +84,21 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
     }
 
     @Override
-    public Slice<PostSummaryResponse> findAllByCursorId(Long userId, Long cursorId, int size) {
+    public Slice<PostSummaryResponse> findAllByCursorId(PostSortOrder order, PostCategoryFilter category, Long userId, Long cursorId, int size) {
         QPost post = QPost.post;
         QPostLike postLike = QPostLike.postLike;
+
+        BooleanBuilder where = new BooleanBuilder()
+                .and(post.status.eq(PostStatus.ACTIVE));
+        if (cursorId != null) where.and(post.id.lt(cursorId));
+        if (category != null && category != PostCategoryFilter.ALL) {
+            where.and(post.postCategory.stringValue().eq(category.name()));
+        }
+
+        OrderSpecifier<?> orderBy = switch (order) {
+            case LATEST -> post.createdAt.desc();
+            case POPULAR -> post.likeCount.desc();
+        };
 
         BooleanExpression likedByCurrentUser = getLikedByCurrentUser(userId, postLike, post);
 
@@ -100,11 +116,8 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
                         likedByCurrentUser
                 ))
                 .from(post)
-                .where(
-                        post.status.eq(PostStatus.ACTIVE),
-                        cursorId != null ? post.id.lt(cursorId) : null
-                )
-                .orderBy(post.id.desc())
+                .where(where)
+                .orderBy(orderBy)
                 .limit(size + 1)
                 .fetch();
 

--- a/src/main/java/org/sopt/bofit/domain/post/repository/PostCustomRepositoryImpl.java
+++ b/src/main/java/org/sopt/bofit/domain/post/repository/PostCustomRepositoryImpl.java
@@ -2,20 +2,12 @@ package org.sopt.bofit.domain.post.repository;
 
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.OrderSpecifier;
-import static org.sopt.bofit.domain.post.constant.TrendPostConstant.TREND_POST_COMMENT_REPLY_WEIGHT;
-import static org.sopt.bofit.domain.post.constant.TrendPostConstant.TREND_POST_COMMENT_WEIGHT;
-import static org.sopt.bofit.domain.post.constant.TrendPostConstant.TREND_POST_LIKE_WEIGHT;
-import static org.sopt.bofit.domain.post.constant.TrendPostConstant.TREND_POST_SCORED_DATE_RANGE;
-import static org.sopt.bofit.domain.post.entity.constant.PostStatus.ACTIVE;
-
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import java.time.LocalDateTime;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.sopt.bofit.domain.comment.entity.QComment;
 import org.sopt.bofit.domain.commentreply.entity.QCommentReply;
@@ -31,6 +23,12 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.sopt.bofit.domain.post.constant.TrendPostConstant.*;
+import static org.sopt.bofit.domain.post.entity.constant.PostStatus.ACTIVE;
 
 
 @Repository
@@ -122,7 +120,7 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
     private OrderSpecifier<?> getSortOrder(PostSortOrder order, QPost post) {
         return switch (order) {
             case LATEST -> post.createdAt.desc();
-            case POPULAR -> post.likeCount.desc();
+            case POPULAR -> post.trendScore.desc();
         };
     }
 

--- a/src/main/java/org/sopt/bofit/domain/post/repository/PostCustomRepositoryImpl.java
+++ b/src/main/java/org/sopt/bofit/domain/post/repository/PostCustomRepositoryImpl.java
@@ -88,17 +88,9 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
         QPost post = QPost.post;
         QPostLike postLike = QPostLike.postLike;
 
-        BooleanBuilder where = new BooleanBuilder()
-                .and(post.status.eq(PostStatus.ACTIVE));
-        if (cursorId != null) where.and(post.id.lt(cursorId));
-        if (category != null && category != PostCategoryFilter.ALL) {
-            where.and(post.postCategory.stringValue().eq(category.name()));
-        }
+        BooleanBuilder where = getCategoryFilter(category, cursorId, post);
 
-        OrderSpecifier<?> orderBy = switch (order) {
-            case LATEST -> post.createdAt.desc();
-            case POPULAR -> post.likeCount.desc();
-        };
+        OrderSpecifier<?> orderBy = getSortOrder(order, post);
 
         BooleanExpression likedByCurrentUser = getLikedByCurrentUser(userId, postLike, post);
 
@@ -125,6 +117,23 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
         if (hasNext) content.remove(size);
 
         return new SliceImpl<>(content, PageRequest.of(0, size), hasNext);
+    }
+
+    private OrderSpecifier<?> getSortOrder(PostSortOrder order, QPost post) {
+        return switch (order) {
+            case LATEST -> post.createdAt.desc();
+            case POPULAR -> post.likeCount.desc();
+        };
+    }
+
+    private BooleanBuilder getCategoryFilter(PostCategoryFilter category, Long cursorId, QPost post) {
+        BooleanBuilder where = new BooleanBuilder()
+                .and(post.status.eq(PostStatus.ACTIVE));
+        if (cursorId != null) where.and(post.id.lt(cursorId));
+        if (category != null && category != PostCategoryFilter.ALL) {
+            where.and(post.postCategory.stringValue().eq(category.name()));
+        }
+        return where;
     }
 
     private BooleanExpression getLikedByCurrentUser(Long userId, QPostLike postLike, QPost post) {

--- a/src/main/java/org/sopt/bofit/domain/post/repository/PostJpaRepository.java
+++ b/src/main/java/org/sopt/bofit/domain/post/repository/PostJpaRepository.java
@@ -19,18 +19,20 @@ public interface PostJpaRepository extends JpaRepository<Post, Long> {
     @Modifying
     @Query("""
 		update Post p
-		set p.likeCount = p.likeCount + 1
+		set p.likeCount = p.likeCount + 1,
+			p.trendScore = p.trendScore + 1
 		where p = :requestPost
 		""")
-    void increaseLikeCount(@Param("requestPost") Post post);
+    void increaseLikeCountAndTrendScore(@Param("requestPost") Post post);
 
     @Modifying
     @Query("""
         UPDATE Post p
-        SET p.likeCount = p.likeCount - 1
+        SET p.likeCount = p.likeCount - 1,
+            p.trendScore = p.trendScore - 1   
         WHERE p = :requestPost
         """)
-    void decreaseLikeCount(@Param("requestPost") Post post);
+    void decreaseLikeCountAndTrendScore(@Param("requestPost") Post post);
 
     @Modifying
     @Query("""
@@ -44,20 +46,22 @@ public interface PostJpaRepository extends JpaRepository<Post, Long> {
     @Modifying
     @Query("""
         UPDATE Post p
-        SET p.commentCount = p.commentCount + 1
+        SET p.commentCount = p.commentCount + 1,
+            p.trendScore = p.trendScore + 1    
         WHERE p = :requestPost
         """
     )
-    void increaseCommentCount(@Param("requestPost") Post post);
+    void increaseCommentCountAndTrendScore(@Param("requestPost") Post post);
 
     @Modifying
     @Query("""
         UPDATE Post p
-        SET p.commentCount = p.commentCount - 1
+        SET p.commentCount = p.commentCount - 1,
+            p.trendScore = p.trendScore - 1    
         WHERE p = :requestPost
         """
     )
-    void decreaseCommentCount(@Param("requestPost") Post post);
+    void decreaseCommentCountAndTrendScore(@Param("requestPost") Post post);
 
     @Modifying
     @Query("""
@@ -84,6 +88,8 @@ public interface PostJpaRepository extends JpaRepository<Post, Long> {
         WHERE p = :requestPost
         """
     )
+
+
     void decreaseTrendScore(@Param("requestPost") Post post);
 
 }

--- a/src/main/java/org/sopt/bofit/domain/post/repository/PostJpaRepository.java
+++ b/src/main/java/org/sopt/bofit/domain/post/repository/PostJpaRepository.java
@@ -1,6 +1,5 @@
 package org.sopt.bofit.domain.post.repository;
 
-import java.util.Optional;
 import org.sopt.bofit.domain.post.entity.Post;
 import org.sopt.bofit.domain.post.entity.constant.PostStatus;
 import org.sopt.bofit.domain.user.entity.User;
@@ -8,6 +7,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface PostJpaRepository extends JpaRepository<Post, Long> {
 
@@ -66,5 +67,23 @@ public interface PostJpaRepository extends JpaRepository<Post, Long> {
 
     )
     void updateWriterNicknameByUserId(@Param("userId") Long userId, @Param("nickname") String nickname);
+
+    @Modifying
+    @Query("""
+        UPDATE Post p
+        SET p.trendScore = p.trendScore + 1
+        WHERE p = :requestPost
+        """
+    )
+    void increaseTrendScore(@Param("requestPost") Post post);
+
+    @Modifying
+    @Query("""
+        UPDATE Post p
+        SET p.trendScore = p.trendScore - 1
+        WHERE p = :requestPost
+        """
+    )
+    void decreaseTrendScore(@Param("requestPost") Post post);
 
 }

--- a/src/main/java/org/sopt/bofit/domain/post/service/PostLikeService.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/PostLikeService.java
@@ -37,7 +37,6 @@ public class PostLikeService {
 
         PostLike postLike = postLikeWriter.create(post, user);
         postWriter.increaseLikeCount(post);
-        postWriter.increaseTrendScore(post);
         postCacheService.increaseLikeCount(postId);
 
     }
@@ -52,7 +51,6 @@ public class PostLikeService {
         postLikeWriter.delete(postLike);
 
         postWriter.decreaseLikeCount(post);
-        postWriter.decreaseTrendScore(post);
         postCacheService.decreaseLikeCount(postId);
     }
 }

--- a/src/main/java/org/sopt/bofit/domain/post/service/PostLikeService.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/PostLikeService.java
@@ -37,7 +37,9 @@ public class PostLikeService {
 
         PostLike postLike = postLikeWriter.create(post, user);
         postWriter.increaseLikeCount(post);
+        postWriter.increaseTrendScore(post);
         postCacheService.increaseLikeCount(postId);
+
     }
 
     @Transactional
@@ -50,6 +52,7 @@ public class PostLikeService {
         postLikeWriter.delete(postLike);
 
         postWriter.decreaseLikeCount(post);
+        postWriter.decreaseTrendScore(post);
         postCacheService.decreaseLikeCount(postId);
     }
 }

--- a/src/main/java/org/sopt/bofit/domain/post/service/PostReader.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/PostReader.java
@@ -12,6 +12,8 @@ import org.sopt.bofit.domain.comment.repository.CommentRepository;
 import org.sopt.bofit.domain.post.dto.response.PostDetailResponse;
 import org.sopt.bofit.domain.post.dto.response.PostSummaryResponse;
 import org.sopt.bofit.domain.post.entity.Post;
+import org.sopt.bofit.domain.post.entity.constant.PostCategoryFilter;
+import org.sopt.bofit.domain.post.entity.constant.PostSortOrder;
 import org.sopt.bofit.domain.post.entity.constant.PostStatus;
 import org.sopt.bofit.domain.post.repository.PostImageRepository;
 import org.sopt.bofit.domain.post.repository.PostRepository;
@@ -31,9 +33,10 @@ public class PostReader {
 
     private final PostImageRepository postImageRepository;
 
-    public SliceResponse<PostSummaryResponse, Long> getAllPosts(Long userId, Long cursorId, int size){
+    public SliceResponse<PostSummaryResponse, Long> getAllPosts(PostSortOrder order, PostCategoryFilter category,
+                                                                Long userId, Long cursorId, int size){
 
-        Slice<PostSummaryResponse> postList = postRepository.findAllByCursorId(userId, cursorId, size);
+        Slice<PostSummaryResponse> postList = postRepository.findAllByCursorId(order, category, userId, cursorId, size);
 
         return SliceResponse.from(postList);
     }

--- a/src/main/java/org/sopt/bofit/domain/post/service/PostService.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/PostService.java
@@ -1,24 +1,13 @@
 package org.sopt.bofit.domain.post.service;
 
-import static org.sopt.bofit.global.exception.constant.PostErrorCode.POST_UNAUTHORIZED;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
 import org.sopt.bofit.domain.post.dto.response.PostCreateResponse;
 import org.sopt.bofit.domain.post.dto.response.PostDetailResponse;
 import org.sopt.bofit.domain.post.dto.response.PostSummaryResponse;
-import org.sopt.bofit.domain.post.dto.response.TrendingPostsResponses;
 import org.sopt.bofit.domain.post.entity.Post;
 import org.sopt.bofit.domain.post.entity.PostImage;
-import org.sopt.bofit.domain.post.entity.TrendPost;
-import org.sopt.bofit.domain.post.entity.constant.TrendPostSort;
 import org.sopt.bofit.domain.post.service.dto.request.PostCreateCommand;
 import org.sopt.bofit.domain.post.service.dto.request.PostUpdateCommand;
-import org.sopt.bofit.domain.post.service.dto.response.TrendingPostDto;
 import org.sopt.bofit.domain.user.entity.User;
 import org.sopt.bofit.domain.user.service.UserReader;
 import org.sopt.bofit.global.dto.response.SliceResponse;
@@ -26,6 +15,11 @@ import org.sopt.bofit.global.file.dto.request.UpdateImageRequest;
 import org.sopt.bofit.global.file.util.ImageValidator;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
+import java.util.stream.IntStream;
+
+import static org.sopt.bofit.global.exception.constant.PostErrorCode.POST_UNAUTHORIZED;
 
 @Service
 @RequiredArgsConstructor
@@ -91,8 +85,9 @@ public class PostService {
         trendPostWriter.validDeletePost(post);
     }
 
-    public SliceResponse<PostSummaryResponse, Long> getAllPosts(Long userId, Long cursorId, int size){
-        return postReader.getAllPosts(userId, cursorId, size);
+    public SliceResponse<PostSummaryResponse, Long> getAllPosts(PostSortOrder order, PostCategoryFilter category,
+                                                                Long userId, Long cursorId, int size){
+        return postReader.getAllPosts(order, category, userId, cursorId, size);
     }
 
     public PostDetailResponse getPostDetail(Long userId, Long postId){

--- a/src/main/java/org/sopt/bofit/domain/post/service/PostService.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/PostService.java
@@ -4,10 +4,16 @@ import lombok.RequiredArgsConstructor;
 import org.sopt.bofit.domain.post.dto.response.PostCreateResponse;
 import org.sopt.bofit.domain.post.dto.response.PostDetailResponse;
 import org.sopt.bofit.domain.post.dto.response.PostSummaryResponse;
+import org.sopt.bofit.domain.post.dto.response.TrendingPostsResponses;
 import org.sopt.bofit.domain.post.entity.Post;
 import org.sopt.bofit.domain.post.entity.PostImage;
+import org.sopt.bofit.domain.post.entity.TrendPost;
+import org.sopt.bofit.domain.post.entity.constant.PostCategoryFilter;
+import org.sopt.bofit.domain.post.entity.constant.PostSortOrder;
+import org.sopt.bofit.domain.post.entity.constant.TrendPostSort;
 import org.sopt.bofit.domain.post.service.dto.request.PostCreateCommand;
 import org.sopt.bofit.domain.post.service.dto.request.PostUpdateCommand;
+import org.sopt.bofit.domain.post.service.dto.response.TrendingPostDto;
 import org.sopt.bofit.domain.user.entity.User;
 import org.sopt.bofit.domain.user.service.UserReader;
 import org.sopt.bofit.global.dto.response.SliceResponse;
@@ -16,6 +22,9 @@ import org.sopt.bofit.global.file.util.ImageValidator;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.IntStream;
 

--- a/src/main/java/org/sopt/bofit/domain/post/service/PostWriter.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/PostWriter.java
@@ -58,4 +58,14 @@ public class PostWriter {
     public void decreaseCommentCount(Post post){
         postRepository.decreaseCommentCount(post);
     }
+
+    @Transactional
+    public void increaseTrendScore(Post post){
+        postRepository.increaseTrendScore(post);
+    }
+
+    @Transactional
+    public void decreaseTrendScore(Post post){
+        postRepository.decreaseTrendScore(post);
+    }
 }

--- a/src/main/java/org/sopt/bofit/domain/post/service/PostWriter.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/PostWriter.java
@@ -41,22 +41,22 @@ public class PostWriter {
 
     @Transactional
     public void increaseLikeCount(Post post){
-        postRepository.increaseLikeCount(post);
+        postRepository.increaseLikeCountAndTrendScore(post);
     }
 
     @Transactional
     public void decreaseLikeCount(Post post){
-        postRepository.decreaseLikeCount(post);
+        postRepository.decreaseLikeCountAndTrendScore(post);
     }
 
     @Transactional
     public void increaseCommentCount(Post post){
-        postRepository.increaseCommentCount(post);
+        postRepository.increaseCommentCountAndTrendScore(post);
     }
 
     @Transactional
     public void decreaseCommentCount(Post post){
-        postRepository.decreaseCommentCount(post);
+        postRepository.decreaseCommentCountAndTrendScore(post);
     }
 
     @Transactional


### PR DESCRIPTION
## Related issue 🛠
- closed #165

## Work Description 📝
- 게시물을 전체 조회할 때 정렬 (인기순, 최신순)과 카테고리 필터링을 하도록 구현했습니다.
## Uncompleted Tasks 😅
- 인기순의 기준이 아직 모호해서 기획 측에서 답변이 오면 그거에 맞춰 수정하겠습니다! 현재는 좋아요 개수로 구현했습니다.

