### PR TITLE
[Refactor] 회원 탈퇴 로직 수정

### DIFF
--- a/src/main/java/org/sopt/bofit/domain/user/service/UserWriter.java
+++ b/src/main/java/org/sopt/bofit/domain/user/service/UserWriter.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -63,7 +64,7 @@ public class UserWriter {
 	public void unlinkUser(Long userId) {
 		User user = userReader.findById(userId);
 		user.deactivate();
-		user.updateOauthId(user.getOauthId() + ":INACTIVE");
+		user.updateOauthId(user.getOauthId() + ":INACTIVE:" + UUID.randomUUID());
 
 		postRepository.updateWriterNicknameByUserId(user.getId(), user.getNickname());
 	}


### PR DESCRIPTION
## Related issue 🛠
- closed #171
  


## Work Description 📝
- 기존 회원 탈퇴 시에 INACTIVE 태그만 붙였기 때문에 재가입한 회원이 또 탈퇴를 할 경우 unique 제약 조건에 걸려 탈퇴가 안 되는 현상을 UUID를 부여함으로써 해결했습니다.
