### PR TITLE
[Feat] 인기 게시글 조회 API 구현

### DIFF
--- a/src/main/java/org/sopt/bofit/domain/comment/service/CommentService.java
+++ b/src/main/java/org/sopt/bofit/domain/comment/service/CommentService.java
@@ -16,6 +16,7 @@ import org.sopt.bofit.domain.comment.service.dto.request.CommentCreateCommand;
 import org.sopt.bofit.domain.comment.service.dto.request.CommentUpdateCommand;
 import org.sopt.bofit.domain.comment.service.dto.response.CommentResponse;
 import org.sopt.bofit.domain.post.entity.Post;
+import org.sopt.bofit.domain.post.service.PostCacheService;
 import org.sopt.bofit.domain.post.service.PostReader;
 import org.sopt.bofit.domain.post.service.PostWriter;
 import org.sopt.bofit.domain.user.entity.User;
@@ -28,8 +29,6 @@ import org.sopt.bofit.global.file.util.ImageValidator;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.*;
 
 @Service
 @RequiredArgsConstructor
@@ -47,6 +46,8 @@ public class CommentService {
 
 	private final PostWriter postWriter;
 
+    private final PostCacheService postCacheService;
+
 
 	@Transactional
 	public Comment createComment(Long userId, Long postId, CommentCreateCommand command){
@@ -60,6 +61,7 @@ public class CommentService {
                     .create(comment, command.imageUrls().get(sequence), sequence + 1));
 
 		postWriter.increaseCommentCount(post);
+        postCacheService.increaseCommentCount(postId);
 
 		return comment;
 	}
@@ -95,6 +97,7 @@ public class CommentService {
 		comment.checkPost(post);
 
 		postWriter.decreaseCommentCount(post);
+        postCacheService.decreaseCommentCount(postId);
 
 		commentWriter.softDelete(comment);
 	}

--- a/src/main/java/org/sopt/bofit/domain/post/constant/TrendPostConstant.java
+++ b/src/main/java/org/sopt/bofit/domain/post/constant/TrendPostConstant.java
@@ -15,5 +15,6 @@ public class TrendPostConstant {
 
     public static final int TREND_POST_COMMENT_WEIGHT = 1;
     public static final int TREND_POST_LIKE_WEIGHT = 1;
+    public static final int TREND_POST_COMMENT_REPLY_WEIGHT = 2;
 
 }

--- a/src/main/java/org/sopt/bofit/domain/post/constant/TrendPostConstant.java
+++ b/src/main/java/org/sopt/bofit/domain/post/constant/TrendPostConstant.java
@@ -1,0 +1,19 @@
+package org.sopt.bofit.domain.post.constant;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class TrendPostConstant {
+
+    public static final String TREND_POST_DEFAULT_SIZE = "5";
+    public final static String TREND_POST_DEFAULT_SORT = "rank";
+
+    public static final int TREND_POST_SCORED_DATE_RANGE = 7;
+
+    public static final int TREND_POST_CALCULATE_SIZE = 1;
+
+    public static final int TREND_POST_COMMENT_WEIGHT = 1;
+    public static final int TREND_POST_LIKE_WEIGHT = 1;
+
+}

--- a/src/main/java/org/sopt/bofit/domain/post/constant/TrendPostConstant.java
+++ b/src/main/java/org/sopt/bofit/domain/post/constant/TrendPostConstant.java
@@ -11,7 +11,7 @@ public class TrendPostConstant {
 
     public static final int TREND_POST_SCORED_DATE_RANGE = 7;
 
-    public static final int TREND_POST_CALCULATE_SIZE = 1;
+    public static final int TREND_POST_CALCULATE_SIZE = 20;
 
     public static final int TREND_POST_COMMENT_WEIGHT = 1;
     public static final int TREND_POST_LIKE_WEIGHT = 1;

--- a/src/main/java/org/sopt/bofit/domain/post/controller/PostController.java
+++ b/src/main/java/org/sopt/bofit/domain/post/controller/PostController.java
@@ -3,6 +3,8 @@ package org.sopt.bofit.domain.post.controller;
 import static org.sopt.bofit.domain.comment.constant.CommentConstant.COMMENTS_DEFAULT_SIZE;
 import static org.sopt.bofit.domain.commentreply.constant.CommentReplyConstant.COMMENT_REPLY_DEFAULT_SIZE;
 import static org.sopt.bofit.domain.post.constant.PostConstant.POSTS_DEFAULT_SIZE;
+import static org.sopt.bofit.domain.post.constant.TrendPostConstant.TREND_POST_DEFAULT_SIZE;
+import static org.sopt.bofit.domain.post.constant.TrendPostConstant.TREND_POST_DEFAULT_SORT;
 import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.CREATE_COMMENT;
 import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.CREATE_COMMENT_REPLY;
 import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.CREATE_POST;
@@ -22,6 +24,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.sopt.bofit.domain.comment.dto.request.CommentCreateRequest;
@@ -37,6 +40,7 @@ import org.sopt.bofit.domain.post.dto.request.PostUpdateRequest;
 import org.sopt.bofit.domain.post.dto.response.PostCreateResponse;
 import org.sopt.bofit.domain.post.dto.response.PostDetailResponse;
 import org.sopt.bofit.domain.post.dto.response.PostSummaryResponse;
+import org.sopt.bofit.domain.post.dto.response.TrendingPostsResponses;
 import org.sopt.bofit.domain.post.service.PostLikeService;
 import org.sopt.bofit.domain.post.service.PostService;
 import org.sopt.bofit.global.annotation.CustomExceptionDescription;
@@ -114,10 +118,22 @@ public class PostController {
     @CustomExceptionDescription(POST_DETAIL)
     @GetMapping("{post-id}")
     public BaseResponse<PostDetailResponse> getPostDetail(
-            @PathVariable(name = "post-id") Long postId,
-             @Parameter(hidden = true) @LoginUserId Long userId
+        @PathVariable(name = "post-id") Long postId,
+        @Parameter(hidden = true) @LoginUserId Long userId
     ){
         return BaseResponse.ok(postService.getPostDetail(userId, postId),"글 상세 조회 성공");
+    }
+
+    @Tag(name = TAG_NAME_COMMUNITY, description = TAG_DESCRIPTION_COMMUNITY)
+    @Operation(summary = "인기 게시물 목록 조회", description = "커뮤니티에서 인기글 목록을 조회합니다.")
+    @CustomExceptionDescription(POST_DETAIL)
+    @GetMapping("/trend")
+    public BaseResponse<TrendingPostsResponses> getTrendPosts(
+        @Parameter(hidden = true) @LoginUserId Long userId,
+        @RequestParam(defaultValue = TREND_POST_DEFAULT_SIZE, required = false) @Max(10) int size,
+        @RequestParam(defaultValue = TREND_POST_DEFAULT_SORT, required = false) String sort
+    ){
+        return BaseResponse.ok(postService.getTrendingPosts(userId, size, sort),"인기글 목록 조회 성공");
     }
 
     @Tag(name = TAG_NAME_COMMUNITY, description = TAG_DESCRIPTION_COMMUNITY)

--- a/src/main/java/org/sopt/bofit/domain/post/controller/PostController.java
+++ b/src/main/java/org/sopt/bofit/domain/post/controller/PostController.java
@@ -126,7 +126,6 @@ public class PostController {
 
     @Tag(name = TAG_NAME_COMMUNITY, description = TAG_DESCRIPTION_COMMUNITY)
     @Operation(summary = "인기 게시물 목록 조회", description = "커뮤니티에서 인기글 목록을 조회합니다.")
-    @CustomExceptionDescription(POST_DETAIL)
     @GetMapping("/trend")
     public BaseResponse<TrendingPostsResponses> getTrendPosts(
         @Parameter(hidden = true) @LoginUserId Long userId,

--- a/src/main/java/org/sopt/bofit/domain/post/dto/response/PostCategoryResponse.java
+++ b/src/main/java/org/sopt/bofit/domain/post/dto/response/PostCategoryResponse.java
@@ -1,0 +1,13 @@
+package org.sopt.bofit.domain.post.dto.response;
+
+import org.sopt.bofit.domain.post.entity.constant.PostCategory;
+
+public record PostCategoryResponse (
+    PostCategory category,
+    String description
+){
+
+    public static PostCategoryResponse from(PostCategory postCategory){
+        return new PostCategoryResponse(postCategory, postCategory.getDescription());
+    }
+}

--- a/src/main/java/org/sopt/bofit/domain/post/dto/response/PostDetailResponse.java
+++ b/src/main/java/org/sopt/bofit/domain/post/dto/response/PostDetailResponse.java
@@ -1,10 +1,9 @@
 package org.sopt.bofit.domain.post.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.Builder;
-
 import java.time.LocalDateTime;
 import java.util.List;
+import lombok.Builder;
 
 @Builder
 public record PostDetailResponse(
@@ -24,13 +23,13 @@ public record PostDetailResponse(
         String content,
 
         @Schema(description = "댓글 수 ", example = "8")
-        long commentCount,
+        int commentCount,
 
         @Schema(description = "생성 시간")
         LocalDateTime createdAt,
 
         @Schema(description = "좋아요 수")
-        Long likeCount,
+        int likeCount,
 
         @Schema(description = "사용자 좋아요 여부")
         boolean likedByCurrentUser,

--- a/src/main/java/org/sopt/bofit/domain/post/dto/response/TrendingPostsResponse.java
+++ b/src/main/java/org/sopt/bofit/domain/post/dto/response/TrendingPostsResponse.java
@@ -23,13 +23,13 @@ public record TrendingPostsResponse (
     String content,
 
     @Schema(description = "댓글 수 ", example = "8")
-    long commentCount,
+    int commentCount,
 
     @Schema(description = "생성 시간")
     LocalDateTime createdAt,
 
     @Schema(description = "좋아요 수")
-    Long likeCount,
+    int likeCount,
 
     @Schema(description = "사용자 좋아요 여부")
     boolean likedByCurrentUser,

--- a/src/main/java/org/sopt/bofit/domain/post/dto/response/TrendingPostsResponse.java
+++ b/src/main/java/org/sopt/bofit/domain/post/dto/response/TrendingPostsResponse.java
@@ -3,7 +3,7 @@ package org.sopt.bofit.domain.post.dto.response;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import lombok.Builder;
-import org.sopt.bofit.domain.post.entity.Post;
+import org.sopt.bofit.domain.post.service.dto.response.TrendingPostDto;
 
 @Builder
 public record TrendingPostsResponse (
@@ -38,10 +38,10 @@ public record TrendingPostsResponse (
     PostCategoryResponse category
 ){
 
-    public static TrendingPostsResponse of(Post post, boolean isLiked){
+    public static TrendingPostsResponse of(TrendingPostDto post, boolean isLiked){
         return TrendingPostsResponse.builder()
-            .postId(post.getId())
-            .writerId(post.getUser().getId())
+            .postId(post.getPostId())
+            .writerId(post.getWriterId())
             .writerNickname(post.getWriterNickname())
             .title(post.getTitle())
             .content(post.getContent())

--- a/src/main/java/org/sopt/bofit/domain/post/dto/response/TrendingPostsResponse.java
+++ b/src/main/java/org/sopt/bofit/domain/post/dto/response/TrendingPostsResponse.java
@@ -1,0 +1,56 @@
+package org.sopt.bofit.domain.post.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import org.sopt.bofit.domain.post.entity.Post;
+
+@Builder
+public record TrendingPostsResponse (
+    @Schema(description = "게시글 ID")
+    Long postId,
+
+    @Schema(description = "작성자 ID")
+    Long writerId,
+
+    @Schema(description = "닉네임", example = "정훈 장")
+    String writerNickname,
+
+    @Schema(description = "게시물 제목")
+    String title,
+
+    @Schema(description = "게시물 내용")
+    String content,
+
+    @Schema(description = "댓글 수 ", example = "8")
+    long commentCount,
+
+    @Schema(description = "생성 시간")
+    LocalDateTime createdAt,
+
+    @Schema(description = "좋아요 수")
+    Long likeCount,
+
+    @Schema(description = "사용자 좋아요 여부")
+    boolean likedByCurrentUser,
+
+    @Schema(description = "게시글 카테고리")
+    PostCategoryResponse category
+){
+
+    public static TrendingPostsResponse of(Post post, boolean isLiked){
+        return TrendingPostsResponse.builder()
+            .postId(post.getId())
+            .writerId(post.getUser().getId())
+            .writerNickname(post.getWriterNickname())
+            .title(post.getTitle())
+            .content(post.getContent())
+            .commentCount(post.getCommentCount())
+            .likeCount(post.getLikeCount())
+            .createdAt(post.getCreatedAt())
+            .likedByCurrentUser(isLiked)
+            .category(PostCategoryResponse.from(post.getPostCategory()))
+            .build();
+    }
+
+}

--- a/src/main/java/org/sopt/bofit/domain/post/dto/response/TrendingPostsResponses.java
+++ b/src/main/java/org/sopt/bofit/domain/post/dto/response/TrendingPostsResponses.java
@@ -2,13 +2,13 @@ package org.sopt.bofit.domain.post.dto.response;
 
 import java.util.List;
 import java.util.Map;
-import org.sopt.bofit.domain.post.entity.Post;
+import org.sopt.bofit.domain.post.service.dto.response.TrendingPostDto;
 
 public record TrendingPostsResponses (List<TrendingPostsResponse> posts){
 
-    public static TrendingPostsResponses of(List<Post> trendingPosts, Map<Post, Boolean> isLiked){
+    public static TrendingPostsResponses of(List<TrendingPostDto> trendingPosts, Map<Long, Boolean> isLiked){
         return new TrendingPostsResponses(trendingPosts.stream()
-            .map(post -> TrendingPostsResponse.of(post, isLiked.get(post)))
+            .map(post -> TrendingPostsResponse.of(post, isLiked.get(post.getPostId())))
             .toList());
     }
 }

--- a/src/main/java/org/sopt/bofit/domain/post/dto/response/TrendingPostsResponses.java
+++ b/src/main/java/org/sopt/bofit/domain/post/dto/response/TrendingPostsResponses.java
@@ -1,0 +1,14 @@
+package org.sopt.bofit.domain.post.dto.response;
+
+import java.util.List;
+import java.util.Map;
+import org.sopt.bofit.domain.post.entity.Post;
+
+public record TrendingPostsResponses (List<TrendingPostsResponse> posts){
+
+    public static TrendingPostsResponses of(List<Post> trendingPosts, Map<Post, Boolean> isLiked){
+        return new TrendingPostsResponses(trendingPosts.stream()
+            .map(post -> TrendingPostsResponse.of(post, isLiked.get(post)))
+            .toList());
+    }
+}

--- a/src/main/java/org/sopt/bofit/domain/post/entity/Post.java
+++ b/src/main/java/org/sopt/bofit/domain/post/entity/Post.java
@@ -1,13 +1,26 @@
 package org.sopt.bofit.domain.post.entity;
 
-import jakarta.persistence.*;
-import lombok.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.util.Objects;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.sopt.bofit.domain.post.entity.constant.PostCategory;
 import org.sopt.bofit.domain.post.entity.constant.PostStatus;
 import org.sopt.bofit.domain.user.entity.User;
 import org.sopt.bofit.global.entity.BaseEntity;
-
-import java.util.Objects;
 
 @Entity
 @Getter
@@ -41,7 +54,7 @@ public class Post extends BaseEntity {
     private User user;
 
     @Column(nullable = false, columnDefinition = "BIGINT DEFAULT 0")
-    private Long likeCount;
+    private int likeCount;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
@@ -55,7 +68,8 @@ public class Post extends BaseEntity {
                 .user(user)
                 .title(title)
                 .content(content)
-                .likeCount(0L)
+                .likeCount(0)
+                .commentCount(0)
                 .postCategory(Enum.valueOf(PostCategory.class, category))
                 .status(PostStatus.ACTIVE)
                 .writerNickname(writerNickname)

--- a/src/main/java/org/sopt/bofit/domain/post/entity/TrendPost.java
+++ b/src/main/java/org/sopt/bofit/domain/post/entity/TrendPost.java
@@ -1,0 +1,47 @@
+package org.sopt.bofit.domain.post.entity;
+
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.sopt.bofit.global.entity.BaseEntity;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TrendPost extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "trend_post_id")
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    @Column(nullable = false)
+    private int ranking;
+
+    public static TrendPost create(Post post, int ranking){
+        return TrendPost.builder()
+            .post(post)
+            .ranking(ranking)
+            .build();
+    }
+
+    @Builder
+    private TrendPost(Post post, int ranking) {
+        this.post = post;
+        this.ranking = ranking;
+    }
+}

--- a/src/main/java/org/sopt/bofit/domain/post/entity/constant/PostCategory.java
+++ b/src/main/java/org/sopt/bofit/domain/post/entity/constant/PostCategory.java
@@ -1,9 +1,16 @@
 package org.sopt.bofit.domain.post.entity.constant;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public enum PostCategory {
-    QNA,
-    INFORMATION,
-    CONVERSATION
+    QNA("보험 QnA"),
+    INFORMATION("정보 공유"),
+    CONVERSATION("사담")
     ;
 
+    private String description;
 }

--- a/src/main/java/org/sopt/bofit/domain/post/entity/constant/TrendPostSort.java
+++ b/src/main/java/org/sopt/bofit/domain/post/entity/constant/TrendPostSort.java
@@ -1,0 +1,24 @@
+package org.sopt.bofit.domain.post.entity.constant;
+
+import java.util.Arrays;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public enum TrendPostSort {
+    RANK("rank", "순위"),
+    RANDOM("random", "무작위")
+    ;
+
+    private final String lowerCase;
+    private final String description;
+
+    public static TrendPostSort from(String value){
+        return Arrays.stream(values())
+            .filter(trendPostSort -> trendPostSort.lowerCase.equalsIgnoreCase(value))
+            .findFirst()
+            .orElse(RANK);
+    }
+}

--- a/src/main/java/org/sopt/bofit/domain/post/repository/PostCustomRepository.java
+++ b/src/main/java/org/sopt/bofit/domain/post/repository/PostCustomRepository.java
@@ -1,6 +1,9 @@
 package org.sopt.bofit.domain.post.repository;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import org.sopt.bofit.domain.post.dto.response.PostSummaryResponse;
+import org.sopt.bofit.domain.post.entity.Post;
 import org.sopt.bofit.domain.user.dto.response.MyPostSummaryResponse;
 import org.springframework.data.domain.Slice;
 
@@ -12,4 +15,7 @@ public interface PostCustomRepository {
     Slice<PostSummaryResponse> findAllByCursorId(Long userId, Long cursorId, int size);
 
     Slice<PostSummaryResponse> findAllByKeywordAndCursorId(Long userId, String keyword, Long cursorId, int size);
+
+    List<Post> findTrendPosts(int size, LocalDateTime now);
+
 }

--- a/src/main/java/org/sopt/bofit/domain/post/repository/PostCustomRepositoryImpl.java
+++ b/src/main/java/org/sopt/bofit/domain/post/repository/PostCustomRepositoryImpl.java
@@ -1,13 +1,22 @@
 package org.sopt.bofit.domain.post.repository;
 
+import static org.sopt.bofit.domain.post.constant.TrendPostConstant.TREND_POST_COMMENT_WEIGHT;
+import static org.sopt.bofit.domain.post.constant.TrendPostConstant.TREND_POST_LIKE_WEIGHT;
+import static org.sopt.bofit.domain.post.constant.TrendPostConstant.TREND_POST_SCORED_DATE_RANGE;
+import static org.sopt.bofit.domain.post.entity.constant.PostStatus.ACTIVE;
+
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDateTime;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.sopt.bofit.domain.comment.entity.QComment;
 import org.sopt.bofit.domain.post.dto.response.PostSummaryResponse;
+import org.sopt.bofit.domain.post.entity.Post;
 import org.sopt.bofit.domain.post.entity.QPost;
 import org.sopt.bofit.domain.post.entity.QPostLike;
 import org.sopt.bofit.domain.post.entity.constant.PostStatus;
@@ -16,8 +25,6 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Repository;
-
-import java.util.List;
 
 
 @Repository
@@ -46,7 +53,7 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
                 .from(post)
                 .where(
                         post.user.id.eq(userId),
-                        post.status.eq(PostStatus.ACTIVE),
+                        post.status.eq(ACTIVE),
                         cursorId != null ? post.id.lt(cursorId) : null
                 )
                 .orderBy(post.id.desc())
@@ -149,6 +156,32 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
         if (hasNext) content.remove(size);
 
         return new SliceImpl<>(content, PageRequest.of(0, size), hasNext);
+    }
+
+    @Override
+    public List<Post> findTrendPosts(int size, LocalDateTime now) {
+
+        QPost post = QPost.post;
+        QPostLike postLike = QPostLike.postLike;
+        QComment comment = QComment.comment;
+
+        NumberExpression<Integer> score = postLike.count().intValue().multiply(TREND_POST_LIKE_WEIGHT)
+            .add(comment.count().intValue().multiply(TREND_POST_COMMENT_WEIGHT));
+
+        LocalDateTime scoredDateRange = now.minusDays(TREND_POST_SCORED_DATE_RANGE);
+
+        List<Post> trendPosts = queryFactory
+            .select(post)
+            .from(post)
+            .leftJoin(postLike).on(postLike.post.eq(post), postLike.createdAt.after(scoredDateRange))
+            .leftJoin(comment).on(comment.post.eq(post), comment.createdAt.after(scoredDateRange))
+            .where(post.status.eq(PostStatus.ACTIVE))
+            .orderBy(score.desc(), post.id.desc())
+            .groupBy(post.id)
+            .limit(size)
+            .fetch();
+
+        return trendPosts;
     }
 
     private NumberExpression<Double> getRelevanceScore(String keyword, QPost post) {

--- a/src/main/java/org/sopt/bofit/domain/post/repository/PostCustomRepositoryImpl.java
+++ b/src/main/java/org/sopt/bofit/domain/post/repository/PostCustomRepositoryImpl.java
@@ -1,5 +1,6 @@
 package org.sopt.bofit.domain.post.repository;
 
+import static org.sopt.bofit.domain.post.constant.TrendPostConstant.TREND_POST_COMMENT_REPLY_WEIGHT;
 import static org.sopt.bofit.domain.post.constant.TrendPostConstant.TREND_POST_COMMENT_WEIGHT;
 import static org.sopt.bofit.domain.post.constant.TrendPostConstant.TREND_POST_LIKE_WEIGHT;
 import static org.sopt.bofit.domain.post.constant.TrendPostConstant.TREND_POST_SCORED_DATE_RANGE;
@@ -15,6 +16,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.sopt.bofit.domain.comment.entity.QComment;
+import org.sopt.bofit.domain.commentreply.entity.QCommentReply;
 import org.sopt.bofit.domain.post.dto.response.PostSummaryResponse;
 import org.sopt.bofit.domain.post.entity.Post;
 import org.sopt.bofit.domain.post.entity.QPost;
@@ -164,9 +166,15 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
         QPost post = QPost.post;
         QPostLike postLike = QPostLike.postLike;
         QComment comment = QComment.comment;
+        QCommentReply commentReply = QCommentReply.commentReply;
 
-        NumberExpression<Integer> score = postLike.count().intValue().multiply(TREND_POST_LIKE_WEIGHT)
-            .add(comment.count().intValue().multiply(TREND_POST_COMMENT_WEIGHT));
+        NumberExpression<Integer> score =
+            postLike.count().intValue().multiply(TREND_POST_LIKE_WEIGHT)
+            .add(comment.count().intValue().multiply(TREND_POST_COMMENT_WEIGHT)
+                .add(commentReply.count().intValue().multiply(TREND_POST_COMMENT_REPLY_WEIGHT))
+                .add(post.likeCount)
+                .add(post.commentCount)
+            );
 
         LocalDateTime scoredDateRange = now.minusDays(TREND_POST_SCORED_DATE_RANGE);
 
@@ -175,6 +183,7 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
             .from(post)
             .leftJoin(postLike).on(postLike.post.eq(post), postLike.createdAt.after(scoredDateRange))
             .leftJoin(comment).on(comment.post.eq(post), comment.createdAt.after(scoredDateRange))
+            .leftJoin(commentReply).on(commentReply.comment.eq(comment), commentReply.createdAt.after(scoredDateRange))
             .where(post.status.eq(PostStatus.ACTIVE))
             .orderBy(score.desc(), post.id.desc())
             .groupBy(post.id)

--- a/src/main/java/org/sopt/bofit/domain/post/repository/PostJpaRepository.java
+++ b/src/main/java/org/sopt/bofit/domain/post/repository/PostJpaRepository.java
@@ -3,8 +3,59 @@ package org.sopt.bofit.domain.post.repository;
 import java.util.Optional;
 import org.sopt.bofit.domain.post.entity.Post;
 import org.sopt.bofit.domain.post.entity.constant.PostStatus;
+import org.sopt.bofit.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface PostJpaRepository extends JpaRepository<Post, Long> {
+
     Optional<Post> findByIdAndStatus(Long postId, PostStatus postStatus);
+
+    boolean existsByIdAndUser(Long postId, User user);
+
+    @Modifying
+    @Query("""
+		update Post p
+		set p.likeCount = p.likeCount + 1
+		where p = :requestPost
+		""")
+    void increaseLikeCount(@Param("requestPost") Post post);
+
+    @Modifying
+    @Query("""
+        UPDATE Post p
+        SET p.likeCount = p.likeCount - 1
+        WHERE p = :requestPost
+        """)
+    void decreaseLikeCount(@Param("requestPost") Post post);
+
+    @Modifying
+    @Query("""
+        UPDATE Post p
+        SET p.writerNickname = :writerNickname
+        WHERE p.user.id = :userId""")
+    void updateWriterNicknameByUserId(@Param("writerNickname") String writerNickname,
+        @Param("userId") Long userId
+    );
+
+    @Modifying
+    @Query("""
+        UPDATE Post p
+        SET p.commentCount = p.commentCount + 1
+        WHERE p = :requestPost
+        """
+    )
+    void increaseCommentCount(@Param("requestPost") Post post);
+
+    @Modifying
+    @Query("""
+        UPDATE Post p
+        SET p.commentCount = p.commentCount - 1
+        WHERE p = :requestPost
+        """
+    )
+    void decreaseCommentCount(@Param("requestPost") Post post);
+
 }

--- a/src/main/java/org/sopt/bofit/domain/post/repository/PostLikeRepository.java
+++ b/src/main/java/org/sopt/bofit/domain/post/repository/PostLikeRepository.java
@@ -22,7 +22,7 @@ public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
         select p.id
         from PostLike pl
         join pl.post p
-        where pl.user = :user and p in :posts
+        where pl.user = :user and p.id in :postIds
     """)
-    Set<Long> findLikedPostIdsByUserAndPosts(@Param("user") User user, @Param("posts") List<Post> posts);
+    Set<Long> findLikedPostIdsByUserAndPosts(@Param("user") User user, @Param("postIds") List<Long> postIds);
 }

--- a/src/main/java/org/sopt/bofit/domain/post/repository/PostLikeRepository.java
+++ b/src/main/java/org/sopt/bofit/domain/post/repository/PostLikeRepository.java
@@ -1,15 +1,28 @@
 package org.sopt.bofit.domain.post.repository;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.sopt.bofit.domain.post.entity.Post;
 import org.sopt.bofit.domain.post.entity.PostLike;
 import org.sopt.bofit.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
 
     boolean existsByPostAndUser(Post post, User user);
+
     Optional<PostLike> findByPostAndUser(Post post, User user);
+
+    @Query("""
+        select p.id
+        from PostLike pl
+        join pl.post p
+        where pl.user = :user and p in :posts
+    """)
+    Set<Long> findLikedPostIdsByUserAndPosts(@Param("user") User user, @Param("posts") List<Post> posts);
 }

--- a/src/main/java/org/sopt/bofit/domain/post/repository/PostRepository.java
+++ b/src/main/java/org/sopt/bofit/domain/post/repository/PostRepository.java
@@ -1,57 +1,8 @@
 package org.sopt.bofit.domain.post.repository;
 
-import org.sopt.bofit.domain.post.entity.Post;
-import org.sopt.bofit.domain.user.entity.User;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface PostRepository extends PostJpaRepository, PostCustomRepository{
 
-    @Modifying
-    @Query("""
-		update Post p
-		set p.likeCount = p.likeCount + 1
-		where p = :requestPost
-		""")
-    void increaseLikeCount(@Param("requestPost") Post post);
-
-    @Modifying
-    @Query("""
-        UPDATE Post p
-        SET p.likeCount = p.likeCount - 1
-        WHERE p = :requestPost
-        """)
-    void decreaseLikeCount(@Param("requestPost") Post post);
-
-    @Modifying
-    @Query("""
-        UPDATE Post p
-        SET p.writerNickname = :writerNickname
-        WHERE p.user.id = :userId""")
-    void updateWriterNicknameByUserId(@Param("writerNickname") String writerNickname,
-                                      @Param("userId") Long userId
-    );
-
-    @Modifying
-    @Query("""
-        UPDATE Post p
-        SET p.commentCount = p.commentCount + 1
-        WHERE p = :requestPost
-        """
-    )
-    void increaseCommentCount(@Param("requestPost") Post post);
-
-    @Modifying
-    @Query("""
-        UPDATE Post p
-        SET p.commentCount = p.commentCount - 1
-        WHERE p = :requestPost
-        """
-    )
-    void decreaseCommentCount(@Param("requestPost") Post post);
-
-    boolean existsByIdAndUser(Long postId, User user);
 }

--- a/src/main/java/org/sopt/bofit/domain/post/repository/TrendPostRepository.java
+++ b/src/main/java/org/sopt/bofit/domain/post/repository/TrendPostRepository.java
@@ -1,0 +1,20 @@
+package org.sopt.bofit.domain.post.repository;
+
+
+import java.util.List;
+import org.sopt.bofit.domain.post.entity.Post;
+import org.sopt.bofit.domain.post.entity.TrendPost;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface TrendPostRepository extends JpaRepository <TrendPost, Long> {
+
+    @Query("""
+      select tp.post
+      from TrendPost tp
+      where tp in :trendPosts
+      order by tp.ranking asc
+    """)
+    List<Post> findAllPostsByTrendPosts(@Param("trendPosts") List<TrendPost> trendPosts);
+}

--- a/src/main/java/org/sopt/bofit/domain/post/repository/TrendPostRepository.java
+++ b/src/main/java/org/sopt/bofit/domain/post/repository/TrendPostRepository.java
@@ -2,6 +2,7 @@ package org.sopt.bofit.domain.post.repository;
 
 
 import java.util.List;
+import java.util.Optional;
 import org.sopt.bofit.domain.post.entity.Post;
 import org.sopt.bofit.domain.post.entity.TrendPost;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,6 +10,8 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface TrendPostRepository extends JpaRepository <TrendPost, Long> {
+
+    Optional<TrendPost> findByPost(Post post);
 
     @Query("""
       select tp.post

--- a/src/main/java/org/sopt/bofit/domain/post/service/PostCacheService.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/PostCacheService.java
@@ -1,0 +1,66 @@
+package org.sopt.bofit.domain.post.service;
+
+import static org.sopt.bofit.global.constant.CacheConstant.TRENDING_POSTS_CACHE_NAME;
+
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.sopt.bofit.domain.post.entity.Post;
+import org.sopt.bofit.domain.post.service.dto.response.TrendingPostDto;
+import org.sopt.bofit.global.cache.CacheService;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PostCacheService {
+
+    private final CacheService cacheService;
+
+    public Map<Long, TrendingPostDto> getTrendPosts(){
+        return cacheService.getTrendingPosts();
+    }
+
+    public boolean deletePost(Post post){
+        if(getTrendPosts().containsKey(post.getId())){
+            clearTrendingPostsCache();
+            return true;
+        }
+        return false;
+    }
+
+    public void updatedPost(Post post){
+        if(getTrendPosts().containsKey(post.getId())){
+            clearTrendingPostsCache();
+        }
+    }
+
+    public void increaseLikeCount(Long postId){
+        Map<Long, TrendingPostDto> trendPosts = getTrendPosts();
+        if(getTrendPosts().containsKey(postId)){
+            getTrendPosts().get(postId).increaseLikeCount();
+        }
+    }
+
+    public void decreaseLikeCount(Long postId){
+        Map<Long, TrendingPostDto> trendPosts = getTrendPosts();
+        if(getTrendPosts().containsKey(postId)){
+            getTrendPosts().get(postId).decreaseLikeCount();
+        }
+    }
+
+    public void increaseCommentCount(Long postId){
+        if(getTrendPosts().containsKey(postId)){
+            getTrendPosts().get(postId).increaseCommentCount();
+        }
+    }
+
+    public void decreaseCommentCount(Long postId){
+        if(getTrendPosts().containsKey(postId)){
+            getTrendPosts().get(postId).decreaseCommentCount();
+        }
+    }
+
+    private void clearTrendingPostsCache(){
+        cacheService.deleteCache(TRENDING_POSTS_CACHE_NAME);
+    }
+
+}

--- a/src/main/java/org/sopt/bofit/domain/post/service/PostLikeReader.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/PostLikeReader.java
@@ -29,9 +29,9 @@ public class PostLikeReader {
             .orElseThrow(() -> new NotFoundException(PostErrorCode.POST_LIKE_NOT_FOUND));
     }
 
-    public Map<Post, Boolean> isLikedPosts(User user, List<Post> posts){
-        Set<Long> likedPostIds = postLikeRepository.findLikedPostIdsByUserAndPosts(user, posts);
-        return posts.stream()
+    public Map<Long, Boolean> isLikedPosts(User user, List<Long> postIds){
+        Set<Long> likedPostIds = postLikeRepository.findLikedPostIdsByUserAndPosts(user, postIds);
+        return postIds.stream()
             .collect(Collectors.toMap(Function.identity(), likedPostIds::contains));
     }
 

--- a/src/main/java/org/sopt/bofit/domain/post/service/PostLikeReader.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/PostLikeReader.java
@@ -1,5 +1,10 @@
 package org.sopt.bofit.domain.post.service;
 
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.sopt.bofit.domain.post.entity.Post;
 import org.sopt.bofit.domain.post.entity.PostLike;
@@ -23,4 +28,11 @@ public class PostLikeReader {
         return postLikeRepository.findByPostAndUser(post, user)
             .orElseThrow(() -> new NotFoundException(PostErrorCode.POST_LIKE_NOT_FOUND));
     }
+
+    public Map<Post, Boolean> isLikedPosts(User user, List<Post> posts){
+        Set<Long> likedPostIds = postLikeRepository.findLikedPostIdsByUserAndPosts(user, posts);
+        return posts.stream()
+            .collect(Collectors.toMap(Function.identity(), likedPostIds::contains));
+    }
+
 }

--- a/src/main/java/org/sopt/bofit/domain/post/service/PostLikeService.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/PostLikeService.java
@@ -22,6 +22,8 @@ public class PostLikeService {
     private final PostLikeReader postLikeReader;
     private final PostLikeWriter postLikeWriter;
 
+    private final PostCacheService postCacheService;
+
     @Transactional
     public void createPostLike(Long userId, Long postId){
         Post post = postReader.getActiveById(postId);
@@ -35,6 +37,7 @@ public class PostLikeService {
 
         PostLike postLike = postLikeWriter.create(post, user);
         postWriter.increaseLikeCount(post);
+        postCacheService.increaseLikeCount(postId);
     }
 
     @Transactional
@@ -47,5 +50,6 @@ public class PostLikeService {
         postLikeWriter.delete(postLike);
 
         postWriter.decreaseLikeCount(post);
+        postCacheService.decreaseLikeCount(postId);
     }
 }

--- a/src/main/java/org/sopt/bofit/domain/post/service/PostReader.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/PostReader.java
@@ -1,6 +1,10 @@
 
 package org.sopt.bofit.domain.post.service;
 
+import static org.sopt.bofit.domain.post.dto.response.PostDetailResponse.PostDetailImageResponse;
+import static org.sopt.bofit.global.exception.constant.PostErrorCode.POST_NOT_FOUND;
+
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.sopt.bofit.domain.comment.entity.Comment;
 import org.sopt.bofit.domain.comment.entity.CommentStatus;
@@ -17,11 +21,6 @@ import org.sopt.bofit.global.exception.customexception.NotFoundException;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
-
-import static org.sopt.bofit.domain.post.dto.response.PostDetailResponse.PostDetailImageResponse;
-import static org.sopt.bofit.global.exception.constant.PostErrorCode.POST_NOT_FOUND;
 
 @Service
 @RequiredArgsConstructor
@@ -52,7 +51,7 @@ public class PostReader {
 
         boolean isLike = postRepository.existsByIdAndUser(postId, writer);
 
-        long postCommentCount = activeComments.size();
+        int postCommentCount = activeComments.size();
 
         return PostDetailResponse.builder()
                 .writerId(writer.getId())

--- a/src/main/java/org/sopt/bofit/domain/post/service/PostService.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/PostService.java
@@ -18,9 +18,9 @@ import org.sopt.bofit.domain.post.entity.TrendPost;
 import org.sopt.bofit.domain.post.entity.constant.TrendPostSort;
 import org.sopt.bofit.domain.post.service.dto.request.PostCreateCommand;
 import org.sopt.bofit.domain.post.service.dto.request.PostUpdateCommand;
+import org.sopt.bofit.domain.post.service.dto.response.TrendingPostDto;
 import org.sopt.bofit.domain.user.entity.User;
 import org.sopt.bofit.domain.user.service.UserReader;
-import org.sopt.bofit.global.cache.CacheService;
 import org.sopt.bofit.global.dto.response.SliceResponse;
 import org.sopt.bofit.global.file.dto.request.UpdateImageRequest;
 import org.sopt.bofit.global.file.util.ImageValidator;
@@ -44,7 +44,7 @@ public class PostService {
     private final TrendPostReader trendPostReader;
     private final TrendPostWriter trendPostWriter;
 
-    private final CacheService cacheService;
+    private final PostCacheService postCacheService;
 
     @Transactional
     public PostCreateResponse createPost(Long userId, PostCreateCommand command) {
@@ -77,12 +77,18 @@ public class PostService {
                         .filter(image -> image.id() != null).map(UpdateImageRequest::id).toList(),
                 command.deleteImageIds());
 
+        trendPostWriter.validUpdatedPost(post);
         return PostCreateResponse.from(post.getId());
     }
 
     @Transactional
     public void deletePost(Long userId, Long postId) {
-        postWriter.deletePost(userId, postId);
+        User user = userReader.getActiveById(userId);
+        Post post = postReader.getActiveById(postId);
+        post.getUser().checkIsWriter(userId, POST_UNAUTHORIZED);
+
+        postWriter.delete(user, post);
+        trendPostWriter.validDeletePost(post);
     }
 
     public SliceResponse<PostSummaryResponse, Long> getAllPosts(Long userId, Long cursorId, int size){
@@ -101,30 +107,29 @@ public class PostService {
     public TrendingPostsResponses getTrendingPosts(Long userId, int size, String sort){
         User user = userReader.getActiveById(userId);
 
-        List<Post> cachedTrendingPosts = cacheService.getTrendingPosts();
-        List<Post> trendingPosts = cachedTrendingPosts.size() < size ?
+        Map<Long, TrendingPostDto> cachedTrendingPosts = postCacheService.getTrendPosts();
+        Map<Long, TrendingPostDto> trendingPosts = cachedTrendingPosts.size() < size ?
             getNewTrendingPosts(size) : cachedTrendingPosts;
 
-        List<Post> targetTrendingPosts = getTargetTrendingPosts(sort, size, trendingPosts);
-        Map<Post, Boolean> isLiked = postLikeReader.isLikedPosts(user, targetTrendingPosts);
+        List<TrendingPostDto> targetTrendingPosts = getTargetTrendingPosts(sort, size, trendingPosts.values().stream().toList());
+        Map<Long, Boolean> isLiked = postLikeReader.isLikedPosts(user, targetTrendingPosts.stream().map(TrendingPostDto::getPostId).toList());
 
         return TrendingPostsResponses.of(targetTrendingPosts, isLiked);
     }
 
-    private List<Post> getNewTrendingPosts(int size){
+    private Map<Long, TrendingPostDto> getNewTrendingPosts(int size){
         List<TrendPost> trendPosts = trendPostReader.getAll();
 
         if(trendPosts.size() < size){
             trendPostWriter.updateTrendPosts();
-            trendPosts = trendPostReader.getAll();
         }
 
-        return trendPostReader.getTrendingPosts(trendPosts);
+        return trendPostReader.getTrendingPosts();
     }
 
-    private List<Post> getTargetTrendingPosts(String sort, int size, List<Post> trendingPosts){
+    private List<TrendingPostDto> getTargetTrendingPosts(String sort, int size, List<TrendingPostDto> trendingPosts){
         if (TrendPostSort.from(sort).equals(TrendPostSort.RANDOM)){
-            ArrayList<Post> shallowTrendingPosts = new ArrayList<>(trendingPosts);
+            ArrayList<TrendingPostDto> shallowTrendingPosts = new ArrayList<>(trendingPosts);
             Collections.shuffle(shallowTrendingPosts);
             return shallowTrendingPosts.subList(0, size);
         }

--- a/src/main/java/org/sopt/bofit/domain/post/service/PostService.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/PostService.java
@@ -1,38 +1,50 @@
 package org.sopt.bofit.domain.post.service;
 
+import static org.sopt.bofit.global.exception.constant.PostErrorCode.POST_UNAUTHORIZED;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
 import org.sopt.bofit.domain.post.dto.response.PostCreateResponse;
 import org.sopt.bofit.domain.post.dto.response.PostDetailResponse;
 import org.sopt.bofit.domain.post.dto.response.PostSummaryResponse;
+import org.sopt.bofit.domain.post.dto.response.TrendingPostsResponses;
 import org.sopt.bofit.domain.post.entity.Post;
 import org.sopt.bofit.domain.post.entity.PostImage;
+import org.sopt.bofit.domain.post.entity.TrendPost;
+import org.sopt.bofit.domain.post.entity.constant.TrendPostSort;
 import org.sopt.bofit.domain.post.service.dto.request.PostCreateCommand;
 import org.sopt.bofit.domain.post.service.dto.request.PostUpdateCommand;
 import org.sopt.bofit.domain.user.entity.User;
 import org.sopt.bofit.domain.user.service.UserReader;
+import org.sopt.bofit.global.cache.CacheService;
 import org.sopt.bofit.global.dto.response.SliceResponse;
 import org.sopt.bofit.global.file.dto.request.UpdateImageRequest;
 import org.sopt.bofit.global.file.util.ImageValidator;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Map;
-import java.util.stream.IntStream;
-
-import static org.sopt.bofit.global.exception.constant.PostErrorCode.POST_UNAUTHORIZED;
-
 @Service
 @RequiredArgsConstructor
 public class PostService {
 
     private final PostReader postReader;
-
     private final PostWriter postWriter;
+
+    private final PostLikeReader postLikeReader;
 
     private final UserReader userReader;
 
     private final PostImageWriter postImageWriter;
     private final PostImageReader postImageReader;
+
+    private final TrendPostReader trendPostReader;
+    private final TrendPostWriter trendPostWriter;
+
+    private final CacheService cacheService;
 
     @Transactional
     public PostCreateResponse createPost(Long userId, PostCreateCommand command) {
@@ -83,6 +95,41 @@ public class PostService {
 
     public SliceResponse<PostSummaryResponse, Long> searchPosts(Long userId, String keyword, Long cursorId, int size){
         return postReader.findPostsByKeywordAndCursorId(userId, keyword, cursorId, size);
+    }
+
+    @Transactional
+    public TrendingPostsResponses getTrendingPosts(Long userId, int size, String sort){
+        User user = userReader.getActiveById(userId);
+
+        List<Post> cachedTrendingPosts = cacheService.getTrendingPosts();
+        List<Post> trendingPosts = cachedTrendingPosts.size() < size ?
+            getNewTrendingPosts(size) : cachedTrendingPosts;
+
+        List<Post> targetTrendingPosts = getTargetTrendingPosts(sort, size, trendingPosts);
+        Map<Post, Boolean> isLiked = postLikeReader.isLikedPosts(user, targetTrendingPosts);
+
+        return TrendingPostsResponses.of(targetTrendingPosts, isLiked);
+    }
+
+    private List<Post> getNewTrendingPosts(int size){
+        List<TrendPost> trendPosts = trendPostReader.getAll();
+
+        if(trendPosts.size() < size){
+            trendPostWriter.updateTrendPosts();
+            trendPosts = trendPostReader.getAll();
+        }
+
+        return trendPostReader.getTrendingPosts(trendPosts);
+    }
+
+    private List<Post> getTargetTrendingPosts(String sort, int size, List<Post> trendingPosts){
+        if (TrendPostSort.from(sort).equals(TrendPostSort.RANDOM)){
+            ArrayList<Post> shallowTrendingPosts = new ArrayList<>(trendingPosts);
+            Collections.shuffle(shallowTrendingPosts);
+            return shallowTrendingPosts.subList(0, size);
+        }
+
+        return trendingPosts.subList(0, size);
     }
 
 }

--- a/src/main/java/org/sopt/bofit/domain/post/service/PostWriter.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/PostWriter.java
@@ -11,8 +11,6 @@ import org.sopt.bofit.domain.user.service.UserReader;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import static org.sopt.bofit.global.exception.constant.PostErrorCode.POST_UNAUTHORIZED;
-
 @Service
 @RequiredArgsConstructor
 public class PostWriter {
@@ -35,16 +33,12 @@ public class PostWriter {
 
 
     @Transactional
-    public void deletePost(Long userId, Long postId) {
-        User user = userReader.getActiveById(userId);
-        Post post = postReader.getActiveById(postId);
-        post.getUser().checkIsWriter(userId, POST_UNAUTHORIZED);
+    public void delete(User user, Post post) {
+        postRepository.delete(post);
 
-        postRepository.deletePostByPostId(postId);
-
-        commentRepository.findAllByPostIdAndStatus(postId, CommentStatus.ACTIVE).forEach(Comment::softDelete);
-
+        commentRepository.findAllByPostIdAndStatus(post.getId(), CommentStatus.ACTIVE).forEach(Comment::softDelete);
     }
+
     @Transactional
     public void increaseLikeCount(Post post){
         postRepository.increaseLikeCount(post);

--- a/src/main/java/org/sopt/bofit/domain/post/service/TrendPostReader.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/TrendPostReader.java
@@ -1,0 +1,29 @@
+package org.sopt.bofit.domain.post.service;
+
+import static org.sopt.bofit.global.constant.CacheConstant.TRENDING_POSTS_CACHE_KEY;
+import static org.sopt.bofit.global.constant.CacheConstant.TRENDING_POSTS_CACHE_NAME;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.sopt.bofit.domain.post.entity.Post;
+import org.sopt.bofit.domain.post.entity.TrendPost;
+import org.sopt.bofit.domain.post.repository.TrendPostRepository;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TrendPostReader {
+
+    private final TrendPostRepository trendPostRepository;
+
+    public List<TrendPost> getAll(){
+        return trendPostRepository.findAll();
+    }
+
+    @Cacheable(cacheNames = TRENDING_POSTS_CACHE_NAME, key = TRENDING_POSTS_CACHE_KEY)
+    public List<Post> getTrendingPosts(List<TrendPost> trendPosts){
+        return trendPostRepository.findAllPostsByTrendPosts(trendPosts);
+    }
+
+}

--- a/src/main/java/org/sopt/bofit/domain/post/service/TrendPostReader.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/TrendPostReader.java
@@ -1,13 +1,16 @@
 package org.sopt.bofit.domain.post.service;
 
-import static org.sopt.bofit.global.constant.CacheConstant.TRENDING_POSTS_CACHE_KEY;
+import static org.sopt.bofit.global.constant.CacheConstant.SPEL_TRENDING_POSTS_CACHE_KEY;
 import static org.sopt.bofit.global.constant.CacheConstant.TRENDING_POSTS_CACHE_NAME;
 
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.sopt.bofit.domain.post.entity.Post;
 import org.sopt.bofit.domain.post.entity.TrendPost;
 import org.sopt.bofit.domain.post.repository.TrendPostRepository;
+import org.sopt.bofit.domain.post.service.dto.response.TrendingPostDto;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
@@ -21,9 +24,18 @@ public class TrendPostReader {
         return trendPostRepository.findAll();
     }
 
-    @Cacheable(cacheNames = TRENDING_POSTS_CACHE_NAME, key = TRENDING_POSTS_CACHE_KEY)
-    public List<Post> getTrendingPosts(List<TrendPost> trendPosts){
-        return trendPostRepository.findAllPostsByTrendPosts(trendPosts);
+    @Cacheable(cacheNames = TRENDING_POSTS_CACHE_NAME, key = SPEL_TRENDING_POSTS_CACHE_KEY)
+    public LinkedHashMap<Long, TrendingPostDto> getTrendingPosts(){
+
+        List<TrendPost> trendPosts = trendPostRepository.findAll();
+
+        return trendPostRepository.findAllPostsByTrendPosts(trendPosts).stream()
+            .collect(Collectors.toMap(
+                Post::getId,
+                TrendingPostDto::from,
+                (oldValue, newValue) -> oldValue,
+                LinkedHashMap::new
+            ));
     }
 
 }

--- a/src/main/java/org/sopt/bofit/domain/post/service/TrendPostWriter.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/TrendPostWriter.java
@@ -5,6 +5,7 @@ import static org.sopt.bofit.global.constant.CacheConstant.TRENDING_POSTS_CACHE_
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
 import org.sopt.bofit.domain.post.entity.Post;
@@ -23,10 +24,12 @@ public class TrendPostWriter {
     private final TrendPostRepository trendPostRepository;
     private final PostRepository postRepository;
 
+    private final PostCacheService postCacheService;
+
     @Scheduled(
         fixedDelayString = "${scheduler.trend-posts-update-delay}"
     )
-    @CacheEvict(cacheNames = TRENDING_POSTS_CACHE_NAME)
+    @CacheEvict(cacheNames = TRENDING_POSTS_CACHE_NAME, allEntries = true)
     @Transactional
     public void updateTrendPosts(){
         List<Post> trendedPosts = postRepository.findTrendPosts(TREND_POST_CALCULATE_SIZE, LocalDateTime.now());
@@ -37,4 +40,16 @@ public class TrendPostWriter {
         trendPostRepository.deleteAllInBatch();
         trendPostRepository.saveAll(trendPosts);
     }
+
+    public void validDeletePost(Post post){
+        if(postCacheService.deletePost(post)){
+            Optional<TrendPost> deletedTrendPost = trendPostRepository.findByPost(post);
+            deletedTrendPost.ifPresent(trendPostRepository::delete);
+        }
+    }
+
+    public void validUpdatedPost(Post post){
+        postCacheService.updatedPost(post);
+    }
+
 }

--- a/src/main/java/org/sopt/bofit/domain/post/service/TrendPostWriter.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/TrendPostWriter.java
@@ -1,0 +1,40 @@
+package org.sopt.bofit.domain.post.service;
+
+import static org.sopt.bofit.domain.post.constant.TrendPostConstant.TREND_POST_CALCULATE_SIZE;
+import static org.sopt.bofit.global.constant.CacheConstant.TRENDING_POSTS_CACHE_NAME;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.IntStream;
+import lombok.RequiredArgsConstructor;
+import org.sopt.bofit.domain.post.entity.Post;
+import org.sopt.bofit.domain.post.entity.TrendPost;
+import org.sopt.bofit.domain.post.repository.PostRepository;
+import org.sopt.bofit.domain.post.repository.TrendPostRepository;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class TrendPostWriter {
+
+    private final TrendPostRepository trendPostRepository;
+    private final PostRepository postRepository;
+
+    @Scheduled(
+        fixedDelayString = "${scheduler.trend-posts-update-delay}"
+    )
+    @CacheEvict(cacheNames = TRENDING_POSTS_CACHE_NAME)
+    @Transactional
+    public void updateTrendPosts(){
+        List<Post> trendedPosts = postRepository.findTrendPosts(TREND_POST_CALCULATE_SIZE, LocalDateTime.now());
+        List<TrendPost> trendPosts = IntStream.range(0, trendedPosts.size())
+            .mapToObj(rank -> TrendPost.create(trendedPosts.get(rank), rank + 1))
+            .toList();
+
+        trendPostRepository.deleteAllInBatch();
+        trendPostRepository.saveAll(trendPosts);
+    }
+}

--- a/src/main/java/org/sopt/bofit/domain/post/service/dto/response/TrendingPostDto.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/dto/response/TrendingPostDto.java
@@ -1,0 +1,80 @@
+package org.sopt.bofit.domain.post.service.dto.response;
+
+
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+import org.sopt.bofit.domain.post.entity.Post;
+import org.sopt.bofit.domain.post.entity.constant.PostCategory;
+import org.sopt.bofit.domain.post.entity.constant.PostStatus;
+
+@Getter
+public class TrendingPostDto {
+
+    private Long postId;
+
+    private Long writerId;
+    private String writerNickname;
+
+    private String title;
+    private String content;
+    private PostStatus status;
+    private PostCategory postCategory;
+
+    private Long likeCount;
+    private int commentCount;
+
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    @Builder
+    private TrendingPostDto(Long postId,
+        Long writerId, String writerNickname,
+        String title, String content, PostStatus status, PostCategory postCategory,
+        Long likeCount, int commentCount,
+        LocalDateTime createdAt, LocalDateTime updatedAt) {
+        this.postId = postId;
+        this.writerId = writerId;
+        this.writerNickname = writerNickname;
+        this.title = title;
+        this.content = content;
+        this.status = status;
+        this.postCategory = postCategory;
+        this.likeCount = likeCount;
+        this.commentCount = commentCount;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    public static TrendingPostDto from(Post post){
+        return TrendingPostDto.builder()
+            .postId(post.getId())
+            .writerId(post.getUser().getId())
+            .writerNickname(post.getWriterNickname())
+            .title(post.getTitle())
+            .content(post.getContent())
+            .status(post.getStatus())
+            .postCategory(post.getPostCategory())
+            .likeCount(post.getLikeCount())
+            .commentCount(post.getCommentCount())
+            .createdAt(post.getCreatedAt())
+            .updatedAt(post.getUpdatedAt())
+            .build();
+    }
+
+    public void increaseLikeCount(){
+        this.likeCount++;
+    }
+
+    public void decreaseLikeCount(){
+        this.likeCount--;
+    }
+
+    public void increaseCommentCount(){
+        this.commentCount++;
+    }
+
+    public void decreaseCommentCount(){
+        this.commentCount--;
+    }
+}

--- a/src/main/java/org/sopt/bofit/domain/post/service/dto/response/TrendingPostDto.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/dto/response/TrendingPostDto.java
@@ -21,7 +21,7 @@ public class TrendingPostDto {
     private PostStatus status;
     private PostCategory postCategory;
 
-    private Long likeCount;
+    private int likeCount;
     private int commentCount;
 
     private LocalDateTime createdAt;
@@ -31,7 +31,7 @@ public class TrendingPostDto {
     private TrendingPostDto(Long postId,
         Long writerId, String writerNickname,
         String title, String content, PostStatus status, PostCategory postCategory,
-        Long likeCount, int commentCount,
+        int likeCount, int commentCount,
         LocalDateTime createdAt, LocalDateTime updatedAt) {
         this.postId = postId;
         this.writerId = writerId;

--- a/src/main/java/org/sopt/bofit/global/cache/CacheService.java
+++ b/src/main/java/org/sopt/bofit/global/cache/CacheService.java
@@ -1,0 +1,12 @@
+package org.sopt.bofit.global.cache;
+
+import java.util.List;
+import org.sopt.bofit.domain.post.entity.Post;
+
+public interface CacheService {
+
+    Object getData(String cacheName, Object key);
+
+    public List<Post> getTrendingPosts();
+
+}

--- a/src/main/java/org/sopt/bofit/global/cache/CacheService.java
+++ b/src/main/java/org/sopt/bofit/global/cache/CacheService.java
@@ -1,12 +1,13 @@
 package org.sopt.bofit.global.cache;
 
-import java.util.List;
-import org.sopt.bofit.domain.post.entity.Post;
+import java.util.Map;
+import org.sopt.bofit.domain.post.service.dto.response.TrendingPostDto;
 
 public interface CacheService {
 
     Object getData(String cacheName, Object key);
 
-    public List<Post> getTrendingPosts();
+    Map<Long, TrendingPostDto> getTrendingPosts();
 
+    void deleteCache(String cacheName);
 }

--- a/src/main/java/org/sopt/bofit/global/cache/CaffeineCacheService.java
+++ b/src/main/java/org/sopt/bofit/global/cache/CaffeineCacheService.java
@@ -5,9 +5,10 @@ import static org.sopt.bofit.global.constant.CacheConstant.TRENDING_POSTS_CACHE_
 import static org.sopt.bofit.global.constant.CacheConstant.TRENDING_POSTS_CACHE_NAME;
 
 import java.util.Collections;
-import java.util.List;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
-import org.sopt.bofit.domain.post.entity.Post;
+import org.sopt.bofit.domain.post.service.dto.response.TrendingPostDto;
 import org.springframework.cache.CacheManager;
 import org.springframework.stereotype.Component;
 
@@ -24,13 +25,20 @@ public class CaffeineCacheService implements CacheService {
 
     @Override
     @SuppressWarnings("unchecked")  // TRENDING_POSTS_CACHE_NAME 캐시는 항상 Post 객체를 담고 있으로 안전함.
-    public List<Post> getTrendingPosts(){
-        Object value = cacheManager.getCache(TRENDING_POSTS_CACHE_NAME).get(TRENDING_POSTS_CACHE_KEY, List.class);
+    public Map<Long, TrendingPostDto> getTrendingPosts(){
+
+        Object value = cacheManager.getCache(TRENDING_POSTS_CACHE_NAME).get(TRENDING_POSTS_CACHE_KEY,  LinkedHashMap.class);
+
         if (value != null &&
-            value instanceof List list
+            value instanceof LinkedHashMap map
         ){
-            return (List<Post>) list;
+            return (LinkedHashMap<Long, TrendingPostDto>) map;
         }
-        return Collections.emptyList();
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public void deleteCache(String cacheName) {
+        cacheManager.getCache(cacheName).clear();
     }
 }

--- a/src/main/java/org/sopt/bofit/global/cache/CaffeineCacheService.java
+++ b/src/main/java/org/sopt/bofit/global/cache/CaffeineCacheService.java
@@ -1,0 +1,36 @@
+package org.sopt.bofit.global.cache;
+
+
+import static org.sopt.bofit.global.constant.CacheConstant.TRENDING_POSTS_CACHE_KEY;
+import static org.sopt.bofit.global.constant.CacheConstant.TRENDING_POSTS_CACHE_NAME;
+
+import java.util.Collections;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.sopt.bofit.domain.post.entity.Post;
+import org.springframework.cache.CacheManager;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CaffeineCacheService implements CacheService {
+
+    private final CacheManager cacheManager;
+
+    @Override
+    public Object getData(String cacheName, Object key){
+        return cacheManager.getCache(cacheName).get(key);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")  // TRENDING_POSTS_CACHE_NAME 캐시는 항상 Post 객체를 담고 있으로 안전함.
+    public List<Post> getTrendingPosts(){
+        Object value = cacheManager.getCache(TRENDING_POSTS_CACHE_NAME).get(TRENDING_POSTS_CACHE_KEY, List.class);
+        if (value != null &&
+            value instanceof List list
+        ){
+            return (List<Post>) list;
+        }
+        return Collections.emptyList();
+    }
+}

--- a/src/main/java/org/sopt/bofit/global/config/CacheConfig.java
+++ b/src/main/java/org/sopt/bofit/global/config/CacheConfig.java
@@ -1,6 +1,5 @@
 package org.sopt.bofit.global.config;
 
-import static org.sopt.bofit.domain.post.constant.TrendPostConstant.TREND_POST_CALCULATE_SIZE;
 import static org.sopt.bofit.global.constant.CacheConstant.DEFAULT_CACHE_NAME;
 import static org.sopt.bofit.global.constant.CacheConstant.DISEASE_HISTORY_SCORING_RULE_CACHE_NAME;
 import static org.sopt.bofit.global.constant.CacheConstant.FAMILY_HISTORY_SCORING_RULE_CACHE_NAME;
@@ -68,7 +67,7 @@ public class CacheConfig {
     private Caffeine<Object, Object> trendPostsCacheBuilder(){
         return Caffeine.newBuilder()
             .expireAfterWrite(30, TimeUnit.MINUTES)
-            .maximumSize(TREND_POST_CALCULATE_SIZE)
+            .maximumSize(1)
             .softValues();
     }
 

--- a/src/main/java/org/sopt/bofit/global/config/CacheConfig.java
+++ b/src/main/java/org/sopt/bofit/global/config/CacheConfig.java
@@ -1,14 +1,21 @@
 package org.sopt.bofit.global.config;
 
-import static org.sopt.bofit.global.constant.CacheConstant.*;
+import static org.sopt.bofit.domain.post.constant.TrendPostConstant.TREND_POST_CALCULATE_SIZE;
+import static org.sopt.bofit.global.constant.CacheConstant.DEFAULT_CACHE_NAME;
+import static org.sopt.bofit.global.constant.CacheConstant.DISEASE_HISTORY_SCORING_RULE_CACHE_NAME;
+import static org.sopt.bofit.global.constant.CacheConstant.FAMILY_HISTORY_SCORING_RULE_CACHE_NAME;
+import static org.sopt.bofit.global.constant.CacheConstant.INSURANCE_REPORT_CACHE_NAME;
+import static org.sopt.bofit.global.constant.CacheConstant.INSURANCE_STATISTIC_CACHE_NAME;
+import static org.sopt.bofit.global.constant.CacheConstant.SELECTED_SCORING_RULE_CACHE_NAME;
+import static org.sopt.bofit.global.constant.CacheConstant.TRENDING_POSTS_CACHE_NAME;
+import static org.sopt.bofit.global.constant.CacheConstant.USER_INFO_SCORING_RULE_CACHE_NAME;
 
 import com.github.benmanes.caffeine.cache.Caffeine;
+import java.util.concurrent.TimeUnit;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.caffeine.CaffeineCacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-
-import java.util.concurrent.TimeUnit;
 
 @Configuration
 public class CacheConfig {
@@ -28,6 +35,8 @@ public class CacheConfig {
 
 		cacheManager.registerCustomCache(INSURANCE_REPORT_CACHE_NAME, insuranceReportCacheBuilder().build());
 		cacheManager.registerCustomCache(INSURANCE_STATISTIC_CACHE_NAME, insuranceStatisticCacheBuilder().build());
+
+        cacheManager.registerCustomCache(TRENDING_POSTS_CACHE_NAME, trendPostsCacheBuilder().build());
 		return cacheManager;
 	}
 
@@ -55,4 +64,12 @@ public class CacheConfig {
 			.softValues()
 			;
 	}
+
+    private Caffeine<Object, Object> trendPostsCacheBuilder(){
+        return Caffeine.newBuilder()
+            .expireAfterWrite(30, TimeUnit.MINUTES)
+            .maximumSize(TREND_POST_CALCULATE_SIZE)
+            .softValues();
+    }
+
 }

--- a/src/main/java/org/sopt/bofit/global/config/SchedulerConfig.java
+++ b/src/main/java/org/sopt/bofit/global/config/SchedulerConfig.java
@@ -1,0 +1,10 @@
+package org.sopt.bofit.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulerConfig {
+
+}

--- a/src/main/java/org/sopt/bofit/global/constant/CacheConstant.java
+++ b/src/main/java/org/sopt/bofit/global/constant/CacheConstant.java
@@ -12,7 +12,11 @@ public class CacheConstant {
 	public final static String DISEASE_HISTORY_SCORING_RULE_CACHE_NAME = "diseaseHistoryScoringRule";
 	public final static String FAMILY_HISTORY_SCORING_RULE_CACHE_NAME = "familyHistoryScoringRule";
 	public final static String SELECTED_SCORING_RULE_CACHE_NAME = "selectedScoringRule";
+
 	public final static String INSURANCE_STATISTIC_CACHE_NAME = "insuranceStatistic";
 	public final static String INSURANCE_REPORT_CACHE_NAME = "insuranceReport";
+
+    public final static String TRENDING_POSTS_CACHE_NAME = "trendingPosts";
+    public final static String TRENDING_POSTS_CACHE_KEY = "all";
 
 }

--- a/src/main/java/org/sopt/bofit/global/constant/CacheConstant.java
+++ b/src/main/java/org/sopt/bofit/global/constant/CacheConstant.java
@@ -17,6 +17,7 @@ public class CacheConstant {
 	public final static String INSURANCE_REPORT_CACHE_NAME = "insuranceReport";
 
     public final static String TRENDING_POSTS_CACHE_NAME = "trendingPosts";
-    public final static String TRENDING_POSTS_CACHE_KEY = "all";
+    public final static String SPEL_TRENDING_POSTS_CACHE_KEY = "'trendingPostAll'";
+    public final static String TRENDING_POSTS_CACHE_KEY = "trendingPostAll";
 
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -85,6 +85,9 @@ management:
 #      show-details: when-authorized
 
 
+scheduler:
+  trend-posts-update-delay: ${TREND_POST_UPDATE_DELAY}
+
 ---
 spring:
   config:

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -37,6 +37,9 @@ jwt:
   accessTokenExpiration: 3600000
   refreshTokenExpiration: 604800000
 
+scheduler:
+  trend-posts-update-delay: 60000
+
 openai:
   secret-key: test-key
   model: test-gpt-model


### PR DESCRIPTION
## Related issue 🛠
- closed #164 
  

## Work Description 📝

- 인기 게시글 테이블 구현
  - TrendPost 에서 순위와 Post 를 관리함
- 스케줄러를 통한 기간별 인기 게시글 판별 로직
  - 현재는 10분 주기를 적용 
  - 좋아요 수와 댓글 수를 합산하여 일주일 내 가장 인기 있었던 게시글을 판단함
- 인기 게시글 캐싱
  - 인기 게시글의 경우 TrendingPostDto 를 사용하여 캐싱을 진행함.
  - 게시글 수정 및 삭제 시 캐시 초기화. 댓글 및 좋아요의 증감에 대해선 DB 레벨에서는 동시성 및 무결성을 보장하나 매번 좋아요 및 댓글 수 증감으로 캐싱을 초기화하는 것은 비용적으로 오버헤드가 크므로 캐시레벨에서 동시성을 고려하지 않는 형태로 이중으로 관리함. 

## Uncompleted Tasks 😅

## To Reviewers 📢
