### PR TITLE
[Feat] 게시글 삭제를 소프트딜리트로 변경

### DIFF
--- a/src/main/java/org/sopt/bofit/domain/post/entity/Post.java
+++ b/src/main/java/org/sopt/bofit/domain/post/entity/Post.java
@@ -1,13 +1,26 @@
 package org.sopt.bofit.domain.post.entity;
 
-import jakarta.persistence.*;
-import lombok.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.util.Objects;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.sopt.bofit.domain.post.entity.constant.PostCategory;
 import org.sopt.bofit.domain.post.entity.constant.PostStatus;
 import org.sopt.bofit.domain.user.entity.User;
 import org.sopt.bofit.global.entity.BaseEntity;
-
-import java.util.Objects;
 
 @Entity
 @Getter
@@ -70,6 +83,10 @@ public class Post extends BaseEntity {
         this.title = title;
         this.content = content;
         this.postCategory = Enum.valueOf(PostCategory.class, category);
+    }
+
+    public void softDelete(){
+        this.status = PostStatus.INACTIVE;
     }
 
     @Override

--- a/src/main/java/org/sopt/bofit/domain/post/entity/PostImage.java
+++ b/src/main/java/org/sopt/bofit/domain/post/entity/PostImage.java
@@ -1,10 +1,23 @@
 package org.sopt.bofit.domain.post.entity;
 
-import jakarta.persistence.*;
-import lombok.*;
-import org.sopt.bofit.domain.post.entity.constant.PostImageStatus;
-
 import static org.sopt.bofit.global.file.constant.ImageConstant.MAX_IMAGE_URL_LENGTH;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.sopt.bofit.domain.post.entity.constant.PostImageStatus;
 
 @Entity
 @Getter
@@ -24,7 +37,6 @@ public class PostImage {
     @Column(nullable = false, length = MAX_IMAGE_URL_LENGTH)
     private String imageUrl;
 
-    @Column(nullable = false)
     private Integer sequence;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/org/sopt/bofit/domain/post/service/PostImageReader.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/PostImageReader.java
@@ -1,16 +1,15 @@
 package org.sopt.bofit.domain.post.service;
 
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.sopt.bofit.domain.post.entity.Post;
 import org.sopt.bofit.domain.post.entity.PostImage;
 import org.sopt.bofit.domain.post.entity.constant.PostImageStatus;
-import org.sopt.bofit.domain.post.entity.constant.PostStatus;
 import org.sopt.bofit.domain.post.repository.PostImageRepository;
 import org.springframework.stereotype.Service;
-
-import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -23,4 +22,7 @@ public class PostImageReader {
                 .collect(Collectors.toMap(PostImage::getId, Function.identity()));
     }
 
+    public List<PostImage> getAllActiveImages(Post post) {
+        return postImageRepository.findAllByPostAndStatus(post, PostImageStatus.ACTIVE);
+    }
 }

--- a/src/main/java/org/sopt/bofit/domain/post/service/PostImageWriter.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/PostImageWriter.java
@@ -1,6 +1,8 @@
 package org.sopt.bofit.domain.post.service;
 
 import jakarta.transaction.Transactional;
+import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.sopt.bofit.domain.post.entity.Post;
 import org.sopt.bofit.domain.post.entity.PostImage;
@@ -8,13 +10,11 @@ import org.sopt.bofit.domain.post.repository.PostImageRepository;
 import org.sopt.bofit.global.file.dto.request.UpdateImageRequest;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
-import java.util.Map;
-
 @Service
 @RequiredArgsConstructor
 public class PostImageWriter {
 
+    private final PostImageReader postImageReader;
     private final PostImageRepository postImageRepository;
 
     public PostImage create(Post post, String url, Integer sequence) {
@@ -42,6 +42,11 @@ public class PostImageWriter {
         deleteImageIds.forEach(id -> {
             postImages.get(id).softDelete();
         });
+    }
+
+    public void deleteAllImagesInPost(Post post) {
+        List<PostImage> allActiveImages = postImageReader.getAllActiveImages(post);
+        allActiveImages.forEach(PostImage::softDelete);
     }
 
 }

--- a/src/main/java/org/sopt/bofit/domain/post/service/PostService.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/PostService.java
@@ -90,6 +90,7 @@ public class PostService {
         post.getUser().checkIsWriter(userId, POST_UNAUTHORIZED);
 
         postWriter.delete(post);
+        postImageWriter.deleteAllImagesInPost(post);
         trendPostWriter.validDeletePost(post);
     }
 

--- a/src/main/java/org/sopt/bofit/domain/post/service/PostService.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/PostService.java
@@ -1,5 +1,12 @@
 package org.sopt.bofit.domain.post.service;
 
+import static org.sopt.bofit.global.exception.constant.PostErrorCode.POST_UNAUTHORIZED;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
 import org.sopt.bofit.domain.post.dto.response.PostCreateResponse;
 import org.sopt.bofit.domain.post.dto.response.PostDetailResponse;
@@ -21,14 +28,6 @@ import org.sopt.bofit.global.file.dto.request.UpdateImageRequest;
 import org.sopt.bofit.global.file.util.ImageValidator;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.IntStream;
-
-import static org.sopt.bofit.global.exception.constant.PostErrorCode.POST_UNAUTHORIZED;
 
 @Service
 @RequiredArgsConstructor
@@ -90,7 +89,7 @@ public class PostService {
         Post post = postReader.getActiveById(postId);
         post.getUser().checkIsWriter(userId, POST_UNAUTHORIZED);
 
-        postWriter.delete(user, post);
+        postWriter.delete(post);
         trendPostWriter.validDeletePost(post);
     }
 

--- a/src/main/java/org/sopt/bofit/domain/post/service/PostWriter.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/PostWriter.java
@@ -31,10 +31,8 @@ public class PostWriter {
         return postRepository.save(post);
     }
 
-
-    @Transactional
-    public void delete(User user, Post post) {
-        postRepository.delete(post);
+    public void delete(Post post) {
+        post.softDelete();
 
         commentRepository.findAllByPostIdAndStatus(post.getId(), CommentStatus.ACTIVE).forEach(Comment::softDelete);
     }


### PR DESCRIPTION
## Related issue 🛠
- closed #197
  

## Work Description 📝
- 게시글 삭제 로직이 기존 논의와 다르게 하드딜리트로 구현되어 있어 소프트 딜리트로 변경
- 게시글 삭제 시 게시글 이미지 삭제 로직이 누락되어 있어 게시글 이미지 삭제 로직 추가
- PostImage의 sequence 칼럼을 not null 하지 않도록 변경 

## Uncompleted Tasks 😅

## To Reviewers 📢
