### PR TITLE
[Refactor] 보험 추천 리포트의 값 객체를 Dto 로 전달하도록 변경

### DIFF
--- a/src/main/java/org/sopt/bofit/domain/insurance/dto/response/BasicInformationResponse.java
+++ b/src/main/java/org/sopt/bofit/domain/insurance/dto/response/BasicInformationResponse.java
@@ -1,0 +1,64 @@
+package org.sopt.bofit.domain.insurance.dto.response;
+
+import lombok.Builder;
+import org.sopt.bofit.domain.insurance.dto.response.option.PaymentPeriodResponse;
+import org.sopt.bofit.domain.insurance.dto.response.option.RefundTypeResponse;
+import org.sopt.bofit.domain.insurance.dto.response.option.RenewableTypeResponse;
+import org.sopt.bofit.domain.insurance.entity.product.BasicInformation;
+import org.sopt.bofit.domain.insurance.entity.product.constant.MaturityAge;
+import org.sopt.bofit.domain.insurance.entity.product.constant.PaymentPeriod;
+import org.sopt.bofit.domain.insurance.entity.product.constant.RefundType;
+import org.sopt.bofit.domain.insurance.entity.product.constant.RenewableType;
+
+/**
+ * @param maturityAge 다른 선택 항목들과 동일하게 MaturityAgeResponse 를 사용하고 싶었지만, 새롭게 만기 나이를 선택할 수 있도록
+ *                    Enum 으로 변경되면서 기존에 사용하던 응답값을 그대로 사용해야하는 클라이언트들의 리소스가 늘어난다고 판단하여
+ *                    MaturityAge Enum을 도입하기 이전과 동일한 형태로 int 값을 리턴하고 있음.
+ */
+public record BasicInformationResponse (
+    String name,
+    String company,
+    String productType,
+    int minEnrollmentAge,
+    int maxEnrollmentAge,
+    int premium,
+    int maturityAge,
+    PaymentPeriodResponse paymentPeriod,
+    RenewableTypeResponse renewableType,
+    RefundTypeResponse refundType
+){
+
+    public static BasicInformationResponse from(BasicInformation basicInformation) {
+        return BasicInformationResponse.builder()
+            .name(basicInformation.getName())
+            .company(basicInformation.getCompany())
+            .productType(basicInformation.getProductType())
+            .minEnrollmentAge(basicInformation.getMinEnrollmentAge())
+            .maxEnrollmentAge(basicInformation.getMaxEnrollmentAge())
+            .premium(basicInformation.getPremium())
+            .maturityAge(basicInformation.getMaturityAge())
+            .paymentPeriod(basicInformation.getPaymentPeriod())
+            .renewableType(basicInformation.getRenewableType())
+            .refundType(basicInformation.getRefundType())
+            .build();
+    }
+
+    @Builder
+    private BasicInformationResponse(String name, String company, String productType,
+        int minEnrollmentAge, int maxEnrollmentAge, int premium,
+        MaturityAge maturityAge, PaymentPeriod paymentPeriod, RenewableType renewableType, RefundType refundType
+    ) {
+        this(
+            name,
+            company,
+            productType,
+            minEnrollmentAge,
+            maxEnrollmentAge,
+            premium,
+            maturityAge.getAge(),
+            PaymentPeriodResponse.from(paymentPeriod),
+            RenewableTypeResponse.from(renewableType),
+            RefundTypeResponse.from(refundType)
+        );
+    }
+}

--- a/src/main/java/org/sopt/bofit/domain/insurance/dto/response/option/InsuranceOptionsResponse.java
+++ b/src/main/java/org/sopt/bofit/domain/insurance/dto/response/option/InsuranceOptionsResponse.java
@@ -1,4 +1,4 @@
-package org.sopt.bofit.domain.insurance.dto.response;
+package org.sopt.bofit.domain.insurance.dto.response.option;
 
 import java.util.List;
 

