### PR TITLE
[Feat] 대댓글 삭제 API 구현

### DIFF
--- a/src/main/java/org/sopt/bofit/domain/comment/service/CommentImageWriter.java
+++ b/src/main/java/org/sopt/bofit/domain/comment/service/CommentImageWriter.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.sopt.bofit.domain.comment.entity.Comment;
 import org.sopt.bofit.domain.comment.entity.CommentImage;
+import org.sopt.bofit.domain.comment.entity.CommentImageStatus;
 import org.sopt.bofit.domain.comment.repository.CommentImageRepository;
 import org.sopt.bofit.global.file.dto.request.UpdateImageRequest;
 import org.springframework.stereotype.Service;
@@ -42,5 +43,11 @@ public class CommentImageWriter {
         });
     }
 
+    @Transactional
+    public void deleteFromComment(Comment comment){
+        List<CommentImage> activeImages = commentImageRepository.findAllByCommentAndStatus(
+            comment, CommentImageStatus.ACTIVE);
+        activeImages.forEach(CommentImage::softDelete);
+    }
 
 }

--- a/src/main/java/org/sopt/bofit/domain/comment/service/CommentImageWriter.java
+++ b/src/main/java/org/sopt/bofit/domain/comment/service/CommentImageWriter.java
@@ -1,15 +1,14 @@
 package org.sopt.bofit.domain.comment.service;
 
 import jakarta.transaction.Transactional;
+import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.sopt.bofit.domain.comment.entity.Comment;
 import org.sopt.bofit.domain.comment.entity.CommentImage;
 import org.sopt.bofit.domain.comment.repository.CommentImageRepository;
 import org.sopt.bofit.global.file.dto.request.UpdateImageRequest;
 import org.springframework.stereotype.Service;
-
-import java.util.List;
-import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -37,7 +36,7 @@ public class CommentImageWriter {
     }
 
     @Transactional
