### PR TITLE
[Feat] Image의 Sequence 가 0부터 시작하도록 변경

### DIFF
--- a/src/main/java/org/sopt/bofit/domain/comment/service/CommentService.java
+++ b/src/main/java/org/sopt/bofit/domain/comment/service/CommentService.java
@@ -58,7 +58,7 @@ public class CommentService {
 
         IntStream.range(0, command.imageUrls().size())
                 .forEach(sequence -> commentImageWriter
-                    .create(comment, command.imageUrls().get(sequence), sequence + 1));
+                    .create(comment, command.imageUrls().get(sequence), sequence));
 
 		postWriter.increaseCommentCount(post);
         postCacheService.increaseCommentCount(postId);

--- a/src/main/java/org/sopt/bofit/domain/commentreply/service/CommentReplyService.java
+++ b/src/main/java/org/sopt/bofit/domain/commentreply/service/CommentReplyService.java
@@ -60,7 +60,7 @@ public class CommentReplyService {
         CommentReply commentReply = commentReplyWriter.create(comment, user, command.content());
         IntStream.range(0, command.imageUrls().size())
                 .forEach(sequence ->
-                    commentReplyImageWriter.create(commentReply, command.imageUrls().get(sequence), sequence+ 1));
+                    commentReplyImageWriter.create(commentReply, command.imageUrls().get(sequence), sequence));
         commentWriter.increaseReplyCount(comment);
         postWriter.increaseTrendScore(post);
         return commentReply;

--- a/src/main/java/org/sopt/bofit/domain/post/service/PostService.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/PostService.java
@@ -1,7 +1,18 @@
 package org.sopt.bofit.domain.post.service;
 
+import static org.sopt.bofit.global.exception.constant.PostErrorCode.POST_UNAUTHORIZED;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
-import org.sopt.bofit.domain.post.dto.response.*;
+import org.sopt.bofit.domain.post.dto.response.PostCreateResponse;
+import org.sopt.bofit.domain.post.dto.response.PostDetailResponse;
+import org.sopt.bofit.domain.post.dto.response.PostSearchResponse;
+import org.sopt.bofit.domain.post.dto.response.PostSummaryResponse;
+import org.sopt.bofit.domain.post.dto.response.TrendingPostsResponses;
 import org.sopt.bofit.domain.post.entity.Post;
 import org.sopt.bofit.domain.post.entity.PostImage;
 import org.sopt.bofit.domain.post.entity.TrendPost;
@@ -18,14 +29,6 @@ import org.sopt.bofit.global.file.dto.request.UpdateImageRequest;
 import org.sopt.bofit.global.file.util.ImageValidator;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.IntStream;
-
-import static org.sopt.bofit.global.exception.constant.PostErrorCode.POST_UNAUTHORIZED;
 
 @Service
 @RequiredArgsConstructor
@@ -54,7 +57,7 @@ public class PostService {
 
         IntStream.range(0, command.imageUrls().size())
                 .forEach(sequence -> postImageWriter
-                        .create(post, command.imageUrls().get(sequence), sequence + 1));
+                        .create(post, command.imageUrls().get(sequence), sequence));
 
         return PostCreateResponse.from(post.getId());
     }

--- a/src/main/java/org/sopt/bofit/global/file/dto/request/NewImageRequest.java
+++ b/src/main/java/org/sopt/bofit/global/file/dto/request/NewImageRequest.java
@@ -4,7 +4,7 @@ import static org.sopt.bofit.global.file.constant.ImageConstant.MAX_IMAGE_URL_LE
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
 import org.hibernate.validator.constraints.Length;
 
 public record NewImageRequest(
@@ -14,7 +14,7 @@ public record NewImageRequest(
         String imageUrl,
 
         @Schema(description = "순서 (null이면 맨 뒤에 추가, 1부터 시작)", example = "3")
-        @Positive
+        @PositiveOrZero
         Integer sequence
 ) {
 }

--- a/src/main/java/org/sopt/bofit/global/file/dto/request/UpdateImageRequest.java
+++ b/src/main/java/org/sopt/bofit/global/file/dto/request/UpdateImageRequest.java
@@ -3,7 +3,7 @@ package org.sopt.bofit.global.file.dto.request;
 import static org.sopt.bofit.global.file.constant.ImageConstant.MAX_IMAGE_URL_LENGTH;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
 import org.hibernate.validator.constraints.Length;
 
 public record UpdateImageRequest(
@@ -14,8 +14,8 @@ public record UpdateImageRequest(
         @Schema(description = "새 이미지 URL (변경 없으면 null)")
         String imageUrl,
 
-        @Schema(description = "순서, 1부터 시작")
-        @Positive
+        @Schema(description = "순서, 0부터 시작")
+        @PositiveOrZero
         Integer sequence
 ) {
 }


### PR DESCRIPTION
## Related issue 🛠
- closed #208
  


## Work Description 📝
- Image의 Sequence 가 0부터 시작하도록 변경
- ImageUpdate 시 Sequence를 0 초과에서 0 이상으로 받도록 변경
## Uncompleted Tasks 😅

## To Reviewers 📢
- 지금 작업하면서 보니까 sequence 순서가 중복으로 들어오거나 건너뛰고 들어오는 등의 요청에 대한 방어 로직이 없어서 이 부분 추후 추가가 필요해보입니다~