--- a/src/main/java/org/sopt/bofit/domain/insurance/dto/response/option/MaturityAgeResponse.java
+++ b/src/main/java/org/sopt/bofit/domain/insurance/dto/response/option/MaturityAgeResponse.java
@@ -1,4 +1,4 @@
-package org.sopt.bofit.domain.insurance.dto.response;
+package org.sopt.bofit.domain.insurance.dto.response.option;
 
 import org.sopt.bofit.domain.insurance.entity.product.constant.MaturityAge;
 
@@ -7,7 +7,7 @@ public record MaturityAgeResponse(
     String displayName
 ) {
 
-    public static MaturityAgeResponse create(MaturityAge maturityAge){
+    public static MaturityAgeResponse from(MaturityAge maturityAge){
         return new MaturityAgeResponse(maturityAge, maturityAge.getDisplayName());
     }
 

--- a/src/main/java/org/sopt/bofit/domain/insurance/dto/response/option/PaymentPeriodResponse.java
+++ b/src/main/java/org/sopt/bofit/domain/insurance/dto/response/option/PaymentPeriodResponse.java
@@ -1,4 +1,4 @@
-package org.sopt.bofit.domain.insurance.dto.response;
+package org.sopt.bofit.domain.insurance.dto.response.option;
 
 import org.sopt.bofit.domain.insurance.entity.product.constant.PaymentPeriod;
 
@@ -7,7 +7,7 @@ public record PaymentPeriodResponse(
     String displayName
 ) {
 
-    public static PaymentPeriodResponse create(PaymentPeriod paymentPeriod){
+    public static PaymentPeriodResponse from(PaymentPeriod paymentPeriod){
         return new PaymentPeriodResponse(paymentPeriod, paymentPeriod.getDisplayName());
     }
 

--- a/src/main/java/org/sopt/bofit/domain/insurance/dto/response/option/RefundTypeResponse.java
+++ b/src/main/java/org/sopt/bofit/domain/insurance/dto/response/option/RefundTypeResponse.java
@@ -1,4 +1,4 @@
-package org.sopt.bofit.domain.insurance.dto.response;
+package org.sopt.bofit.domain.insurance.dto.response.option;
 
 import org.sopt.bofit.domain.insurance.entity.product.constant.RefundType;
 
@@ -7,7 +7,7 @@ public record RefundTypeResponse(
     String displayName
 ) {
 
-    public static RefundTypeResponse create(RefundType refundType) {
+    public static RefundTypeResponse from(RefundType refundType) {
         return new RefundTypeResponse(refundType, refundType.getDisplayName());
     }
 

--- a/src/main/java/org/sopt/bofit/domain/insurance/dto/response/option/RenewableTypeResponse.java
+++ b/src/main/java/org/sopt/bofit/domain/insurance/dto/response/option/RenewableTypeResponse.java
@@ -1,4 +1,4 @@
-package org.sopt.bofit.domain.insurance.dto.response;
+package org.sopt.bofit.domain.insurance.dto.response.option;
 
 import org.sopt.bofit.domain.insurance.entity.product.constant.RenewableType;
 
@@ -7,7 +7,7 @@ public record RenewableTypeResponse(
     String displayName
 ) {
 
-    public static RenewableTypeResponse create(RenewableType renewableType){
+    public static RenewableTypeResponse from(RenewableType renewableType){
         return new RenewableTypeResponse(renewableType, renewableType.getDisplayName());
     }
 

--- a/src/main/java/org/sopt/bofit/domain/insurance/entity/product/constant/MaturityAge.java
+++ b/src/main/java/org/sopt/bofit/domain/insurance/entity/product/constant/MaturityAge.java
@@ -1,6 +1,5 @@
 package org.sopt.bofit.domain.insurance.entity.product.constant;
 
-import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.Arrays;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -15,7 +14,6 @@ public enum MaturityAge {
     OLD_100(100, "100세")
     ;
 
-    @JsonValue
     private final int age;
     private final String displayName;
 

--- a/src/main/java/org/sopt/bofit/domain/insurance/entity/product/constant/PaymentPeriod.java
+++ b/src/main/java/org/sopt/bofit/domain/insurance/entity/product/constant/PaymentPeriod.java
@@ -1,6 +1,5 @@
 package org.sopt.bofit.domain.insurance.entity.product.constant;
 
-import com.fasterxml.jackson.annotation.JsonValue;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -13,7 +12,6 @@ public enum PaymentPeriod {
     YEAR_30(30, "30년")
     ;
 
-    @JsonValue
     private final int year;
     private final String displayName;
 

--- a/src/main/java/org/sopt/bofit/domain/insurance/service/InsuranceService.java
+++ b/src/main/java/org/sopt/bofit/domain/insurance/service/InsuranceService.java
@@ -2,11 +2,11 @@ package org.sopt.bofit.domain.insurance.service;
 
 import java.util.Arrays;
 import lombok.RequiredArgsConstructor;
-import org.sopt.bofit.domain.insurance.dto.response.InsuranceOptionsResponse;
-import org.sopt.bofit.domain.insurance.dto.response.MaturityAgeResponse;
-import org.sopt.bofit.domain.insurance.dto.response.PaymentPeriodResponse;
-import org.sopt.bofit.domain.insurance.dto.response.RefundTypeResponse;
-import org.sopt.bofit.domain.insurance.dto.response.RenewableTypeResponse;
+import org.sopt.bofit.domain.insurance.dto.response.option.InsuranceOptionsResponse;
+import org.sopt.bofit.domain.insurance.dto.response.option.MaturityAgeResponse;
+import org.sopt.bofit.domain.insurance.dto.response.option.PaymentPeriodResponse;
+import org.sopt.bofit.domain.insurance.dto.response.option.RefundTypeResponse;
+import org.sopt.bofit.domain.insurance.dto.response.option.RenewableTypeResponse;
 import org.sopt.bofit.domain.insurance.entity.product.constant.MaturityAge;
 import org.sopt.bofit.domain.insurance.entity.product.constant.PaymentPeriod;
 import org.sopt.bofit.domain.insurance.entity.product.constant.RefundType;
@@ -19,10 +19,10 @@ public class InsuranceService {
 
     public InsuranceOptionsResponse getOptionInfos(){
         return new InsuranceOptionsResponse(
-            Arrays.stream(RenewableType.values()).map(RenewableTypeResponse::create).toList(),
-            Arrays.stream(RefundType.values()).map(RefundTypeResponse::create).toList(),
-            Arrays.stream(PaymentPeriod.values()).map(PaymentPeriodResponse::create).toList(),
-            Arrays.stream(MaturityAge.values()).map(MaturityAgeResponse::create).toList()
+            Arrays.stream(RenewableType.values()).map(RenewableTypeResponse::from).toList(),
+            Arrays.stream(RefundType.values()).map(RefundTypeResponse::from).toList(),
+            Arrays.stream(PaymentPeriod.values()).map(PaymentPeriodResponse::from).toList(),
+            Arrays.stream(MaturityAge.values()).map(MaturityAgeResponse::from).toList()
         );
     }
 

--- a/src/main/java/org/sopt/bofit/domain/insurancereport/dto/response/InsuranceReportResponse.java
+++ b/src/main/java/org/sopt/bofit/domain/insurancereport/dto/response/InsuranceReportResponse.java
@@ -1,26 +1,21 @@
 package org.sopt.bofit.domain.insurancereport.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import java.util.List;
 import java.util.UUID;
-
-import org.sopt.bofit.domain.insurance.entity.benefit.Cancer;
-import org.sopt.bofit.domain.insurance.entity.product.BasicInformation;
+import lombok.Builder;
+import org.sopt.bofit.domain.insurance.dto.response.BasicInformationResponse;
 import org.sopt.bofit.domain.insurancereport.constant.AdditionalInfo;
 import org.sopt.bofit.domain.insurancereport.entity.Disease;
 import org.sopt.bofit.domain.insurancereport.entity.InsuranceReport;
-import org.sopt.bofit.domain.insurancereport.entity.ReportRationale;
-
-import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-
-import lombok.Builder;
 
 @Builder
 @JsonPropertyOrder({"reportId", "reportInformation", "reportRationale",
 	"majorDisease", "surgery", "hospitalization", "disability", "death", "externalUri"})
 public record InsuranceReportResponse (
 	UUID reportId,
-	BasicInformation reportInformation,
-	ReportRationale reportRationale,
+	BasicInformationResponse reportInformation,
+	ReportRationaleResponse reportRationale,
 	SectionData majorDisease,
 	SectionData surgery,
 	SectionData hospitalization,
@@ -32,8 +27,8 @@ public record InsuranceReportResponse (
 	public static InsuranceReportResponse from(InsuranceReport report){
 		return InsuranceReportResponse.builder()
 			.reportId(report.getId())
-			.reportInformation(report.getProduct().getBasicInformation())
-			.reportRationale(report.getReportRationale())
+			.reportInformation(BasicInformationResponse.from(report.getProduct().getBasicInformation()))
+			.reportRationale(ReportRationaleResponse.from(report.getReportRationale()))
 			.majorDisease(SectionData.majorDisease(report))
 			.surgery(SectionData.surgery(report))
 			.hospitalization(SectionData.hospitalization(report))

--- a/src/main/java/org/sopt/bofit/domain/insurancereport/dto/response/ReportRationaleResponse.java
+++ b/src/main/java/org/sopt/bofit/domain/insurancereport/dto/response/ReportRationaleResponse.java
@@ -1,0 +1,15 @@
+package org.sopt.bofit.domain.insurancereport.dto.response;
+
+import java.util.List;
+import org.sopt.bofit.domain.insurancereport.entity.ReportRationale;
+
+public record ReportRationaleResponse(
+    List<String> reasons,
+    List<String> keywordChips
+) {
+
+    public static ReportRationaleResponse from(ReportRationale reportRationale){
+        return new ReportRationaleResponse(reportRationale.getReasons(), reportRationale.getKeywordChips());
+    }
+
+}

--- a/src/main/java/org/sopt/bofit/domain/user/controller/UserInfoController.java
+++ b/src/main/java/org/sopt/bofit/domain/user/controller/UserInfoController.java
@@ -6,7 +6,7 @@ import static org.sopt.bofit.global.constant.SwaggerConstant.TAG_NAME_USER_INFO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.sopt.bofit.domain.insurance.dto.response.InsuranceOptionsResponse;
+import org.sopt.bofit.domain.insurance.dto.response.option.InsuranceOptionsResponse;
 import org.sopt.bofit.domain.insurance.service.InsuranceService;
 import org.sopt.bofit.domain.user.dto.response.CoveragePreferenceResponses;
 import org.sopt.bofit.domain.user.dto.response.DiagnosedDiseaseResponses;


### PR DESCRIPTION
## Related issue 🛠
- closed #206
  


## Work Description 📝
- 값 객체를 반환값으로 사용하던 부분을 wrapping 하여 응답값 타입 등을 세밀하게 컨트롤하고자 함.
  - BasicInformaion
  - rationale
- 주석으로도 작성했지만, 현재 BasicInformationResponse 에서 선택 항목 중 maturityAge 만 Response가 아니라 정수형으로 변환해서 반환하고 있음. 다른 선택 항목들과 동일하게 MaturityAgeResponse 를 사용하고 싶었지만, 새롭게 만기 나이를 선택할 수 있도록 Enum 으로 변경되면서 기존에 사용하던 응답값을 그대로 사용해야하는 클라이언트들의 리소스가 늘어난다고 판단하여 MaturityAge Enum을 도입하기 이전과 동일한 형태로 int 값을 리턴하고 있음.
## Uncompleted Tasks 😅

## To Reviewers 📢