-    public void softDelete(Map<Long, CommentImage> commentImages, List<Long> deleteImageIds){
+    public void delete(Map<Long, CommentImage> commentImages, List<Long> deleteImageIds){
         deleteImageIds.forEach(id -> {
             commentImages.get(id).softDelete();
         });

--- a/src/main/java/org/sopt/bofit/domain/comment/service/CommentService.java
+++ b/src/main/java/org/sopt/bofit/domain/comment/service/CommentService.java
@@ -100,7 +100,7 @@ public class CommentService {
         postCacheService.decreaseCommentCount(postId);
 
 		commentWriter.delete(comment);
-        commentImageWriter.delete();
+        commentImageWriter.deleteFromComment(comment);
 	}
 
     @Transactional(readOnly = true)

--- a/src/main/java/org/sopt/bofit/domain/comment/service/CommentService.java
+++ b/src/main/java/org/sopt/bofit/domain/comment/service/CommentService.java
@@ -1,5 +1,13 @@
 package org.sopt.bofit.domain.comment.service;
 
+import static org.sopt.bofit.domain.comment.constant.CommentConstant.MAX_IMAGE_COUNT;
+import static org.sopt.bofit.global.exception.constant.CommentErrorCode.COMMENT_UNAUTHORIZED;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
 import org.sopt.bofit.domain.comment.dto.response.CommentWithImagesResponse;
 import org.sopt.bofit.domain.comment.entity.Comment;
@@ -21,15 +29,6 @@ import org.sopt.bofit.global.file.util.ImageValidator;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.stream.IntStream;
-
-import static org.sopt.bofit.domain.comment.constant.CommentConstant.MAX_IMAGE_COUNT;
-import static org.sopt.bofit.global.exception.constant.CommentErrorCode.COMMENT_UNAUTHORIZED;
 
 @Service
 @RequiredArgsConstructor
@@ -82,7 +81,7 @@ public class CommentService {
                         .filter(image -> image.id() != null).map(UpdateImageRequest::id).toList(),
                 command.deleteImageIds());
 
-        commentImageWriter.softDelete(commentImageMap, command.deleteImageIds());
+        commentImageWriter.delete(commentImageMap, command.deleteImageIds());
         commentImageWriter.updateAll(comment, commentImageMap, command.updatedImages());
         command.content().ifPresent(comment::updateContent);
 
@@ -100,7 +99,8 @@ public class CommentService {
 		postWriter.decreaseCommentCount(post);
         postCacheService.decreaseCommentCount(postId);
 
-		commentWriter.softDelete(comment);
+		commentWriter.delete(comment);
+        commentImageWriter.delete();
 	}
 
     @Transactional(readOnly = true)

--- a/src/main/java/org/sopt/bofit/domain/comment/service/CommentWriter.java
+++ b/src/main/java/org/sopt/bofit/domain/comment/service/CommentWriter.java
@@ -18,7 +18,7 @@ public class CommentWriter {
 		return commentRepository.save(comment);
 	}
 
-	public Comment softDelete(Comment comment){
+	public Comment delete(Comment comment){
 		return comment.softDelete();
 	}
 

--- a/src/main/java/org/sopt/bofit/domain/commentreply/entity/CommentReply.java
+++ b/src/main/java/org/sopt/bofit/domain/commentreply/entity/CommentReply.java
@@ -84,4 +84,8 @@ public class CommentReply extends BaseEntity {
         this.content = content;
     }
 
+    public void softDelete(){
+        this.status = CommentReplyStatus.INACTIVE;
+    }
+
 }

--- a/src/main/java/org/sopt/bofit/domain/commentreply/entity/CommentReply.java
+++ b/src/main/java/org/sopt/bofit/domain/commentreply/entity/CommentReply.java
@@ -22,6 +22,7 @@ import org.sopt.bofit.domain.user.entity.User;
 import org.sopt.bofit.global.entity.BaseEntity;
 import org.sopt.bofit.global.exception.constant.CommentReplyErrorCode;
 import org.sopt.bofit.global.exception.customexception.BadRequestException;
+import org.sopt.bofit.global.exception.customexception.ForbiddenException;
 
 @Getter
 @Entity
@@ -70,6 +71,12 @@ public class CommentReply extends BaseEntity {
     public void checkComment(Comment comment){
         if (! this.comment.equals(comment)){
             throw new BadRequestException(CommentReplyErrorCode.UNMATCHED_COMMENT_REPLY_COMMENT);
+        }
+    }
+
+    public void checkWriter(User user){
+        if (! this.user.equals(user)){
+            throw new ForbiddenException(CommentReplyErrorCode.COMMENT_REPLY_UNAUTHORIZED);
         }
     }
 

--- a/src/main/java/org/sopt/bofit/domain/commentreply/service/CommentReplyImageWriter.java
+++ b/src/main/java/org/sopt/bofit/domain/commentreply/service/CommentReplyImageWriter.java
@@ -1,15 +1,15 @@
 package org.sopt.bofit.domain.commentreply.service;
 
 import jakarta.transaction.Transactional;
+import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.sopt.bofit.domain.commentreply.entity.CommentReply;
 import org.sopt.bofit.domain.commentreply.entity.CommentReplyImage;
+import org.sopt.bofit.domain.commentreply.entity.CommentReplyImageStatus;
 import org.sopt.bofit.domain.commentreply.repository.CommentReplyImageRepository;
 import org.sopt.bofit.global.file.dto.request.UpdateImageRequest;
 import org.springframework.stereotype.Service;
-
-import java.util.List;
-import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -41,6 +41,13 @@ public class CommentReplyImageWriter {
                 currentImages.get(image.id()).updateSequence(image.sequence());
             }
         });
+    }
+
+    public void deleteFromCommentReply(CommentReply commentReply){
+        List<CommentReplyImage> activeImages = commentReplyImageRepository.findAllByCommentReplyAndStatus(
+            commentReply, CommentReplyImageStatus.ACTIVE);
+
+        activeImages.forEach(CommentReplyImage::softDelete);
     }
 
 }

--- a/src/main/java/org/sopt/bofit/domain/commentreply/service/CommentReplyImageWriter.java
+++ b/src/main/java/org/sopt/bofit/domain/commentreply/service/CommentReplyImageWriter.java
@@ -22,7 +22,7 @@ public class CommentReplyImageWriter {
     }
 
     @Transactional
