### PR TITLE
[Refactor] User 엔티티 필드 구조 리팩토링

### DIFF
--- a/src/main/java/org/sopt/bofit/domain/insurance/controller/InsuranceController.java
+++ b/src/main/java/org/sopt/bofit/domain/insurance/controller/InsuranceController.java
@@ -47,7 +47,7 @@ public class InsuranceController {
 	public BaseResponse<IssueInsuranceReportResponse> issueReport(
 		@Parameter(hidden = true) @LoginUserId Long userId,
 		@Valid @RequestBody InsuranceReportRequest request){
-		IssueInsuranceReportResponse response = insuranceReportService.recommend(userId, request.toUserInfoCommand(), request.toPersonalInfoCommand());
+		IssueInsuranceReportResponse response = insuranceReportService.recommend(userId, request.toUserInfoCommand(), request.toPersonalInfo());
 		return BaseResponse.create(response, "보험 추천 리포트 발급 성공");
 	}
 

--- a/src/main/java/org/sopt/bofit/domain/insurancereport/dto/request/InsuranceReportRequest.java
+++ b/src/main/java/org/sopt/bofit/domain/insurancereport/dto/request/InsuranceReportRequest.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Map;
 import lombok.Builder;
 import org.sopt.bofit.domain.insurancereport.annotation.PremiumRange;
+import org.sopt.bofit.domain.user.entity.PersonalInfo;
 import org.sopt.bofit.domain.user.entity.constant.CoveragePreference;
 import org.sopt.bofit.domain.user.entity.constant.DiagnosedDisease;
 import org.sopt.bofit.domain.user.entity.constant.Gender;
@@ -87,6 +88,18 @@ public record InsuranceReportRequest(
 	public PersonalInfoCommand toPersonalInfoCommand(){
 			return new PersonalInfoCommand(name, gender, birthDate, job, isMarried, isDriver, hasChild);
 	}
+
+    public PersonalInfo toPersonalInfo(){
+        return PersonalInfo.builder()
+            .name(name)
+            .gender(gender)
+            .birthDate(birthDate)
+            .job(job)
+            .isMarried(isMarried)
+            .isDriver(isDriver)
+            .hasChild(hasChild)
+            .build();
+    }
 
     public UserInfoCommand toUserInfoCommand(){
         return new UserInfoCommand(

--- a/src/main/java/org/sopt/bofit/domain/insurancereport/service/InsuranceReportService.java
+++ b/src/main/java/org/sopt/bofit/domain/insurancereport/service/InsuranceReportService.java
@@ -16,10 +16,10 @@ import org.sopt.bofit.domain.insurancereport.dto.response.disability.DisabilityS
 import org.sopt.bofit.domain.insurancereport.dto.response.majordisease.MajorDiseaseSection;
 import org.sopt.bofit.domain.insurancereport.dto.response.surgery.SurgerySection;
 import org.sopt.bofit.domain.insurancereport.entity.InsuranceReport;
+import org.sopt.bofit.domain.user.entity.PersonalInfo;
 import org.sopt.bofit.domain.user.entity.User;
 import org.sopt.bofit.domain.user.entity.UserInfo;
 import org.sopt.bofit.domain.user.service.UserReader;
-import org.sopt.bofit.domain.user.service.dto.request.PersonalInfoCommand;
 import org.sopt.bofit.domain.user.service.dto.request.UserInfoCommand;
 import org.sopt.bofit.domain.user.util.UserUtil;
 import org.springframework.stereotype.Service;
@@ -37,10 +37,10 @@ public class InsuranceReportService {
 
 	private final UserReader userReader;
 
-	public IssueInsuranceReportResponse recommend(Long userId, UserInfoCommand userInfoCommand, PersonalInfoCommand personalInfoCommand){
+	public IssueInsuranceReportResponse recommend(Long userId, UserInfoCommand userInfoCommand, PersonalInfo personalInfo){
 		User user = userReader.getActiveById(userId);
         UserInfo userInfo = userInfoCommand.createUserInfo(user);
-        int age = UserUtil.convertInternationalAge(personalInfoCommand.birthDate());
+        int age = UserUtil.convertInternationalAge(personalInfo.getBirthDate());
 
 		List<InsuranceProduct> products
 			= insuranceProductReader.getAgeAndPremiumFilteredProducts(age, userInfo.getMinPrice(), userInfo.getMaxPrice());
@@ -50,9 +50,10 @@ public class InsuranceReportService {
 		InsuranceProduct recommendedProduct = insuranceReportWriter.recommendBestInsurance(
 			products, user, userInfo, age);
 
-        InsuranceReport createdReport = insuranceReportWriter.createReport(totalAverage, recommendedProduct, user, userInfo, age);
+        InsuranceReport createdReport
+            = insuranceReportWriter.createReport(totalAverage, recommendedProduct, user, userInfo, personalInfo, age);
         InsuranceReport insuranceReport = insuranceReportWriter.saveReport(createdReport, user, userInfo,
-            personalInfoCommand);
+            personalInfo);
 
 		return new IssueInsuranceReportResponse(insuranceReport.getId());
 	}

--- a/src/main/java/org/sopt/bofit/domain/insurancereport/service/InsuranceReportWriter.java
+++ b/src/main/java/org/sopt/bofit/domain/insurancereport/service/InsuranceReportWriter.java
@@ -21,12 +21,12 @@ import org.sopt.bofit.domain.insurancereport.repository.InsuranceReportRepositor
 import org.sopt.bofit.domain.insurancereport.service.filter.CoveragePreferenceFilter;
 import org.sopt.bofit.domain.insurancereport.service.filter.DiseaseHistoryFilter;
 import org.sopt.bofit.domain.insurancereport.service.scoringrule.ScoringRuleCalculator;
+import org.sopt.bofit.domain.user.entity.PersonalInfo;
 import org.sopt.bofit.domain.user.entity.User;
 import org.sopt.bofit.domain.user.entity.UserInfo;
 import org.sopt.bofit.domain.user.service.UserInfoWriter;
 import org.sopt.bofit.domain.user.service.UserReader;
 import org.sopt.bofit.domain.user.service.UserWriter;
-import org.sopt.bofit.domain.user.service.dto.request.PersonalInfoCommand;
 import org.sopt.bofit.global.external.openai.client.OpenAiClient;
 import org.sopt.bofit.global.external.openai.dto.request.ChatRequestMessage;
 import org.sopt.bofit.global.external.openai.template.OpenAiPromptManager;
@@ -76,6 +76,7 @@ public class InsuranceReportWriter {
         InsuranceProduct product,
         User user,
         UserInfo userInfo,
+        PersonalInfo personalInfo,
         int age
     ){
         CoverageStatus cancerStatus = cancerCoverageStatus(product, average);
@@ -136,7 +137,7 @@ public class InsuranceReportWriter {
 
             .build();
 
-        report.updateRationale(generateRationale(user, userInfo, report, age));
+        report.updateRationale(generateRationale(personalInfo, userInfo, report, age));
         return report;
     }
 
@@ -146,19 +147,19 @@ public class InsuranceReportWriter {
 		InsuranceReport report,
 		User requestUser,
 		UserInfo userInfo,
-        PersonalInfoCommand personalInfoCommand
+        PersonalInfo personalInfo
 	){
         User user = userReader.getActiveById(requestUser.getId());
 		InsuranceReport savedInsuranceReport = insuranceReportRepository.save(report);
 		userInfoWriter.save(userInfo.updateReport(savedInsuranceReport));
 
-        userWriter.updateUser(user, personalInfoCommand);
+        userWriter.updateUser(user, personalInfo);
 
 		return savedInsuranceReport;
 	}
 
 	public ReportRationale generateRationale(
-		User user,
+        PersonalInfo personalInfo,
 		UserInfo userInfo,
 		InsuranceReport report,
 		int age
@@ -167,7 +168,7 @@ public class InsuranceReportWriter {
 		ReportRationale response = openAiClient.sendReportRelationalRequest(
 			List.of(
 				new ChatRequestMessage(SYSTEM.getValue(), openAiPromptManager.generateReportSystemMessage()),
-				new ChatRequestMessage(SYSTEM.getValue(), openAiPromptManager.generateReportRationale(user, userInfo, report, age))
+				new ChatRequestMessage(SYSTEM.getValue(), openAiPromptManager.generateReportRationale(personalInfo, userInfo, report, age))
 			));
 		return response;
 	}

--- a/src/main/java/org/sopt/bofit/domain/insurancereport/service/scoringrule/UserInfoRuleCalculator.java
+++ b/src/main/java/org/sopt/bofit/domain/insurancereport/service/scoringrule/UserInfoRuleCalculator.java
@@ -1,12 +1,12 @@
 package org.sopt.bofit.domain.insurancereport.service.scoringrule;
 
-import static org.sopt.bofit.domain.insurancereport.constant.ScoringRuleConstant.*;
-import static org.sopt.bofit.domain.user.entity.constant.Job.*;
+import static org.sopt.bofit.domain.insurancereport.constant.ScoringRuleConstant.MAJOR_DISEASE_RISKED_AGE;
+import static org.sopt.bofit.domain.user.entity.constant.Job.DRIVER_DELIVERY;
 
 import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
-
+import lombok.RequiredArgsConstructor;
 import org.sopt.bofit.domain.insurance.entity.product.InsuranceProduct;
 import org.sopt.bofit.domain.insurancereport.entity.scoringrule.userinfo.UserInfoRuleType;
 import org.sopt.bofit.domain.insurancereport.entity.scoringrule.userinfo.UserInfoScoringRule;
@@ -15,8 +15,6 @@ import org.sopt.bofit.domain.user.entity.User;
 import org.sopt.bofit.domain.user.entity.constant.Gender;
 import org.sopt.bofit.domain.user.entity.constant.Job;
 import org.springframework.stereotype.Service;
-
-import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
@@ -41,12 +39,12 @@ public class UserInfoRuleCalculator {
 	private Map<UserInfoRuleType, Predicate<User>> getUserInfoRuleMap(int age){
 		return Map.of(
 			UserInfoRuleType.AT_RISK_OF_MAJOR_DISEASE, user -> age > MAJOR_DISEASE_RISKED_AGE,
-			UserInfoRuleType.FEMALE, user -> user.getGender().equals(Gender.FEMALE),
-			UserInfoRuleType.PRODUCTION_SITE, user -> user.getJob().equals(Job.PRODUCTION_SITE),
-			UserInfoRuleType.DRIVER_DELIVERY, user -> user.getJob().equals(DRIVER_DELIVERY),
-			UserInfoRuleType.MARRIED, User::isMarried,
-			UserInfoRuleType.HAS_CHILD, User::isHasChild,
-			UserInfoRuleType.DRIVER, User::isDriver
+			UserInfoRuleType.FEMALE, user -> user.getPersonalInfo().getGender().equals(Gender.FEMALE),
+			UserInfoRuleType.PRODUCTION_SITE, user -> user.getPersonalInfo().getJob().equals(Job.PRODUCTION_SITE),
+			UserInfoRuleType.DRIVER_DELIVERY, user -> user.getPersonalInfo().getJob().equals(DRIVER_DELIVERY),
+			UserInfoRuleType.MARRIED, user -> user.getPersonalInfo().isMarried(),
+			UserInfoRuleType.HAS_CHILD, user -> user.getPersonalInfo().isHasChild(),
+			UserInfoRuleType.DRIVER, user -> user.getPersonalInfo().isDriver()
 		);
 	}
 

--- a/src/main/java/org/sopt/bofit/domain/insurancereport/template/ReportPromptTemplate.java
+++ b/src/main/java/org/sopt/bofit/domain/insurancereport/template/ReportPromptTemplate.java
@@ -1,17 +1,15 @@
 package org.sopt.bofit.domain.insurancereport.template;
 
 import java.util.stream.Collectors;
-
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 import org.sopt.bofit.domain.insurance.entity.product.InsuranceProduct;
 import org.sopt.bofit.domain.insurancereport.entity.InsuranceReport;
-import org.sopt.bofit.domain.user.entity.User;
+import org.sopt.bofit.domain.user.entity.PersonalInfo;
 import org.sopt.bofit.domain.user.entity.UserInfo;
 import org.sopt.bofit.domain.user.entity.constant.CoveragePreference;
 import org.sopt.bofit.domain.user.entity.constant.DiagnosedDisease;
 import org.sopt.bofit.global.external.openai.template.OpenAiPromptTemplate;
-
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class ReportPromptTemplate {
@@ -19,7 +17,7 @@ public class ReportPromptTemplate {
 
 	private final static String SYSTEM_MESSAGE = "너는 보험 리포트를 작성하는 전문가야. 아래 사용자 정보를 바탕으로, 요구사항에 맞춰 보험 리포트 설명을 작성해줘.";
 	public static String recommendReasonAndKeywordChip(
-		User user,
+        PersonalInfo personalInfo,
 		UserInfo userInfo,
 		InsuranceReport report,
 		int age
@@ -39,7 +37,7 @@ public class ReportPromptTemplate {
 		
 		keywordChips example: "중대 질환 든든 보장", "합리적인 보험료"
     """ +
-			userDetailTemplate(user, userInfo, age)
+			userDetailTemplate(personalInfo, userInfo, age)
 			+ reportInfoTemplate(report, report.getProduct()),
     """
      {
@@ -54,7 +52,7 @@ public class ReportPromptTemplate {
 			);
 	}
 
-	public static String userDetailTemplate(User user, UserInfo userInfo, int age){
+	public static String userDetailTemplate(PersonalInfo personalInfo, UserInfo userInfo, int age){
 		return """
    			### 사용자 정보
 			- 나이: %d
@@ -71,11 +69,11 @@ public class ReportPromptTemplate {
 				"""
 			.formatted(
 				age,
-				user.getGender().getDisplayName(),
-				user.getJob().getDisplayName(),
-				user.isMarried(),
-				user.isHasChild(),
-				user.isDriver(),
+                personalInfo.getGender().getDisplayName(),
+                personalInfo.getJob().getDisplayName(),
+                personalInfo.isMarried(),
+                personalInfo.isHasChild(),
+                personalInfo.isDriver(),
 				userInfo.getDiseaseHistory().stream()
 					.map(DiagnosedDisease::getDiseaseName)
 					.collect(Collectors.joining(DELIMITER)),

--- a/src/main/java/org/sopt/bofit/domain/user/dto/response/UserProfileResponse.java
+++ b/src/main/java/org/sopt/bofit/domain/user/dto/response/UserProfileResponse.java
@@ -1,9 +1,8 @@
 package org.sopt.bofit.domain.user.dto.response;
 
-import org.sopt.bofit.domain.user.entity.User;
-
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
+import org.sopt.bofit.domain.user.entity.User;
 
 public record UserProfileResponse(
         @Schema(description = "유저 PK", example = "1")
@@ -39,7 +38,7 @@ public record UserProfileResponse(
     public static UserProfileResponse from(User user) {
         return UserProfileResponse.builder()
             .userId(user.getId())
-            .username(user.getName())
+            .username(user.getPersonalInfo().getName())
             .nickname(user.getNickname())
             .profileImageUrl(user.getProfileImage())
             .isRecommendInsurance(user.isRecommendInsurance())

--- a/src/main/java/org/sopt/bofit/domain/user/entity/PersonalInfo.java
+++ b/src/main/java/org/sopt/bofit/domain/user/entity/PersonalInfo.java
@@ -1,0 +1,80 @@
+package org.sopt.bofit.domain.user.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import java.time.LocalDate;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.sopt.bofit.domain.user.entity.constant.Gender;
+import org.sopt.bofit.domain.user.entity.constant.Job;
+
+@Getter
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PersonalInfo {
+
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    private Gender gender;
+
+    @Column(name = "birth_date")
+    private LocalDate birthDate;
+
+    @Enumerated(EnumType.STRING)
+    private Job job;
+
+    @Column(name = "is_married")
+    private boolean isMarried;
+
+    @Column(name = "is_driver")
+    private boolean isDriver;
+
+    @Column(name = "has_child")
+    private boolean hasChild;
+
+
+    @Builder
+    private PersonalInfo(String name, Gender gender, LocalDate birthDate, Job job,
+        boolean isMarried, boolean isDriver, boolean hasChild) {
+        this.name = name;
+        this.gender = gender;
+        this.birthDate = birthDate;
+        this.job = job;
+        this.isMarried = isMarried;
+        this.isDriver = isDriver;
+        this.hasChild = hasChild;
+    }
+
+    protected void updateName(String name) {
+        this.name = name;
+    }
+
+    protected void updateGender(Gender gender) {
+        this.gender = gender;
+    }
+
+    protected void updateBirthDate(LocalDate birthDate) {
+        this.birthDate = birthDate;
+    }
+
+    protected void updateJob(Job job) {
+        this.job = job;
+    }
+
+    protected void updateMarried(boolean married) {
+        isMarried = married;
+    }
+
+    protected void updateDriver(boolean driver) {
+        isDriver = driver;
+    }
+
+    protected void updateHasChild(boolean hasChild) {
+        this.hasChild = hasChild;
+    }
+}

--- a/src/main/java/org/sopt/bofit/domain/user/entity/User.java
+++ b/src/main/java/org/sopt/bofit/domain/user/entity/User.java
@@ -1,14 +1,28 @@
 package org.sopt.bofit.domain.user.entity;
 
-import jakarta.persistence.*;
-import lombok.*;
-import org.sopt.bofit.domain.user.entity.constant.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.time.LocalDate;
+import java.util.Objects;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.sopt.bofit.domain.user.entity.constant.Gender;
+import org.sopt.bofit.domain.user.entity.constant.Job;
+import org.sopt.bofit.domain.user.entity.constant.LoginProvider;
+import org.sopt.bofit.domain.user.entity.constant.UserNicknameConstant;
+import org.sopt.bofit.domain.user.entity.constant.UserStatus;
 import org.sopt.bofit.global.entity.BaseEntity;
 import org.sopt.bofit.global.exception.constant.ErrorCode;
 import org.sopt.bofit.global.exception.customexception.ForbiddenException;
-
-import java.time.LocalDate;
-import java.util.Objects;
 
 @Entity
 @Getter
@@ -28,30 +42,13 @@ public class User extends BaseEntity {
     @Column(unique = true, nullable = false, name = "oauth_id")
     private String oauthId;
 
-    private String name;
-
     private String nickname;
 
     @Column(name = "profile_image")
     private String profileImage;
 
-    @Enumerated(EnumType.STRING)
-    private Gender gender;
-
-    @Column(name = "birth_date")
-    private LocalDate birthDate;
-
-    @Enumerated(EnumType.STRING)
-    private Job job;
-
-    @Column(name = "is_married")
-    private boolean isMarried;
-
-    @Column(name = "is_driver")
-    private boolean isDriver;
-
-    @Column(name = "has_child")
-    private boolean hasChild;
+    @Embedded
+    private PersonalInfo personalInfo;
 
     @Column(name = "is_recommend_insurance")
     private boolean isRecommendInsurance;
@@ -62,7 +59,7 @@ public class User extends BaseEntity {
     private UserStatus status = UserStatus.ACTIVE;
 
     public void updateName(String name) {
-        this.name = name;
+        this.personalInfo.updateName(name);
     }
 
     public void updateNickname(String nickname) {
@@ -74,27 +71,27 @@ public class User extends BaseEntity {
     }
 
     public void updateGender(Gender gender) {
-        this.gender = gender;
+        this.personalInfo.updateGender(gender);
     }
 
     public void updateBirthDate(LocalDate birthDate) {
-        this.birthDate = birthDate;
+        this.personalInfo.updateBirthDate(birthDate);
     }
 
     public void updateJob(Job job) {
-        this.job = job;
+        this.personalInfo.updateJob(job);
     }
 
     public void updateMarried(boolean married) {
-        isMarried = married;
+        this.personalInfo.updateMarried(married);
     }
 
     public void updateDriver(boolean driver) {
-        isDriver = driver;
+        this.personalInfo.updateDriver(driver);
     }
 
     public void updateHasChild(boolean hasChild) {
-        this.hasChild = hasChild;
+        this.personalInfo.updateHasChild(hasChild);
     }
 
     public void recommendedInsurance(){

--- a/src/main/java/org/sopt/bofit/domain/user/entity/User.java
+++ b/src/main/java/org/sopt/bofit/domain/user/entity/User.java
@@ -58,6 +58,10 @@ public class User extends BaseEntity {
     @Builder.Default
     private UserStatus status = UserStatus.ACTIVE;
 
+    public void updatePersonalInfo(PersonalInfo personalInfo) {
+        this.personalInfo = personalInfo;
+    }
+
     public void updateName(String name) {
         this.personalInfo.updateName(name);
     }

--- a/src/main/java/org/sopt/bofit/domain/user/service/UserService.java
+++ b/src/main/java/org/sopt/bofit/domain/user/service/UserService.java
@@ -7,11 +7,11 @@ import org.sopt.bofit.domain.user.dto.response.JobResponses;
 import org.sopt.bofit.domain.user.dto.response.MyCommentSummaryResponse;
 import org.sopt.bofit.domain.user.dto.response.MyPostSummaryResponse;
 import org.sopt.bofit.domain.user.dto.response.UserProfileResponse;
+import org.sopt.bofit.domain.user.entity.PersonalInfo;
 import org.sopt.bofit.domain.user.entity.User;
 import org.sopt.bofit.domain.user.entity.constant.CoveragePreference;
 import org.sopt.bofit.domain.user.entity.constant.DiagnosedDisease;
 import org.sopt.bofit.domain.user.entity.constant.Job;
-import org.sopt.bofit.domain.user.service.dto.request.PersonalInfoCommand;
 import org.sopt.bofit.global.dto.response.SliceResponse;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -40,12 +40,12 @@ public class UserService {
 	}
 
 	@Transactional
-	public User userUpdate(Long userId, PersonalInfoCommand personalInfoCommand){
+	public User userUpdate(Long userId, PersonalInfo personalInfo){
 		User user = userReader.findById(userId);
 
 		return userWriter.updateUser(
 			user,
-            personalInfoCommand
+            personalInfo
 		);
 	}
 

--- a/src/main/java/org/sopt/bofit/domain/user/service/UserWriter.java
+++ b/src/main/java/org/sopt/bofit/domain/user/service/UserWriter.java
@@ -3,9 +3,9 @@ package org.sopt.bofit.domain.user.service;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.sopt.bofit.domain.post.repository.PostRepository;
+import org.sopt.bofit.domain.user.entity.PersonalInfo;
 import org.sopt.bofit.domain.user.entity.User;
 import org.sopt.bofit.domain.user.repository.UserRepository;
-import org.sopt.bofit.domain.user.service.dto.request.PersonalInfoCommand;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,16 +23,9 @@ public class UserWriter {
     @Transactional
     public User updateUser(
         User user,
-        PersonalInfoCommand personalInfoCommand
+        PersonalInfo personalInfo
     ){
-        user.updateName(personalInfoCommand.name());
-        user.updateJob(personalInfoCommand.job());
-        user.updateHasChild(personalInfoCommand.hasChild());
-        user.updateDriver(personalInfoCommand.isDriver());
-        user.updateGender(personalInfoCommand.gender());
-        user.updateMarried(personalInfoCommand.isMarried());
-        user.updateBirthDate(personalInfoCommand.birthDate());
-
+        user.updatePersonalInfo(personalInfo);
         user.recommendedInsurance();
 
         return user;

--- a/src/main/java/org/sopt/bofit/global/external/openai/template/OpenAiPromptManager.java
+++ b/src/main/java/org/sopt/bofit/global/external/openai/template/OpenAiPromptManager.java
@@ -2,7 +2,7 @@ package org.sopt.bofit.global.external.openai.template;
 
 import org.sopt.bofit.domain.insurancereport.entity.InsuranceReport;
 import org.sopt.bofit.domain.insurancereport.template.ReportPromptTemplate;
-import org.sopt.bofit.domain.user.entity.User;
+import org.sopt.bofit.domain.user.entity.PersonalInfo;
 import org.sopt.bofit.domain.user.entity.UserInfo;
 import org.springframework.stereotype.Component;
 
@@ -10,12 +10,12 @@ import org.springframework.stereotype.Component;
 public class OpenAiPromptManager {
 
 	public String generateReportRationale(
-		User user,
+        PersonalInfo personalInfo,
 		UserInfo userInfo,
 		InsuranceReport report,
 		int age
 	){
-		return ReportPromptTemplate.recommendReasonAndKeywordChip(user, userInfo, report, age);
+		return ReportPromptTemplate.recommendReasonAndKeywordChip(personalInfo, userInfo, report, age);
 	}
 
 	public String generateReportSystemMessage(){

--- a/src/test/java/org/sopt/bofit/domain/insurancereport/fixture/UserFixture.java
+++ b/src/test/java/org/sopt/bofit/domain/insurancereport/fixture/UserFixture.java
@@ -1,0 +1,59 @@
+package org.sopt.bofit.domain.insurancereport.fixture;
+
+import java.time.LocalDate;
+import org.sopt.bofit.domain.user.entity.PersonalInfo;
+import org.sopt.bofit.domain.user.entity.User;
+import org.sopt.bofit.domain.user.entity.constant.Gender;
+import org.sopt.bofit.domain.user.entity.constant.Job;
+import org.sopt.bofit.domain.user.entity.constant.LoginProvider;
+
+public class UserFixture {
+
+    public static final String USER_NICKNAME = "테스트용 유저";
+    public static final String USER_OAUTH_ID = "123456789";
+    public static final LoginProvider USER_LOGIN_PROVIDER = LoginProvider.KAKAO;
+    public static final String USER_PROFILE_IMAGE = "profile.jpg";
+
+
+    public static final String PERSONAL_NAME = "테스터";
+    public static final Gender PERSONAL_GENDER = Gender.MALE;
+    public static final LocalDate PERSONAL_BIRTH_DATE = LocalDate.of(2000, 1, 1);
+    public static final Job PERSONAL_JOB = Job.STUDENT;
+    public static final boolean PERSONAL_IS_MARRIED = false;
+    public static final boolean PERSONAL_IS_DRIVER = false;
+    public static final boolean PERSONAL_HAS_CHILD = false;
+
+
+    public static User getUser(){
+        return User.builder()
+            .nickname(USER_NICKNAME)
+            .oauthId(USER_OAUTH_ID)
+            .loginProvider(USER_LOGIN_PROVIDER)
+            .profileImage(USER_PROFILE_IMAGE)
+            .personalInfo(getPersonalInfo())
+            .build();
+    }
+
+    public static User getUser(PersonalInfo personalInfo){
+        return User.builder()
+            .nickname(USER_NICKNAME)
+            .oauthId(USER_OAUTH_ID)
+            .loginProvider(USER_LOGIN_PROVIDER)
+            .profileImage(USER_PROFILE_IMAGE)
+            .personalInfo(personalInfo)
+            .build();
+    }
+
+    public static PersonalInfo getPersonalInfo(){
+        return PersonalInfo.builder()
+            .name(PERSONAL_NAME)
+            .gender(PERSONAL_GENDER)
+            .birthDate(PERSONAL_BIRTH_DATE)
+            .job(PERSONAL_JOB)
+            .isDriver(PERSONAL_IS_DRIVER)
+            .isMarried(PERSONAL_IS_MARRIED)
+            .hasChild(PERSONAL_HAS_CHILD)
+            .build();
+    }
+
+}

--- a/src/test/java/org/sopt/bofit/domain/insurancereport/service/InsuranceReportReaderTest.java
+++ b/src/test/java/org/sopt/bofit/domain/insurancereport/service/InsuranceReportReaderTest.java
@@ -1,11 +1,14 @@
 package org.sopt.bofit.domain.insurancereport.service;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import java.util.List;
 import java.util.UUID;
-
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -20,16 +23,13 @@ import org.sopt.bofit.domain.insurancereport.builder.InsuranceReportTestBuilder;
 import org.sopt.bofit.domain.insurancereport.entity.InsuranceReport;
 import org.sopt.bofit.domain.insurancereport.entity.constant.CoverageStatus;
 import org.sopt.bofit.domain.insurancereport.errorcode.InsuranceReportErrorCode;
+import org.sopt.bofit.domain.insurancereport.fixture.UserFixture;
 import org.sopt.bofit.domain.insurancereport.repository.InsuranceReportRepository;
 import org.sopt.bofit.domain.user.entity.User;
-import org.sopt.bofit.domain.user.entity.constant.LoginProvider;
 import org.sopt.bofit.domain.user.repository.UserRepository;
 import org.sopt.bofit.global.exception.customexception.NotFoundException;
 import org.sopt.bofit.support.IntegrationTestSupport;
 import org.springframework.beans.factory.annotation.Autowired;
-
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.PersistenceContext;
 
 class InsuranceReportReaderTest extends IntegrationTestSupport {
 
@@ -71,11 +71,7 @@ class InsuranceReportReaderTest extends IntegrationTestSupport {
 			.withStatisticRange(StatisticRange.TOTAL_AVERAGE)
 			.build();
 
-		User user = User.builder()
-			.name("유저1")
-			.loginProvider(LoginProvider.KAKAO)
-			.oauthId("0123456")
-			.build();
+		User user = UserFixture.getUser();
 
 		insuranceProductRepository.save(product);
 		insuranceStatisticRepository.save(statistic);
@@ -133,11 +129,7 @@ class InsuranceReportReaderTest extends IntegrationTestSupport {
 			.withStatisticRange(StatisticRange.TOTAL_AVERAGE)
 			.build();
 
-		User user = User.builder()
-			.name("유저1")
-			.loginProvider(LoginProvider.KAKAO)
-			.oauthId("0123456")
-			.build();
+		User user = UserFixture.getUser();
 
 		insuranceProductRepository.saveAll(List.of(product1, product2));
 		insuranceStatisticRepository.save(statistic);
@@ -176,11 +168,7 @@ class InsuranceReportReaderTest extends IntegrationTestSupport {
 	@Test
 	void getLastReportWhenReportDidntExist(){
 		// given
-		User user = User.builder()
-			.name("유저1")
-			.loginProvider(LoginProvider.KAKAO)
-			.oauthId("0123456")
-			.build();
+		User user = UserFixture.getUser();
 		userRepository.save(user);
 
 		// when // then

--- a/src/test/java/org/sopt/bofit/domain/insurancereport/service/InsuranceReportServiceTest.java
+++ b/src/test/java/org/sopt/bofit/domain/insurancereport/service/InsuranceReportServiceTest.java
@@ -31,14 +31,12 @@ import org.sopt.bofit.domain.insurancereport.entity.Disease;
 import org.sopt.bofit.domain.insurancereport.entity.InsuranceReport;
 import org.sopt.bofit.domain.insurancereport.entity.ReportRationale;
 import org.sopt.bofit.domain.insurancereport.entity.constant.CoverageStatus;
+import org.sopt.bofit.domain.insurancereport.fixture.UserFixture;
 import org.sopt.bofit.domain.insurancereport.fixture.UserInfoFixture;
 import org.sopt.bofit.domain.insurancereport.repository.InsuranceReportRepository;
 import org.sopt.bofit.domain.user.entity.User;
 import org.sopt.bofit.domain.user.entity.constant.CoveragePreference;
 import org.sopt.bofit.domain.user.entity.constant.DiagnosedDisease;
-import org.sopt.bofit.domain.user.entity.constant.Gender;
-import org.sopt.bofit.domain.user.entity.constant.Job;
-import org.sopt.bofit.domain.user.entity.constant.LoginProvider;
 import org.sopt.bofit.domain.user.repository.UserInfoRepository;
 import org.sopt.bofit.domain.user.repository.UserRepository;
 import org.sopt.bofit.domain.user.service.dto.request.UserInfoCommand;
@@ -109,30 +107,12 @@ class InsuranceReportServiceTest extends IntegrationTestSupport {
 			.build();
 
 		LocalDate birth = LocalDate.now().minusYears(30);
-		User user = User.builder()
-			.name("유저1")
-			.birthDate(birth)
-			.loginProvider(LoginProvider.KAKAO)
-			.gender(Gender.FEMALE)
-			.job(Job.STUDENT)
-			.isMarried(false)
-			.hasChild(false)
-			.oauthId("0123456")
-			.build();
+		User user = UserFixture.getUser();
 
 		Map<CoveragePreference, Integer> selectedCoverages = Map.of(
 			CoveragePreference.MAXIMUM_COVERAGE, 1,
 			CoveragePreference.MAJOR_DISEASE, 2
 		);
-
-//		UserInfo userInfo = UserInfo.builder()
-//			.minPrice(10000)
-//			.maxPrice(100000)
-//			.familyHistory(List.of(DiagnosedDisease.NONE))
-//			.diseaseHistory(List.of(DiagnosedDisease.NONE))
-//			.coveragePreferences(selectedCoverages)
-//			.user(user)
-//			.build();
 
         UserInfoCommand userInfo = UserInfoFixture.userInfoCommand(
             10000,
@@ -150,8 +130,8 @@ class InsuranceReportServiceTest extends IntegrationTestSupport {
 			.thenReturn(new ReportRationale(DEFAULT_RATIONALE_REASONS, DEFAULT_RATIONAL_KEYWORD_CHIPS));
 
 		// when
-		IssueInsuranceReportResponse result = insuranceReportService.recommend(savedUser.getId(), userInfo,
-            UserInfoFixture.userInfoUpdateCommand());
+		IssueInsuranceReportResponse result =
+            insuranceReportService.recommend(savedUser.getId(), userInfo, UserFixture.getPersonalInfo());
 
 		// then
 		Optional<InsuranceReport> resultReportId = insuranceReportRepository.findById(result.insuranceReportId());
@@ -189,11 +169,7 @@ class InsuranceReportServiceTest extends IntegrationTestSupport {
 			.withGeneralCancerSurgery(500)
 			.build();
 
-		User user = User.builder()
-			.name("유저1")
-			.loginProvider(LoginProvider.KAKAO)
-			.oauthId("0123456")
-			.build();
+		User user = UserFixture.getUser();
 
 		insuranceProductRepository.save(product1);
 		insuranceStatisticRepository.save(statistic);
@@ -237,11 +213,7 @@ class InsuranceReportServiceTest extends IntegrationTestSupport {
 			.withGeneralCancerSurgery(500)
 			.build();
 
-		User user = User.builder()
-			.name("유저1")
-			.loginProvider(LoginProvider.KAKAO)
-			.oauthId("0123456")
-			.build();
+		User user = UserFixture.getUser();
 
 		insuranceProductRepository.save(product1);
 		insuranceStatisticRepository.save(statistic);

--- a/src/test/java/org/sopt/bofit/domain/insurancereport/service/InsuranceReportWriterTest.java
+++ b/src/test/java/org/sopt/bofit/domain/insurancereport/service/InsuranceReportWriterTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.anyList;
 import static org.mockito.Mockito.when;
 import static org.sopt.bofit.domain.insurancereport.constant.InsuranceReportConstant.DEFAULT_RATIONALE_REASONS;
 import static org.sopt.bofit.domain.insurancereport.constant.InsuranceReportConstant.DEFAULT_RATIONAL_KEYWORD_CHIPS;
+import static org.sopt.bofit.domain.insurancereport.fixture.UserFixture.PERSONAL_NAME;
 
 import java.util.List;
 import java.util.Map;
@@ -23,18 +24,15 @@ import org.sopt.bofit.domain.insurance.repository.InsuranceStatisticRepository;
 import org.sopt.bofit.domain.insurancereport.builder.InsuranceReportTestBuilder;
 import org.sopt.bofit.domain.insurancereport.entity.InsuranceReport;
 import org.sopt.bofit.domain.insurancereport.entity.ReportRationale;
-import org.sopt.bofit.domain.insurancereport.fixture.UserInfoFixture;
+import org.sopt.bofit.domain.insurancereport.fixture.UserFixture;
 import org.sopt.bofit.domain.insurancereport.repository.InsuranceReportRepository;
+import org.sopt.bofit.domain.user.entity.PersonalInfo;
 import org.sopt.bofit.domain.user.entity.User;
 import org.sopt.bofit.domain.user.entity.UserInfo;
 import org.sopt.bofit.domain.user.entity.constant.CoveragePreference;
 import org.sopt.bofit.domain.user.entity.constant.DiagnosedDisease;
-import org.sopt.bofit.domain.user.entity.constant.Gender;
-import org.sopt.bofit.domain.user.entity.constant.Job;
-import org.sopt.bofit.domain.user.entity.constant.LoginProvider;
 import org.sopt.bofit.domain.user.repository.UserInfoRepository;
 import org.sopt.bofit.domain.user.repository.UserRepository;
-import org.sopt.bofit.domain.user.service.dto.request.PersonalInfoCommand;
 import org.sopt.bofit.support.IntegrationTestSupport;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -95,13 +93,7 @@ class InsuranceReportWriterTest extends IntegrationTestSupport {
 			.withStatus(InsuranceStatus.RECOMMENDED)
 			.build();
 
-		User user = User.builder()
-			.gender(Gender.FEMALE)
-			.hasChild(false)
-			.job(Job.STUDENT)
-			.isDriver(false)
-			.isMarried(false)
-			.build();
+		User user = UserFixture.getUser();
 
 		UserInfo userInfo = UserInfo.builder()
 			.minPrice(10000)
@@ -132,17 +124,7 @@ class InsuranceReportWriterTest extends IntegrationTestSupport {
             .withStatisticRange(StatisticRange.TOTAL_AVERAGE)
             .build();
 
-        String userName = "유저1";
-        User user = User.builder()
-            .name(userName)
-            .loginProvider(LoginProvider.KAKAO)
-            .gender(Gender.FEMALE)
-            .job(Job.STUDENT)
-            .isMarried(false)
-            .hasChild(false)
-            .oauthId("0123456")
-            .build();
-
+        User user = UserFixture.getUser();
         Map<CoveragePreference, Integer> selectedCoverages = Map.of(
             CoveragePreference.MAXIMUM_COVERAGE, 1,
             CoveragePreference.MAJOR_DISEASE, 2
@@ -164,14 +146,17 @@ class InsuranceReportWriterTest extends IntegrationTestSupport {
         when(openAiClient.sendReportRelationalRequest(anyList()))
             .thenReturn(new ReportRationale(DEFAULT_RATIONALE_REASONS, DEFAULT_RATIONAL_KEYWORD_CHIPS));
 
+        PersonalInfo personalInfo = UserFixture.getPersonalInfo();
+
         // when
-        InsuranceReport result = insuranceReportWriter.createReport(statistic, savedProduct, savedUser, userInfo, 30);
+        InsuranceReport result =
+            insuranceReportWriter.createReport(statistic, savedProduct, savedUser, userInfo, personalInfo, 30);
 
         // then
         assertThat(result)
             .isNotNull()
-            .extracting("product.basicInformation.name", "user.name", "reportRationale.reasons")
-            .containsExactly(productName, userName, DEFAULT_RATIONALE_REASONS );
+            .extracting("product.basicInformation.name", "user.personalInfo.name", "reportRationale.reasons")
+            .containsExactly(productName, PERSONAL_NAME, DEFAULT_RATIONALE_REASONS );
 
     }
 
@@ -188,16 +173,7 @@ class InsuranceReportWriterTest extends IntegrationTestSupport {
 			.withStatisticRange(StatisticRange.TOTAL_AVERAGE)
 			.build();
 
-		String userName = "유저1";
-		User user = User.builder()
-			.name(userName)
-			.loginProvider(LoginProvider.KAKAO)
-			.gender(Gender.FEMALE)
-			.job(Job.STUDENT)
-			.isMarried(false)
-			.hasChild(false)
-			.oauthId("0123456")
-			.build();
+		User user = UserFixture.getUser();
 
 		Map<CoveragePreference, Integer> selectedCoverages = Map.of(
 			CoveragePreference.MAXIMUM_COVERAGE, 1,
@@ -223,11 +199,10 @@ class InsuranceReportWriterTest extends IntegrationTestSupport {
             .withStatistic(savedStatistic)
             .build();
 
-        PersonalInfoCommand personalInfoCommand = UserInfoFixture.userInfoUpdateCommand();
+        PersonalInfo personalInfo = UserFixture.getPersonalInfo();
 
 	    // when
-		InsuranceReport result = insuranceReportWriter.saveReport(insuranceReport, savedUser, userInfo,
-            personalInfoCommand);
+		InsuranceReport result = insuranceReportWriter.saveReport(insuranceReport, savedUser, userInfo, personalInfo);
 
 		// then
 		assertThat(userInfoRepository.findAll().size()).isEqualTo(1);

--- a/src/test/java/org/sopt/bofit/domain/insurancereport/service/scoringrule/UserInfoRuleCalculatorTest.java
+++ b/src/test/java/org/sopt/bofit/domain/insurancereport/service/scoringrule/UserInfoRuleCalculatorTest.java
@@ -1,13 +1,19 @@
 package org.sopt.bofit.domain.insurancereport.service.scoringrule;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.sopt.bofit.domain.insurancereport.constant.ScoringRuleConstant.*;
-import static org.sopt.bofit.domain.insurancereport.entity.scoringrule.ConditionCoverage.*;
-import static org.sopt.bofit.domain.insurancereport.entity.scoringrule.ConditionOperator.*;
-import static org.sopt.bofit.domain.insurancereport.entity.scoringrule.userinfo.UserInfoRuleType.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.sopt.bofit.domain.insurancereport.constant.ScoringRuleConstant.MAJOR_DISEASE_RISKED_AGE;
+import static org.sopt.bofit.domain.insurancereport.entity.scoringrule.ConditionCoverage.ATYPICAL_CANCER_DIAGNOSIS;
+import static org.sopt.bofit.domain.insurancereport.entity.scoringrule.ConditionCoverage.GENERAL_CANCER_DIAGNOSIS;
+import static org.sopt.bofit.domain.insurancereport.entity.scoringrule.ConditionCoverage.INJURY_SURGERY;
+import static org.sopt.bofit.domain.insurancereport.entity.scoringrule.ConditionCoverage.ISCHEMIC_HEART_DISEASE_DIAGNOSIS;
+import static org.sopt.bofit.domain.insurancereport.entity.scoringrule.ConditionOperator.EXIST;
+import static org.sopt.bofit.domain.insurancereport.entity.scoringrule.ConditionOperator.GE;
+import static org.sopt.bofit.domain.insurancereport.entity.scoringrule.userinfo.UserInfoRuleType.AT_RISK_OF_MAJOR_DISEASE;
+import static org.sopt.bofit.domain.insurancereport.entity.scoringrule.userinfo.UserInfoRuleType.DRIVER;
+import static org.sopt.bofit.domain.insurancereport.entity.scoringrule.userinfo.UserInfoRuleType.FEMALE;
+import static org.sopt.bofit.domain.insurancereport.entity.scoringrule.userinfo.UserInfoRuleType.HAS_CHILD;
 
 import java.util.List;
-
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -16,7 +22,9 @@ import org.sopt.bofit.domain.insurance.entity.product.InsuranceProduct;
 import org.sopt.bofit.domain.insurancereport.entity.scoringrule.ConditionOperator;
 import org.sopt.bofit.domain.insurancereport.entity.scoringrule.userinfo.UserInfoRuleType;
 import org.sopt.bofit.domain.insurancereport.entity.scoringrule.userinfo.UserInfoScoringRule;
+import org.sopt.bofit.domain.insurancereport.fixture.UserFixture;
 import org.sopt.bofit.domain.insurancereport.repository.scoringrule.UserInfoScoringRuleRepository;
+import org.sopt.bofit.domain.user.entity.PersonalInfo;
 import org.sopt.bofit.domain.user.entity.User;
 import org.sopt.bofit.domain.user.entity.constant.Gender;
 import org.sopt.bofit.domain.user.entity.constant.Job;
@@ -47,11 +55,13 @@ class UserInfoRuleCalculatorTest extends IntegrationTestSupport {
 			.withIschemicDiagnosis(1000)
 			.build();
 
-		User user = User.builder()
-			.job(Job.DRIVER_DELIVERY)
-			.isDriver(true)
-			.gender(Gender.FEMALE)
-			.build();
+        PersonalInfo personalInfo = PersonalInfo.builder()
+            .job(Job.DRIVER_DELIVERY)
+            .isDriver(true)
+            .gender(Gender.FEMALE)
+            .build();
+
+		User user = UserFixture.getUser(personalInfo);
 
 		UserInfoScoringRule appliedRule1 = UserInfoScoringRule.create(
 			FEMALE,

--- a/src/test/java/org/sopt/bofit/domain/post/service/PostLikeServiceTest.java
+++ b/src/test/java/org/sopt/bofit/domain/post/service/PostLikeServiceTest.java
@@ -1,14 +1,19 @@
 package org.sopt.bofit.domain.post.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.sopt.bofit.domain.insurancereport.fixture.UserFixture;
 import org.sopt.bofit.domain.post.entity.Post;
 import org.sopt.bofit.domain.post.entity.PostLike;
 import org.sopt.bofit.domain.post.repository.PostLikeRepository;
 import org.sopt.bofit.domain.post.repository.PostRepository;
 import org.sopt.bofit.domain.user.entity.User;
-import org.sopt.bofit.domain.user.entity.constant.LoginProvider;
 import org.sopt.bofit.domain.user.repository.UserRepository;
 import org.sopt.bofit.global.exception.constant.ErrorCode;
 import org.sopt.bofit.global.exception.constant.PostErrorCode;
@@ -17,11 +22,6 @@ import org.sopt.bofit.global.exception.customexception.CustomException;
 import org.sopt.bofit.global.exception.customexception.NotFoundException;
 import org.sopt.bofit.support.IntegrationTestSupport;
 import org.springframework.beans.factory.annotation.Autowired;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class PostLikeServiceTest extends IntegrationTestSupport {
 
@@ -59,11 +59,7 @@ class PostLikeServiceTest extends IntegrationTestSupport {
     @Test
     void createPostLike(){
         // given
-        User user = User.builder()
-            .name("유저1")
-            .loginProvider(LoginProvider.KAKAO)
-            .oauthId("0123456")
-            .build();
+        User user = UserFixture.getUser();
         userRepository.save(user);
 
         Post post = Post.create(user, "testTitle", "testComment", "QNA", "test");
@@ -84,11 +80,7 @@ class PostLikeServiceTest extends IntegrationTestSupport {
     @Test
     void createPostLikeConflict(){
         // given
-        User user = User.builder()
-            .name("유저1")
-            .loginProvider(LoginProvider.KAKAO)
-            .oauthId("0123456")
-            .build();
+        User user = UserFixture.getUser();
         userRepository.save(user);
 
         Post post = Post.create(user, "testTitle", "testComment", "QNA","test");
@@ -108,11 +100,7 @@ class PostLikeServiceTest extends IntegrationTestSupport {
     @Test
     void deletePostLike(){
         // given
-        User user = User.builder()
-            .name("유저1")
-            .loginProvider(LoginProvider.KAKAO)
-            .oauthId("0123456")
-            .build();
+        User user = UserFixture.getUser();
         userRepository.save(user);
 
         Post post = Post.create(user, "testTitle", "testComment","QNA","test");
@@ -137,11 +125,7 @@ class PostLikeServiceTest extends IntegrationTestSupport {
     @Test
     void deletePostLikeConflict(){
         // given
-        User user = User.builder()
-            .name("유저1")
-            .loginProvider(LoginProvider.KAKAO)
-            .oauthId("0123456")
-            .build();
+        User user = UserFixture.getUser();
         userRepository.save(user);
 
         Post post = Post.create(user, "testTitle", "testComment","QNA", "test");


### PR DESCRIPTION
## Related issue 🛠
- closed #181
  
## Work Description 📝
- 기존 플랫하게 가져가던 User 엔티티의 필드 구조를 보다 객체지향적으로 사용할 수 있도록 PersonalInfo로 분리했습니다.
- 이거 되게 좋다고 생각하는게 PersonalInfo 는 개념적으로도 응집도가 높아서, 보험 추천 받을 때 따로 사용되는 등 구분이 확실히 되어서 코드가 훨씬 보기 좋아졌습니다. 그리고 User 필드 수정하는 부분도 받아온 PersonalInfo를 그대로 적용할 수 있어서 깔끔해졌어요.


## Uncompleted Tasks 😅

## To Reviewers 📢
