### PR TITLE
[Fix] 게시물 검색 시 중복 페이지 반환되는 문제 수정

### DIFF
--- a/src/main/java/org/sopt/bofit/domain/post/controller/PostController.java
+++ b/src/main/java/org/sopt/bofit/domain/post/controller/PostController.java
@@ -1,32 +1,10 @@
 package org.sopt.bofit.domain.post.controller;
 
-import static org.sopt.bofit.domain.comment.constant.CommentConstant.COMMENTS_DEFAULT_SIZE;
-import static org.sopt.bofit.domain.commentreply.constant.CommentReplyConstant.COMMENT_REPLY_DEFAULT_SIZE;
-import static org.sopt.bofit.domain.post.constant.PostConstant.POSTS_DEFAULT_SIZE;
-import static org.sopt.bofit.domain.post.constant.TrendPostConstant.TREND_POST_DEFAULT_SIZE;
-import static org.sopt.bofit.domain.post.constant.TrendPostConstant.TREND_POST_DEFAULT_SORT;
-import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.CREATE_COMMENT;
-import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.CREATE_COMMENT_REPLY;
-import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.CREATE_POST;
-import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.CREATE_POST_LIKE;
-import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.DEFAULT;
-import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.DELETE_COMMENT;
-import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.DELETE_COMMENT_REPLY;
-import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.DELETE_POST;
-import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.DELETE_POST_LIKE;
-import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.POST_DETAIL;
-import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.UPDATE_COMMENT;
-import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.UPDATE_COMMENT_REPLY;
-import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.UPDATE_POST;
-import static org.sopt.bofit.global.constant.SwaggerConstant.TAG_DESCRIPTION_COMMUNITY;
-import static org.sopt.bofit.global.constant.SwaggerConstant.TAG_NAME_COMMUNITY;
-
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.sopt.bofit.domain.comment.dto.request.CommentCreateRequest;
 import org.sopt.bofit.domain.comment.dto.request.CommentUpdateRequest;
@@ -38,10 +16,7 @@ import org.sopt.bofit.domain.commentreply.dto.response.CommentReplyWithImagesRes
 import org.sopt.bofit.domain.commentreply.service.CommentReplyService;
 import org.sopt.bofit.domain.post.dto.request.PostCreateRequest;
 import org.sopt.bofit.domain.post.dto.request.PostUpdateRequest;
-import org.sopt.bofit.domain.post.dto.response.PostCreateResponse;
-import org.sopt.bofit.domain.post.dto.response.PostDetailResponse;
-import org.sopt.bofit.domain.post.dto.response.PostSummaryResponse;
-import org.sopt.bofit.domain.post.dto.response.TrendingPostsResponses;
+import org.sopt.bofit.domain.post.dto.response.*;
 import org.sopt.bofit.domain.post.entity.constant.PostCategoryFilter;
 import org.sopt.bofit.domain.post.entity.constant.PostSortOrder;
 import org.sopt.bofit.domain.post.service.PostLikeService;
@@ -50,16 +25,18 @@ import org.sopt.bofit.global.annotation.CustomExceptionDescription;
 import org.sopt.bofit.global.annotation.LoginUserId;
 import org.sopt.bofit.global.dto.response.BaseResponse;
 import org.sopt.bofit.global.dto.response.SliceResponse;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Optional;
+
+import static org.sopt.bofit.domain.comment.constant.CommentConstant.COMMENTS_DEFAULT_SIZE;
+import static org.sopt.bofit.domain.commentreply.constant.CommentReplyConstant.COMMENT_REPLY_DEFAULT_SIZE;
+import static org.sopt.bofit.domain.post.constant.PostConstant.POSTS_DEFAULT_SIZE;
+import static org.sopt.bofit.domain.post.constant.TrendPostConstant.TREND_POST_DEFAULT_SIZE;
+import static org.sopt.bofit.domain.post.constant.TrendPostConstant.TREND_POST_DEFAULT_SORT;
+import static org.sopt.bofit.global.config.swagger.SwaggerResponseDescription.*;
+import static org.sopt.bofit.global.constant.SwaggerConstant.TAG_DESCRIPTION_COMMUNITY;
+import static org.sopt.bofit.global.constant.SwaggerConstant.TAG_NAME_COMMUNITY;
 
 @RestController
 @RequiredArgsConstructor