-    public void softDelete(Map<Long, CommentReplyImage> commentReplyImages, List<Long> deleteImageIds){
+    public void delete(Map<Long, CommentReplyImage> commentReplyImages, List<Long> deleteImageIds){
         deleteImageIds.forEach(id -> {
             commentReplyImages.get(id).softDelete();
         });

--- a/src/main/java/org/sopt/bofit/domain/commentreply/service/CommentReplyService.java
+++ b/src/main/java/org/sopt/bofit/domain/commentreply/service/CommentReplyService.java
@@ -87,7 +87,7 @@ public class CommentReplyService {
                         .filter(image -> image.id() != null).map(UpdateImageRequest::id).toList(),
                 command.deleteImageIds());
 
-        commentReplyImageWriter.softDelete(commentReplyImageMap, command.deleteImageIds());
+        commentReplyImageWriter.delete(commentReplyImageMap, command.deleteImageIds());
         commentReplyImageWriter.updateAll(commentReply, commentReplyImageMap, command.updatedImages());
         command.content().ifPresent(commentReply::updateContent);
 

--- a/src/main/java/org/sopt/bofit/domain/commentreply/service/CommentReplyService.java
+++ b/src/main/java/org/sopt/bofit/domain/commentreply/service/CommentReplyService.java
@@ -1,6 +1,11 @@
 package org.sopt.bofit.domain.commentreply.service;
 
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
 import org.sopt.bofit.domain.comment.entity.Comment;
 import org.sopt.bofit.domain.comment.service.CommentReader;
@@ -23,12 +28,6 @@ import org.sopt.bofit.global.file.util.ImageValidator;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.stream.IntStream;
 
 @Service
 @RequiredArgsConstructor
@@ -93,6 +92,22 @@ public class CommentReplyService {
         command.content().ifPresent(commentReply::updateContent);
 
         return commentReply;
+    }
+
+    @Transactional
+    public void delete(Long userId, Long postId, Long commentId, Long commentReplyId){
+        User user = userReader.getActiveById(userId);
+        Post post = postReader.getActiveById(postId);
+        Comment comment = commentReader.getActiveById(commentId);
+        CommentReply commentReply = commentReplyReader.getActiveById(commentReplyId);
+
+        commentReply.checkComment(comment);
+        commentReply.checkWriter(user);
+
+        commentReplyWriter.delete(commentReply);
+        postWriter.decreaseTrendScore(post);
+        commentWriter.decreaseReplyCount(comment);
+        commentReplyImageWriter.deleteFromCommentReply(commentReply);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/org/sopt/bofit/domain/commentreply/service/CommentReplyWriter.java
+++ b/src/main/java/org/sopt/bofit/domain/commentreply/service/CommentReplyWriter.java
@@ -18,4 +18,8 @@ public class CommentReplyWriter {
         return commentReplyRepository.save(commentReply);
     }
 
+    public void delete (CommentReply commentReply){
+        commentReply.softDelete();
+    }
+
 }

--- a/src/main/java/org/sopt/bofit/domain/insurance/controller/InsuranceController.java
+++ b/src/main/java/org/sopt/bofit/domain/insurance/controller/InsuranceController.java
@@ -47,7 +47,7 @@ public class InsuranceController {
 	public BaseResponse<IssueInsuranceReportResponse> issueReport(
 		@Parameter(hidden = true) @LoginUserId Long userId,
 		@Valid @RequestBody InsuranceReportRequest request){
-		IssueInsuranceReportResponse response = insuranceReportService.recommend(userId, request.toUserInfoCommand(), request.toUserUpdate());
+		IssueInsuranceReportResponse response = insuranceReportService.recommend(userId, request.toUserInfoCommand(), request.toPersonalInfoCommand());
 		return BaseResponse.create(response, "보험 추천 리포트 발급 성공");
 	}
 

--- a/src/main/java/org/sopt/bofit/domain/insurancereport/dto/request/InsuranceReportRequest.java
+++ b/src/main/java/org/sopt/bofit/domain/insurancereport/dto/request/InsuranceReportRequest.java
@@ -19,8 +19,8 @@ import org.sopt.bofit.domain.user.entity.constant.CoveragePreference;
 import org.sopt.bofit.domain.user.entity.constant.DiagnosedDisease;
 import org.sopt.bofit.domain.user.entity.constant.Gender;
 import org.sopt.bofit.domain.user.entity.constant.Job;
+import org.sopt.bofit.domain.user.service.dto.request.PersonalInfoCommand;
 import org.sopt.bofit.domain.user.service.dto.request.UserInfoCommand;
-import org.sopt.bofit.domain.user.service.dto.request.UserInfoUpdateCommand;
 import org.springframework.format.annotation.DateTimeFormat;
 
 @PremiumRange
@@ -84,9 +84,8 @@ public record InsuranceReportRequest(
 	int maxPremium
 ) {
 
-	public UserInfoUpdateCommand toUserUpdate(){
-			return new UserInfoUpdateCommand(name, gender, birthDate, job,
-				isMarried, isDriver, hasChild);
+	public PersonalInfoCommand toPersonalInfoCommand(){
+			return new PersonalInfoCommand(name, gender, birthDate, job, isMarried, isDriver, hasChild);
 	}
 
     public UserInfoCommand toUserInfoCommand(){

--- a/src/main/java/org/sopt/bofit/domain/insurancereport/service/InsuranceReportService.java
+++ b/src/main/java/org/sopt/bofit/domain/insurancereport/service/InsuranceReportService.java
@@ -19,8 +19,8 @@ import org.sopt.bofit.domain.insurancereport.entity.InsuranceReport;
 import org.sopt.bofit.domain.user.entity.User;
 import org.sopt.bofit.domain.user.entity.UserInfo;
 import org.sopt.bofit.domain.user.service.UserReader;
+import org.sopt.bofit.domain.user.service.dto.request.PersonalInfoCommand;
 import org.sopt.bofit.domain.user.service.dto.request.UserInfoCommand;
-import org.sopt.bofit.domain.user.service.dto.request.UserInfoUpdateCommand;
 import org.sopt.bofit.domain.user.util.UserUtil;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -37,10 +37,10 @@ public class InsuranceReportService {
 
 	private final UserReader userReader;
 
-	public IssueInsuranceReportResponse recommend(Long userId, UserInfoCommand userInfoCommand, UserInfoUpdateCommand userInfoUpdateCommand){
+	public IssueInsuranceReportResponse recommend(Long userId, UserInfoCommand userInfoCommand, PersonalInfoCommand personalInfoCommand){
 		User user = userReader.getActiveById(userId);
         UserInfo userInfo = userInfoCommand.createUserInfo(user);
-        int age = UserUtil.convertInternationalAge(userInfoUpdateCommand.birthDate());
+        int age = UserUtil.convertInternationalAge(personalInfoCommand.birthDate());
 
 		List<InsuranceProduct> products
 			= insuranceProductReader.getAgeAndPremiumFilteredProducts(age, userInfo.getMinPrice(), userInfo.getMaxPrice());
@@ -51,7 +51,8 @@ public class InsuranceReportService {
 			products, user, userInfo, age);
 
         InsuranceReport createdReport = insuranceReportWriter.createReport(totalAverage, recommendedProduct, user, userInfo, age);
-        InsuranceReport insuranceReport = insuranceReportWriter.saveReport(createdReport, user, userInfo, userInfoUpdateCommand);
+        InsuranceReport insuranceReport = insuranceReportWriter.saveReport(createdReport, user, userInfo,
+            personalInfoCommand);
 
 		return new IssueInsuranceReportResponse(insuranceReport.getId());
 	}

--- a/src/main/java/org/sopt/bofit/domain/insurancereport/service/InsuranceReportService.java
+++ b/src/main/java/org/sopt/bofit/domain/insurancereport/service/InsuranceReportService.java
@@ -40,7 +40,7 @@ public class InsuranceReportService {
 	public IssueInsuranceReportResponse recommend(Long userId, UserInfoCommand userInfoCommand, UserInfoUpdateCommand userInfoUpdateCommand){
 		User user = userReader.getActiveById(userId);
         UserInfo userInfo = userInfoCommand.createUserInfo(user);
-        int age = UserUtil.convertInternationalAge(user.getBirthDate());
+        int age = UserUtil.convertInternationalAge(userInfoUpdateCommand.birthDate());
 
 		List<InsuranceProduct> products
 			= insuranceProductReader.getAgeAndPremiumFilteredProducts(age, userInfo.getMinPrice(), userInfo.getMaxPrice());

--- a/src/main/java/org/sopt/bofit/domain/insurancereport/service/InsuranceReportWriter.java
+++ b/src/main/java/org/sopt/bofit/domain/insurancereport/service/InsuranceReportWriter.java
@@ -26,7 +26,7 @@ import org.sopt.bofit.domain.user.entity.UserInfo;
 import org.sopt.bofit.domain.user.service.UserInfoWriter;
 import org.sopt.bofit.domain.user.service.UserReader;
 import org.sopt.bofit.domain.user.service.UserWriter;
-import org.sopt.bofit.domain.user.service.dto.request.UserInfoUpdateCommand;
+import org.sopt.bofit.domain.user.service.dto.request.PersonalInfoCommand;
 import org.sopt.bofit.global.external.openai.client.OpenAiClient;
 import org.sopt.bofit.global.external.openai.dto.request.ChatRequestMessage;
 import org.sopt.bofit.global.external.openai.template.OpenAiPromptManager;
@@ -146,13 +146,13 @@ public class InsuranceReportWriter {
 		InsuranceReport report,
 		User requestUser,
 		UserInfo userInfo,
-        UserInfoUpdateCommand userInfoUpdateCommand
+        PersonalInfoCommand personalInfoCommand
 	){
         User user = userReader.getActiveById(requestUser.getId());
 		InsuranceReport savedInsuranceReport = insuranceReportRepository.save(report);
 		userInfoWriter.save(userInfo.updateReport(savedInsuranceReport));
 
-        userWriter.updateUser(user, userInfoUpdateCommand);
+        userWriter.updateUser(user, personalInfoCommand);
 
 		return savedInsuranceReport;
 	}

--- a/src/main/java/org/sopt/bofit/domain/post/controller/PostController.java
+++ b/src/main/java/org/sopt/bofit/domain/post/controller/PostController.java
@@ -11,6 +11,7 @@ import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.CR
 import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.CREATE_POST_LIKE;
 import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.DEFAULT;
 import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.DELETE_COMMENT;
+import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.DELETE_COMMENT_REPLY;
 import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.DELETE_POST;
 import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.DELETE_POST_LIKE;
 import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.POST_DETAIL;
@@ -40,8 +41,8 @@ import org.sopt.bofit.domain.post.dto.request.PostUpdateRequest;
 import org.sopt.bofit.domain.post.dto.response.PostCreateResponse;
 import org.sopt.bofit.domain.post.dto.response.PostDetailResponse;
 import org.sopt.bofit.domain.post.dto.response.PostSummaryResponse;
-import org.sopt.bofit.domain.post.entity.constant.PostCategoryFilter;
 import org.sopt.bofit.domain.post.dto.response.TrendingPostsResponses;
+import org.sopt.bofit.domain.post.entity.constant.PostCategoryFilter;
 import org.sopt.bofit.domain.post.entity.constant.PostSortOrder;
 import org.sopt.bofit.domain.post.service.PostLikeService;
 import org.sopt.bofit.domain.post.service.PostService;
@@ -49,16 +50,16 @@ import org.sopt.bofit.global.annotation.CustomExceptionDescription;
 import org.sopt.bofit.global.annotation.LoginUserId;
 import org.sopt.bofit.global.dto.response.BaseResponse;
 import org.sopt.bofit.global.dto.response.SliceResponse;
-import org.springframework.web.bind.annotation.*;
-
-import java.util.Optional;
-
-import static org.sopt.bofit.domain.comment.constant.CommentConstant.COMMENTS_DEFAULT_SIZE;
-import static org.sopt.bofit.domain.commentreply.constant.CommentReplyConstant.COMMENT_REPLY_DEFAULT_SIZE;
-import static org.sopt.bofit.domain.post.constant.PostConstant.POSTS_DEFAULT_SIZE;
-import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.*;
-import static org.sopt.bofit.global.constant.SwaggerConstant.TAG_DESCRIPTION_COMMUNITY;
-import static org.sopt.bofit.global.constant.SwaggerConstant.TAG_NAME_COMMUNITY;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
@@ -215,7 +216,7 @@ public class PostController {
         @Parameter(hidden = true) @LoginUserId Long userId
     ){
         postLikeService.deletePostLike(userId, postId);
-        return BaseResponse.create("좋아요 삭제 성공");
+        return BaseResponse.ok("좋아요 삭제 성공");
     }
 
     @Tag(name = TAG_NAME_COMMUNITY, description = TAG_DESCRIPTION_COMMUNITY)
@@ -259,7 +260,21 @@ public class PostController {
         @RequestBody @Valid CommentReplyUpdateRequest request
     ){
         commentReplyService.update(userId, postId, commentId, commentReplyId, request.toCommand());
-        return BaseResponse.create("대댓글 수정 성공");
+        return BaseResponse.ok("대댓글 수정 성공");
+    }
+
+    @Tag(name = TAG_NAME_COMMUNITY, description = TAG_DESCRIPTION_COMMUNITY)
+    @Operation(summary = "대댓글 삭제", description = "유저가 커뮤니티 댓글의 대댓글을 삭제합니다.")
+    @CustomExceptionDescription(DELETE_COMMENT_REPLY)
+    @DeleteMapping("/{post-id}/comments/{comment-id}/reply/{comment-reply-id}")
+    public BaseResponse<Void> deleteCommentReply(
+        @PathVariable(name = "post-id") Long postId,
+        @PathVariable(name = "comment-id") Long commentId,
+        @PathVariable(name = "comment-reply-id") Long commentReplyId,
+        @Parameter(hidden = true) @LoginUserId Long userId
+    ){
+        commentReplyService.delete(userId, postId, commentId, commentReplyId);
+        return BaseResponse.ok("대댓글 삭제 성공");
     }
 
     @Tag(name = TAG_NAME_COMMUNITY, description = TAG_DESCRIPTION_COMMUNITY)

--- a/src/main/java/org/sopt/bofit/domain/user/entity/UserInfo.java
+++ b/src/main/java/org/sopt/bofit/domain/user/entity/UserInfo.java
@@ -1,18 +1,5 @@
 package org.sopt.bofit.domain.user.entity;
 
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-
-import org.hibernate.annotations.Type;
-import org.sopt.bofit.domain.insurancereport.entity.InsuranceReport;
-import org.sopt.bofit.domain.user.entity.constant.CoveragePreference;
-import org.sopt.bofit.domain.user.entity.constant.DiagnosedDisease;
-import org.sopt.bofit.global.converter.CoveragePreferenceMapConverter;
-import org.sopt.bofit.global.converter.DiseaseEnumListJsonConverter;
-import org.sopt.bofit.global.entity.BaseEntity;
-
 import io.hypersistence.utils.hibernate.type.json.JsonType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
@@ -25,11 +12,22 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Type;
+import org.sopt.bofit.domain.insurancereport.entity.InsuranceReport;
+import org.sopt.bofit.domain.user.entity.constant.CoveragePreference;
+import org.sopt.bofit.domain.user.entity.constant.DiagnosedDisease;
+import org.sopt.bofit.global.converter.CoveragePreferenceMapConverter;
+import org.sopt.bofit.global.converter.DiseaseEnumListJsonConverter;
+import org.sopt.bofit.global.entity.BaseEntity;
 
 @Entity
 @Getter
@@ -38,6 +36,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @Table(name = "user_info")
 public class UserInfo extends BaseEntity {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/org/sopt/bofit/domain/user/service/UserService.java
+++ b/src/main/java/org/sopt/bofit/domain/user/service/UserService.java
@@ -11,7 +11,7 @@ import org.sopt.bofit.domain.user.entity.User;
 import org.sopt.bofit.domain.user.entity.constant.CoveragePreference;
 import org.sopt.bofit.domain.user.entity.constant.DiagnosedDisease;
 import org.sopt.bofit.domain.user.entity.constant.Job;
-import org.sopt.bofit.domain.user.service.dto.request.UserInfoUpdateCommand;
+import org.sopt.bofit.domain.user.service.dto.request.PersonalInfoCommand;
 import org.sopt.bofit.global.dto.response.SliceResponse;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -40,12 +40,12 @@ public class UserService {
 	}
 
 	@Transactional
-	public User userUpdate(Long userId, UserInfoUpdateCommand userInfoUpdateCommand){
+	public User userUpdate(Long userId, PersonalInfoCommand personalInfoCommand){
 		User user = userReader.findById(userId);
 
 		return userWriter.updateUser(
 			user,
-			userInfoUpdateCommand
+            personalInfoCommand
 		);
 	}
 

--- a/src/main/java/org/sopt/bofit/domain/user/service/UserWriter.java
+++ b/src/main/java/org/sopt/bofit/domain/user/service/UserWriter.java
@@ -1,15 +1,13 @@
 package org.sopt.bofit.domain.user.service;
 
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.sopt.bofit.domain.post.repository.PostRepository;
 import org.sopt.bofit.domain.user.entity.User;
 import org.sopt.bofit.domain.user.repository.UserRepository;
-import org.sopt.bofit.domain.user.service.dto.request.UserInfoUpdateCommand;
+import org.sopt.bofit.domain.user.service.dto.request.PersonalInfoCommand;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.time.LocalDate;
-import java.util.UUID;
 
 
 @Service
@@ -25,15 +23,15 @@ public class UserWriter {
     @Transactional
     public User updateUser(
         User user,
-        UserInfoUpdateCommand userInfoUpdateCommand
+        PersonalInfoCommand personalInfoCommand
     ){
-        user.updateName(userInfoUpdateCommand.name());
-        user.updateJob(userInfoUpdateCommand.job());
-        user.updateHasChild(userInfoUpdateCommand.hasChild());
-        user.updateDriver(userInfoUpdateCommand.isDriver());
-        user.updateGender(userInfoUpdateCommand.gender());
-        user.updateMarried(userInfoUpdateCommand.isMarried());
-        user.updateBirthDate(userInfoUpdateCommand.birthDate());
+        user.updateName(personalInfoCommand.name());
+        user.updateJob(personalInfoCommand.job());
+        user.updateHasChild(personalInfoCommand.hasChild());
+        user.updateDriver(personalInfoCommand.isDriver());
+        user.updateGender(personalInfoCommand.gender());
+        user.updateMarried(personalInfoCommand.isMarried());
+        user.updateBirthDate(personalInfoCommand.birthDate());
 
         user.recommendedInsurance();
 

--- a/src/main/java/org/sopt/bofit/domain/user/service/dto/request/PersonalInfoCommand.java
+++ b/src/main/java/org/sopt/bofit/domain/user/service/dto/request/PersonalInfoCommand.java
@@ -5,7 +5,7 @@ import org.sopt.bofit.domain.user.entity.constant.Gender;
 import org.sopt.bofit.domain.user.entity.constant.Job;
 
 
-public record UserInfoUpdateCommand(
+public record PersonalInfoCommand(
 	String name,
 	Gender gender,
 	LocalDate birthDate,

--- a/src/main/java/org/sopt/bofit/domain/user/service/dto/request/UserInfoCommand.java
+++ b/src/main/java/org/sopt/bofit/domain/user/service/dto/request/UserInfoCommand.java
@@ -18,6 +18,7 @@ public record UserInfoCommand (
 
     public UserInfo createUserInfo(User user){
         return UserInfo.builder()
+            .user(user)
             .maxPrice(maxPrice)
             .minPrice(minPrice)
             .diseaseHistory(diseaseHistory)

--- a/src/main/java/org/sopt/bofit/global/config/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/org/sopt/bofit/global/config/swagger/SwaggerResponseDescription.java
@@ -4,6 +4,7 @@ import static org.sopt.bofit.domain.insurancereport.errorcode.InsuranceReportErr
 import static org.sopt.bofit.domain.insurancereport.errorcode.InsuranceReportErrorCode.NOT_FOUND_INSURANCE_REPORT;
 import static org.sopt.bofit.global.exception.constant.CommentErrorCode.COMMENT_ALREADY_DELETED;
 import static org.sopt.bofit.global.exception.constant.CommentErrorCode.COMMENT_NOT_FOUND;
+import static org.sopt.bofit.global.exception.constant.CommentErrorCode.COMMENT_UNAUTHORIZED;
 import static org.sopt.bofit.global.exception.constant.CommentErrorCode.UNMATCHED_COMMENT_IMAGE;
 import static org.sopt.bofit.global.exception.constant.CommentErrorCode.UNMATCHED_COMMENT_POST;
 import static org.sopt.bofit.global.exception.constant.CommentReplyErrorCode.COMMENT_REPLY_NOT_FOUND;
@@ -135,6 +136,13 @@ public enum SwaggerResponseDescription {
         POST_NOT_FOUND,
         COMMENT_REPLY_NOT_FOUND,
         COMMENT_REPLY_UNAUTHORIZED
+    ))),
+    DELETE_COMMENT_REPLY(new LinkedHashSet<>(Set.of(
+        USER_NOT_FOUND,
+        COMMENT_NOT_FOUND,
+        POST_NOT_FOUND,
+        COMMENT_UNAUTHORIZED,
+        UNMATCHED_COMMENT_POST
     ))),
     UPDATE_NICKNAME(new LinkedHashSet<>(Set.of(
         USER_NOT_FOUND

--- a/src/test/java/org/sopt/bofit/domain/insurancereport/fixture/UserInfoFixture.java
+++ b/src/test/java/org/sopt/bofit/domain/insurancereport/fixture/UserInfoFixture.java
@@ -7,13 +7,13 @@ import org.sopt.bofit.domain.user.entity.constant.CoveragePreference;
 import org.sopt.bofit.domain.user.entity.constant.DiagnosedDisease;
 import org.sopt.bofit.domain.user.entity.constant.Gender;
 import org.sopt.bofit.domain.user.entity.constant.Job;
+import org.sopt.bofit.domain.user.service.dto.request.PersonalInfoCommand;
 import org.sopt.bofit.domain.user.service.dto.request.UserInfoCommand;
-import org.sopt.bofit.domain.user.service.dto.request.UserInfoUpdateCommand;
 
 public class UserInfoFixture {
 
-    public static UserInfoUpdateCommand userInfoUpdateCommand(){
-        return new UserInfoUpdateCommand(
+    public static PersonalInfoCommand userInfoUpdateCommand(){
+        return new PersonalInfoCommand(
             "테스트",
             Gender.FEMALE,
             LocalDate.of(2000, 01, 01),

--- a/src/test/java/org/sopt/bofit/domain/insurancereport/service/InsuranceReportWriterTest.java
+++ b/src/test/java/org/sopt/bofit/domain/insurancereport/service/InsuranceReportWriterTest.java
@@ -34,7 +34,7 @@ import org.sopt.bofit.domain.user.entity.constant.Job;
 import org.sopt.bofit.domain.user.entity.constant.LoginProvider;
 import org.sopt.bofit.domain.user.repository.UserInfoRepository;
 import org.sopt.bofit.domain.user.repository.UserRepository;
-import org.sopt.bofit.domain.user.service.dto.request.UserInfoUpdateCommand;
+import org.sopt.bofit.domain.user.service.dto.request.PersonalInfoCommand;
 import org.sopt.bofit.support.IntegrationTestSupport;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -223,10 +223,11 @@ class InsuranceReportWriterTest extends IntegrationTestSupport {
             .withStatistic(savedStatistic)
             .build();
 
-        UserInfoUpdateCommand userInfoUpdateCommand = UserInfoFixture.userInfoUpdateCommand();
+        PersonalInfoCommand personalInfoCommand = UserInfoFixture.userInfoUpdateCommand();
 
 	    // when
-		InsuranceReport result = insuranceReportWriter.saveReport(insuranceReport, savedUser, userInfo, userInfoUpdateCommand);
+		InsuranceReport result = insuranceReportWriter.saveReport(insuranceReport, savedUser, userInfo,
+            personalInfoCommand);
 
 		// then
 		assertThat(userInfoRepository.findAll().size()).isEqualTo(1);


### PR DESCRIPTION
## Related issue 🛠
- closed #177
  


## Work Description 📝
- 대댓글 삭제 API 구현
- 대댓글 이미지도 함께 삭제되도록 구현
- 보험 추천 로직의 dto 명 수정

## Uncompleted Tasks 😅

## To Reviewers 📢
