### PR TITLE
[Feat] 검색어가 1글자인 경우 like 연산 수행하도록 구현

### DIFF
--- a/src/main/java/org/sopt/bofit/domain/post/repository/PostCustomRepositoryImpl.java
+++ b/src/main/java/org/sopt/bofit/domain/post/repository/PostCustomRepositoryImpl.java
@@ -121,7 +121,16 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
 
         BooleanExpression likedByCurrentUser = getLikedByCurrentUser(userId, postLike, post);
 
-        NumberExpression<Double> relevanceScore = getRelevanceScore(keyword, post);
+        BooleanExpression searchCondition;
+        if (keyword != null && keyword.length() < 2) {
+            String likePattern = "%" + keyword + "%";
+            searchCondition = post.title.like(likePattern)
+                    .or(post.content.like(likePattern))
+                    .or(post.writerNickname.like(likePattern));
+        } else {
+            NumberExpression<Double> relevanceScore = getRelevanceScore(keyword, post);
+            searchCondition = relevanceScore.gt(0);
+        }
 
         List<PostSummaryResponse> content = queryFactory
                 .select(Projections.constructor(PostSummaryResponse.class,
@@ -137,11 +146,13 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
                         likedByCurrentUser
                 ))
                 .from(post)
-                .where(relevanceScore.gt(0),
+                .where(searchCondition,
                         post.status.eq(PostStatus.ACTIVE),
                         cursorId != null ? post.id.lt(cursorId) : null
                         )
-                .orderBy(relevanceScore.desc())
+                .orderBy(keyword != null && keyword.length() > 1
+                        ? getRelevanceScore(keyword, post).desc()
+                        : post.id.desc())
                 .limit(size + 1)
                 .fetch();
 

--- a/src/main/java/org/sopt/bofit/domain/post/repository/PostRepository.java
+++ b/src/main/java/org/sopt/bofit/domain/post/repository/PostRepository.java
@@ -63,4 +63,6 @@ public interface PostRepository extends PostJpaRepository, PostCustomRepository{
 
     )
     void updateWriterNicknameByUserId(@Param("userId") Long userId, @Param("nickname") String nickname);
+
+
 }


### PR DESCRIPTION
## Related issue 🛠
- closed #162
  


## Work Description 📝
- 게시물이 1글자인 경우 like 연산을 수행하도록 메서드 내부 로직을 수정하였습니다.
- 1글자인 경우에는 Full Text Search를 수행하지 않기 때문에 시간 순으로 정렬합니다.