@@ -281,13 +258,13 @@ public class PostController {
     @Operation(summary = "게시물 검색", description = "검색 키워드를 기반으로 게시물을 검색합니다.")
     @CustomExceptionDescription(DEFAULT)
     @GetMapping("search")
-    public BaseResponse<SliceResponse<PostSummaryResponse, Long>> searchPosts(
+    public BaseResponse<SliceResponse<PostSearchResponse, String>> searchPosts(
             @RequestParam(name = "keyword") String keyword,
             @Parameter(hidden = true) @LoginUserId Long userId,
-            @RequestParam(required = false, name = "cursor") Long cursorId,
+            @RequestParam(required = false, name = "cursor") String cursor,
             @RequestParam(required = false, defaultValue = POSTS_DEFAULT_SIZE) int size
     ){
-        return BaseResponse.ok(postService.searchPosts(userId, keyword, cursorId, size),"게시물 검색 성공");
+        return BaseResponse.ok(postService.searchPosts(userId, keyword, cursor, size),"게시물 검색 성공");
     }
 
 }

--- a/src/main/java/org/sopt/bofit/domain/post/dto/response/PostSearchResponse.java
+++ b/src/main/java/org/sopt/bofit/domain/post/dto/response/PostSearchResponse.java
@@ -1,0 +1,60 @@
+package org.sopt.bofit.domain.post.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.sopt.bofit.global.dto.response.CursorProvider;
+
+import java.time.LocalDateTime;
+
+public record PostSearchResponse(
+        @Schema(description = "게시글 ID")
+        Long postId,
+
+        @Schema(description = "작성자 ID")
+        Long writerId,
+
+        @Schema(description = "게시글 제목", example = "아니")
+        String title,
+
+        @Schema(description = "게시글 내용", example = "장정훈 그는 누구인가")
+        String content,
+
+        @Schema(description = "작성자 닉네임", example = "정훈 장")
+        String writerNickname,
+
+        @Schema(description = "작성자 프로필 사진")
+        String profileImageUrl,
+
+        @Schema(description = "댓글 수", example = "8")
+        int commentCount,
+
+        @Schema(description = "게시물 작성 시각")
+        LocalDateTime createdAt,
+
+        @Schema(description = "좋아요 수")
+        int likeCount,
+
+        @Schema(description = "사용자의 좋아요 여부")
+        boolean likedByCurrentUser,
+
+        @Schema(description = "연관도")
+        double relevanceScore
+
+) implements CursorProvider<String> {
+
+    @Override
+    public String nextCursor() {
+        return relevanceScore + "," + postId;
+    }
+
+    public static Cursor decodeCursor(String cursor) {
+        if (cursor == null || !cursor.contains(",")) {
+            return null;
+        }
+        String[] parts = cursor.split(",");
+        double relevance = Double.parseDouble(parts[0]);
+        long postId = Long.parseLong(parts[1]);
+        return new Cursor(relevance, postId);
+    }
+
+    public record Cursor(double relevance, long postId) {}
+}

--- a/src/main/java/org/sopt/bofit/domain/post/repository/PostCustomRepository.java
+++ b/src/main/java/org/sopt/bofit/domain/post/repository/PostCustomRepository.java
@@ -1,5 +1,6 @@
 package org.sopt.bofit.domain.post.repository;
 
+import org.sopt.bofit.domain.post.dto.response.PostSearchResponse;
 import org.sopt.bofit.domain.post.dto.response.PostSummaryResponse;
 import org.sopt.bofit.domain.post.entity.Post;
 import org.sopt.bofit.domain.post.entity.constant.PostCategoryFilter;
@@ -17,7 +18,7 @@ public interface PostCustomRepository {
 
     Slice<PostSummaryResponse> findAllByCursorId(PostSortOrder order, PostCategoryFilter category, Long userId, Long cursorId, int size);
 
-    Slice<PostSummaryResponse> findAllByKeywordAndCursorId(Long userId, String keyword, Long cursorId, int size);
+    Slice<PostSearchResponse> findAllByKeywordAndCursorId(Long userId, String keyword, String cursor, int size);
 
     List<Post> findTrendPosts(int size, LocalDateTime now);
 

--- a/src/main/java/org/sopt/bofit/domain/post/repository/PostCustomRepositoryImpl.java
+++ b/src/main/java/org/sopt/bofit/domain/post/repository/PostCustomRepositoryImpl.java
@@ -11,6 +11,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.sopt.bofit.domain.comment.entity.QComment;
 import org.sopt.bofit.domain.commentreply.entity.QCommentReply;
+import org.sopt.bofit.domain.post.dto.response.PostSearchResponse;
 import org.sopt.bofit.domain.post.dto.response.PostSummaryResponse;
 import org.sopt.bofit.domain.post.entity.Post;
 import org.sopt.bofit.domain.post.entity.QPost;
@@ -144,25 +145,42 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
     }
 
     @Override
-    public Slice<PostSummaryResponse> findAllByKeywordAndCursorId(Long userId, String keyword, Long cursorId, int size) {
+    public Slice<PostSearchResponse> findAllByKeywordAndCursorId(Long userId, String keyword, String cursor, int size) {
         QPost post = QPost.post;
         QPostLike postLike = QPostLike.postLike;
 
         BooleanExpression likedByCurrentUser = getLikedByCurrentUser(userId, postLike, post);
 
         BooleanExpression searchCondition;
+
+        NumberExpression<Double> relevanceScore;
+
         if (keyword != null && keyword.length() < 2) {
+            relevanceScore = Expressions.asNumber(0.0);
             String likePattern = "%" + keyword + "%";
             searchCondition = post.title.like(likePattern)
                     .or(post.content.like(likePattern))
                     .or(post.writerNickname.like(likePattern));
         } else {
-            NumberExpression<Double> relevanceScore = getRelevanceScore(keyword, post);
+            relevanceScore = getRelevanceScore(keyword, post);
             searchCondition = relevanceScore.gt(0);
         }
 
-        List<PostSummaryResponse> content = queryFactory
-                .select(Projections.constructor(PostSummaryResponse.class,
+        PostSearchResponse.Cursor cursorObj = PostSearchResponse.decodeCursor(cursor);
+        BooleanExpression cursorCondition = null;
+        if (cursorObj != null) {
+            cursorCondition = relevanceScore.lt(cursorObj.relevance())
+                    .or(relevanceScore.eq(cursorObj.relevance())
+                            .and(post.id.lt(cursorObj.postId())));
+        }
+
+        List<OrderSpecifier<?>> orderSpecifiers = List.of(
+                relevanceScore.desc(),
+                post.createdAt.desc()
+        );
+
+        List<PostSearchResponse> content = queryFactory
+                .select(Projections.constructor(PostSearchResponse.class,
                         post.id,
                         post.user.id,
                         post.title,
@@ -172,16 +190,16 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
                         post.commentCount,
                         post.createdAt,
                         post.likeCount,
-                        likedByCurrentUser
+                        likedByCurrentUser,
+                        relevanceScore
                 ))
                 .from(post)
-                .where(searchCondition,
+                .where(
+                        searchCondition,
                         post.status.eq(PostStatus.ACTIVE),
-                        cursorId != null ? post.id.lt(cursorId) : null
+                        cursorCondition
                         )
-                .orderBy(keyword != null && keyword.length() > 1
-                        ? getRelevanceScore(keyword, post).desc()
-                        : post.id.desc())
+                .orderBy(orderSpecifiers.toArray(new OrderSpecifier[0]))
                 .limit(size + 1)
                 .fetch();
 

--- a/src/main/java/org/sopt/bofit/domain/post/service/PostReader.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/PostReader.java
@@ -1,10 +1,9 @@
 
 package org.sopt.bofit.domain.post.service;
 
-import static org.sopt.bofit.global.exception.constant.PostErrorCode.POST_NOT_FOUND;
-
 import lombok.RequiredArgsConstructor;
 import org.sopt.bofit.domain.comment.repository.CommentRepository;
+import org.sopt.bofit.domain.post.dto.response.PostSearchResponse;
 import org.sopt.bofit.domain.post.dto.response.PostSummaryResponse;
 import org.sopt.bofit.domain.post.entity.Post;
 import org.sopt.bofit.domain.post.entity.constant.PostCategoryFilter;
@@ -16,6 +15,8 @@ import org.sopt.bofit.global.dto.response.SliceResponse;
 import org.sopt.bofit.global.exception.customexception.NotFoundException;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
+
+import static org.sopt.bofit.global.exception.constant.PostErrorCode.POST_NOT_FOUND;
 
 @Service
 @RequiredArgsConstructor
@@ -44,8 +45,8 @@ public class PostReader {
             .orElseThrow(() -> new NotFoundException(POST_NOT_FOUND));
     }
 
-    public SliceResponse<PostSummaryResponse, Long> findPostsByKeywordAndCursorId(Long userId, String keyword, Long cursorId, int size) {
-        Slice<PostSummaryResponse> postList = postRepository.findAllByKeywordAndCursorId(userId, keyword, cursorId, size);
+    public SliceResponse<PostSearchResponse, String> findPostsByKeywordAndCursorId(Long userId, String keyword, String cursor, int size) {
+        Slice<PostSearchResponse> postList = postRepository.findAllByKeywordAndCursorId(userId, keyword, cursor, size);
 
         return SliceResponse.from(postList);
     }

--- a/src/main/java/org/sopt/bofit/domain/post/service/PostService.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/PostService.java
@@ -1,17 +1,7 @@
 package org.sopt.bofit.domain.post.service;
 
-import static org.sopt.bofit.global.exception.constant.PostErrorCode.POST_UNAUTHORIZED;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
-import org.sopt.bofit.domain.post.dto.response.PostCreateResponse;
-import org.sopt.bofit.domain.post.dto.response.PostDetailResponse;
-import org.sopt.bofit.domain.post.dto.response.PostSummaryResponse;
-import org.sopt.bofit.domain.post.dto.response.TrendingPostsResponses;
+import org.sopt.bofit.domain.post.dto.response.*;
 import org.sopt.bofit.domain.post.entity.Post;
 import org.sopt.bofit.domain.post.entity.PostImage;
 import org.sopt.bofit.domain.post.entity.TrendPost;
@@ -28,6 +18,14 @@ import org.sopt.bofit.global.file.dto.request.UpdateImageRequest;
 import org.sopt.bofit.global.file.util.ImageValidator;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.IntStream;
+
+import static org.sopt.bofit.global.exception.constant.PostErrorCode.POST_UNAUTHORIZED;
 
 @Service
 @RequiredArgsConstructor
@@ -111,8 +109,8 @@ public class PostService {
         return PostDetailResponse.of(post, writer, isLiked, allActiveImages);
     }
 
-    public SliceResponse<PostSummaryResponse, Long> searchPosts(Long userId, String keyword, Long cursorId, int size){
-        return postReader.findPostsByKeywordAndCursorId(userId, keyword, cursorId, size);
+    public SliceResponse<PostSearchResponse, String> searchPosts(Long userId, String keyword, String cursor, int size){
+        return postReader.findPostsByKeywordAndCursorId(userId, keyword, cursor, size);
     }
 
     @Transactional


### PR DESCRIPTION
## Related issue 🛠
- closed #194



## Work Description 📝
- 기존에 한 글자 검색 시와 두 글자 이상 검색 시에 사용하는 정렬 기준과 Cursor가 달라서 중복된 데이터가 반환되는 현상이 있었습니다. 이를 해결하기 위해 복합 Cursor를 사용하도록 수정했습니다.
- 기존에 사용하던 postId에 연관도 점수인 relevanceScore를 모두 고려하도록 커서를 수정했으며, 검색어가 한 글자인 경우에는 relevanceScore가 0으로 고정이고, 게시물 생성 시간 순대로 나열하도록 했고, 그 이외에는 연관도 순으로 정렬되게끔 구현했습니다. 연관도가 같다면, 게시물 생성 시간을 기준으로 비교합니다. 
- 따라서 기존에 사용하던 PostSummaryResponse 대신 새로 검색용 DTO인 PostSearchResponse를 만들었습니다. 
```
{
  "code": 200,
  "message": "게시물 검색 성공",
  "data": {
    "content": [
      {
        "postId": 39,
        "writerId": 15,
        "title": "아니",
        "content": "테스트테스트",
        "writerNickname": "김재",
        "profileImageUrl": "string",
        "commentCount": 0,
        "createdAt": "2025-09-20T16:29:50.947622",
        "likeCount": 0,
        "likedByCurrentUser": false,
        "relevanceScore": 3.493149518966675
      },
      {
        "postId": 43,
        "writerId": 15,
        "title": "아니",
        "content": "테스트테스",
        "writerNickname": "김재",
        "profileImageUrl": "string",
        "commentCount": 2,
        "createdAt": "2025-09-20T16:30:25.040358",
        "likeCount": 0,
        "likedByCurrentUser": false,
        "relevanceScore": 2.6198620796203613
      }
    ],
    "nextCursor": "2.6198620796203613,43",
    "isLast": false
  }
}
```
위와 같이 원래는 nextCursor로 postId만을 반환했다면 이제는 연관도와 함께 반환합니다.

