### PR TITLE
[Fix] 유저 정보에 personal info가 없는 경우 정상적으로 내려주도록 변경 

### DIFF
--- a/src/main/java/org/sopt/bofit/domain/insurancereport/service/scoringrule/UserInfoRuleCalculator.java
+++ b/src/main/java/org/sopt/bofit/domain/insurancereport/service/scoringrule/UserInfoRuleCalculator.java
@@ -29,12 +29,14 @@ public class UserInfoRuleCalculator {
             .sum();
     }
 
+    /** deprecated*/
 	public double calculate(User user, InsuranceProduct product, int age){
 		return getUserInfoRuleMap(age).entrySet().stream()
 			.mapToDouble(entry ->  considerUserInfo(entry.getValue(), user, product, entry.getKey()))
 			.sum();
 	}
 
+    /** deprecated*/
 	private double considerUserInfo (Predicate<User> condition, User user, InsuranceProduct product, UserInfoRuleType ruleType) {
 		double additional = 0;
 		if (condition.test(user)) {
@@ -51,6 +53,7 @@ public class UserInfoRuleCalculator {
         return additional;
     }
 
+    /** deprecated*/
 	private Map<UserInfoRuleType, Predicate<User>> getUserInfoRuleMap(int age){
 		return Map.of(
 			UserInfoRuleType.AT_RISK_OF_MAJOR_DISEASE, user -> age > MAJOR_DISEASE_RISKED_AGE,

--- a/src/main/java/org/sopt/bofit/domain/user/dto/response/UserProfileResponse.java
+++ b/src/main/java/org/sopt/bofit/domain/user/dto/response/UserProfileResponse.java
@@ -1,7 +1,9 @@
 package org.sopt.bofit.domain.user.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.Optional;
 import lombok.Builder;
+import org.sopt.bofit.domain.user.entity.PersonalInfo;
 import org.sopt.bofit.domain.user.entity.User;
 
 public record UserProfileResponse(
@@ -36,9 +38,13 @@ public record UserProfileResponse(
     }
 
     public static UserProfileResponse from(User user) {
+        String name = Optional.ofNullable(user.getPersonalInfo())
+            .map(PersonalInfo::getName)
+            .orElse(null);
+
         return UserProfileResponse.builder()
             .userId(user.getId())
-            .username(user.getPersonalInfo().getName())
+            .username(name)
             .nickname(user.getNickname())
             .profileImageUrl(user.getProfileImage())
             .isRecommendInsurance(user.isRecommendInsurance())


### PR DESCRIPTION
## Related issue 🛠
- closed #192 
  


## Work Description 📝
- 유저 정보에 personal info가 없는 경우 정상적으로 내려주도록 변경
## Uncompleted Tasks 😅

## To Reviewers 📢
