### PR TITLE
[Refactor] S3 + CloudFront 연동에 따른 API 스펙 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,8 @@ repositories {
 
 ext {
 	resilience4jVersion = '2.2.0'
+	awsSdkVersion = '2.29.52'
+	awspringVersion = '3.2.1'
 }
 
 dependencies {
@@ -93,10 +95,15 @@ dependencies {
 	implementation 'com.github.ben-manes.caffeine:caffeine:3.1.8'
 
 	//AWS TODO 버전 맞추기
-	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
-	implementation 'software.amazon.awssdk:s3:2.25.66'
-	implementation 'software.amazon.awssdk:auth:2.25.66'
-	implementation 'software.amazon.awssdk:regions:2.25.66'
+	implementation platform("software.amazon.awssdk:bom:${awsSdkVersion}")
+	implementation "software.amazon.awssdk:s3"
+	implementation "software.amazon.awssdk:sqs"
+	implementation "software.amazon.awssdk:auth"
+	implementation "software.amazon.awssdk:regions"
+
+	implementation 'com.amazonaws:aws-java-sdk-s3:1.12.767'
+	implementation "io.awspring.cloud:spring-cloud-aws-starter-sqs:${awspringVersion}"
+	implementation "io.awspring.cloud:spring-cloud-aws-starter:${awspringVersion}"
 	implementation group: 'com.amazonaws', name: 'aws-lambda-java-core', version: '1.2.1'
 	implementation group: 'com.amazonaws', name: 'aws-lambda-java-events', version: '3.7.0'
     // Spring Cloud AWS SQS Starter

--- a/src/main/java/org/sopt/bofit/domain/comment/dto/request/CommentCreateRequest.java
+++ b/src/main/java/org/sopt/bofit/domain/comment/dto/request/CommentCreateRequest.java
@@ -1,17 +1,18 @@
 package org.sopt.bofit.domain.comment.dto.request;
 
-import static org.sopt.bofit.domain.comment.constant.CommentConstant.COMMENT_CONTENT_MAX_SIZE;
-import static org.sopt.bofit.domain.comment.constant.CommentConstant.MAX_IMAGE_COUNT;
-import static org.sopt.bofit.global.file.constant.ImageConstant.MAX_IMAGE_URL_LENGTH;
-
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
-import java.util.List;
 import org.hibernate.validator.constraints.Length;
 import org.sopt.bofit.domain.comment.service.dto.request.CommentCreateCommand;
+
+import java.util.List;
+
+import static org.sopt.bofit.domain.comment.constant.CommentConstant.COMMENT_CONTENT_MAX_SIZE;
+import static org.sopt.bofit.domain.comment.constant.CommentConstant.MAX_IMAGE_COUNT;
+import static org.sopt.bofit.global.file.constant.ImageConstant.MAX_IMAGE_URL_LENGTH;
 
 public record CommentCreateRequest (
 	@Schema(description = "댓글 내용", example = "좋은 글이네요")
@@ -19,13 +20,13 @@ public record CommentCreateRequest (
 	@Length(max = COMMENT_CONTENT_MAX_SIZE, message = "content 의 최대 길이인 {max}을 초과했습니다.")
 	String content,
 
-	@Schema(description = "이미지 url 목록. url 이 존재하지 않는 경우에도 빈 리스트를 요구")
+	@Schema(description = "이미지 key 목록. key가 존재하지 않는 경우에도 빈 리스트를 요구")
 	@Size(max = MAX_IMAGE_COUNT, message = "이미지 url 의 최대 개수({max}) 를 초과했습니다.")
-	@NotNull(message = "url 목록은 비어있을 수 없습니다.")
+	@NotNull(message = "key 목록은 비어있을 수 없습니다.")
 	@Valid
-	List<@Length(max = MAX_IMAGE_URL_LENGTH, message = "이미지 url 의 최대 길이({max}) 를 초과했습니다.") String> imageUrls
+	List<@Length(max = MAX_IMAGE_URL_LENGTH, message = "이미지 url 의 최대 길이({max}) 를 초과했습니다.") String> imageKeys
 ) {
 	public CommentCreateCommand toCommand(){
-		return new CommentCreateCommand(this.content, this.imageUrls);
+		return new CommentCreateCommand(this.content, this.imageKeys);
 	}
 }

--- a/src/main/java/org/sopt/bofit/domain/comment/service/CommentImageWriter.java
+++ b/src/main/java/org/sopt/bofit/domain/comment/service/CommentImageWriter.java
@@ -33,7 +33,7 @@ public class CommentImageWriter {
     ){
         updatedImages.forEach(image -> {
                 if(image.id() == null){
-                    create(comment, image.imageUrl(), image.sequence());
+                    create(comment, image.imageKey(), image.sequence());
                 }else {
                     currentImages.get(image.id()).updateSequence(image.sequence());
                 }

--- a/src/main/java/org/sopt/bofit/domain/comment/service/CommentImageWriter.java
+++ b/src/main/java/org/sopt/bofit/domain/comment/service/CommentImageWriter.java
@@ -1,23 +1,27 @@
 package org.sopt.bofit.domain.comment.service;
 
 import jakarta.transaction.Transactional;
-import java.util.List;
-import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.sopt.bofit.domain.comment.entity.Comment;
 import org.sopt.bofit.domain.comment.entity.CommentImage;
 import org.sopt.bofit.domain.comment.entity.CommentImageStatus;
 import org.sopt.bofit.domain.comment.repository.CommentImageRepository;
 import org.sopt.bofit.global.file.dto.request.UpdateImageRequest;
+import org.sopt.bofit.global.file.util.CloudFrontUrlCreator;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
 public class CommentImageWriter {
     private final CommentImageRepository commentImageRepository;
+    private final CloudFrontUrlCreator cloudFrontUrlCreator;
 
-    public CommentImage create(Comment comment, String url, Integer sequence){
-        CommentImage commentImage = CommentImage.create(comment, url, sequence);
+    public CommentImage create(Comment comment, String imageKey, Integer sequence){
+        String cloudFrontUrl = cloudFrontUrlCreator.createCloudFrontUrl(imageKey);
+        CommentImage commentImage = CommentImage.create(comment, cloudFrontUrl, sequence);
         return commentImageRepository.save(commentImage);
     }
 

--- a/src/main/java/org/sopt/bofit/domain/comment/service/CommentService.java
+++ b/src/main/java/org/sopt/bofit/domain/comment/service/CommentService.java
@@ -1,13 +1,5 @@
 package org.sopt.bofit.domain.comment.service;
 
-import static org.sopt.bofit.domain.comment.constant.CommentConstant.MAX_IMAGE_COUNT;
-import static org.sopt.bofit.global.exception.constant.CommentErrorCode.COMMENT_UNAUTHORIZED;
-
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
 import org.sopt.bofit.domain.comment.dto.response.CommentWithImagesResponse;
 import org.sopt.bofit.domain.comment.entity.Comment;
@@ -29,6 +21,15 @@ import org.sopt.bofit.global.file.util.ImageValidator;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.IntStream;
+
+import static org.sopt.bofit.domain.comment.constant.CommentConstant.MAX_IMAGE_COUNT;
+import static org.sopt.bofit.global.exception.constant.CommentErrorCode.COMMENT_UNAUTHORIZED;
 
 @Service
 @RequiredArgsConstructor
@@ -56,9 +57,9 @@ public class CommentService {
 
 		Comment comment = commentWriter.create(post, user, command.content());
 
-        IntStream.range(0, command.imageUrls().size())
+        IntStream.range(0, command.imageKeys().size())
                 .forEach(sequence -> commentImageWriter
-                    .create(comment, command.imageUrls().get(sequence), sequence));
+                    .create(comment, command.imageKeys().get(sequence), sequence));
 
 		postWriter.increaseCommentCount(post);
         postCacheService.increaseCommentCount(postId);

--- a/src/main/java/org/sopt/bofit/domain/comment/service/dto/request/CommentCreateCommand.java
+++ b/src/main/java/org/sopt/bofit/domain/comment/service/dto/request/CommentCreateCommand.java
@@ -4,6 +4,6 @@ import java.util.List;
 
 public record CommentCreateCommand(
     String content,
-    List<String> imageUrls
+    List<String> imageKeys
 ) {
 }

--- a/src/main/java/org/sopt/bofit/domain/commentreply/dto/request/CommentReplyCreateRequest.java
+++ b/src/main/java/org/sopt/bofit/domain/commentreply/dto/request/CommentReplyCreateRequest.java
@@ -1,17 +1,18 @@
 package org.sopt.bofit.domain.commentreply.dto.request;
 
-import static org.sopt.bofit.domain.commentreply.constant.CommentReplyConstant.MAX_CONTENT_LENGTH;
-import static org.sopt.bofit.domain.commentreply.constant.CommentReplyConstant.MAX_IMAGE_COUNT;
-import static org.sopt.bofit.global.file.constant.ImageConstant.MAX_IMAGE_URL_LENGTH;
-
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
-import java.util.List;
 import org.hibernate.validator.constraints.Length;
 import org.sopt.bofit.domain.commentreply.service.dto.request.CommentReplyCreateCommand;
+
+import java.util.List;
+
+import static org.sopt.bofit.domain.commentreply.constant.CommentReplyConstant.MAX_CONTENT_LENGTH;
+import static org.sopt.bofit.domain.commentreply.constant.CommentReplyConstant.MAX_IMAGE_COUNT;
+import static org.sopt.bofit.global.file.constant.ImageConstant.MAX_IMAGE_URL_LENGTH;
 
 public record CommentReplyCreateRequest(
     @Schema(description = "본문", example = "대댓글 작성하기 ~")
@@ -23,10 +24,10 @@ public record CommentReplyCreateRequest(
     @Size(max = MAX_IMAGE_COUNT, message = "이미지 url 의 최대 개수({max}) 를 초과했습니다.")
     @NotNull(message = "url 목록은 비어있을 수 없습니다.")
     @Valid
-    List<@Length(max = MAX_IMAGE_URL_LENGTH, message = "이미지 url 의 최대 길이({max}) 를 초과했습니다.") String> imageUrls
+    List<@Length(max = MAX_IMAGE_URL_LENGTH, message = "이미지 url 의 최대 길이({max}) 를 초과했습니다.") String> imageKeys
 ){
     public CommentReplyCreateCommand toCommand(){
-        return new CommentReplyCreateCommand(this.content, this.imageUrls);
+        return new CommentReplyCreateCommand(this.content, this.imageKeys);
     }
 
 }

--- a/src/main/java/org/sopt/bofit/domain/commentreply/service/CommentReplyImageWriter.java
+++ b/src/main/java/org/sopt/bofit/domain/commentreply/service/CommentReplyImageWriter.java
@@ -1,23 +1,27 @@
 package org.sopt.bofit.domain.commentreply.service;
 
 import jakarta.transaction.Transactional;
-import java.util.List;
-import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.sopt.bofit.domain.commentreply.entity.CommentReply;
 import org.sopt.bofit.domain.commentreply.entity.CommentReplyImage;
 import org.sopt.bofit.domain.commentreply.entity.CommentReplyImageStatus;
 import org.sopt.bofit.domain.commentreply.repository.CommentReplyImageRepository;
 import org.sopt.bofit.global.file.dto.request.UpdateImageRequest;
+import org.sopt.bofit.global.file.util.CloudFrontUrlCreator;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
 public class CommentReplyImageWriter {
     private final CommentReplyImageRepository commentReplyImageRepository;
+    private final CloudFrontUrlCreator cloudFrontUrlCreator;
 
-    public CommentReplyImage create(CommentReply commentReply, String imageUrl, Integer sequence){
-        CommentReplyImage commentReplyImage = CommentReplyImage.create(commentReply, imageUrl, sequence);
+    public CommentReplyImage create(CommentReply commentReply, String imageKey, Integer sequence){
+        String cloudFrontUrl = cloudFrontUrlCreator.createCloudFrontUrl(imageKey);
+        CommentReplyImage commentReplyImage = CommentReplyImage.create(commentReply, cloudFrontUrl, sequence);
         return commentReplyImageRepository.save(commentReplyImage);
     }
 
@@ -36,7 +40,7 @@ public class CommentReplyImageWriter {
     ){
         updatedImages.forEach(image -> {
             if(image.id() == null){
-                create(commentReply, image.imageUrl(), image.sequence());
+                create(commentReply, image.imageKey(), image.sequence());
             }else {
                 currentImages.get(image.id()).updateSequence(image.sequence());
             }

--- a/src/main/java/org/sopt/bofit/domain/commentreply/service/CommentReplyService.java
+++ b/src/main/java/org/sopt/bofit/domain/commentreply/service/CommentReplyService.java
@@ -58,9 +58,9 @@ public class CommentReplyService {
         comment.checkPost(post);
 
         CommentReply commentReply = commentReplyWriter.create(comment, user, command.content());
-        IntStream.range(0, command.imageUrls().size())
+        IntStream.range(0, command.imageKeys().size())
                 .forEach(sequence ->
-                    commentReplyImageWriter.create(commentReply, command.imageUrls().get(sequence), sequence));
+                    commentReplyImageWriter.create(commentReply, command.imageKeys().get(sequence), sequence));
         commentWriter.increaseReplyCount(comment);
         postWriter.increaseTrendScore(post);
         return commentReply;

--- a/src/main/java/org/sopt/bofit/domain/commentreply/service/dto/request/CommentReplyCreateCommand.java
+++ b/src/main/java/org/sopt/bofit/domain/commentreply/service/dto/request/CommentReplyCreateCommand.java
@@ -4,7 +4,7 @@ import java.util.List;
 
 public record CommentReplyCreateCommand(
     String content,
-    List<String> imageUrls
+    List<String> imageKeys
 ) {
 
 }

--- a/src/main/java/org/sopt/bofit/domain/post/dto/request/PostCreateRequest.java
+++ b/src/main/java/org/sopt/bofit/domain/post/dto/request/PostCreateRequest.java
@@ -25,10 +25,10 @@ public record PostCreateRequest(
         @ValidPostCategory
         String category,
 
-        @Schema(description = "이미지 url")
-        List<String> imageUrls
+        @Schema(description = "이미지 url key 값")
+        List<String> imageKeys
 ) {
     public PostCreateCommand toCommand() {
-        return new PostCreateCommand(title, content, category, imageUrls);
+        return new PostCreateCommand(title, content, category, imageKeys);
     }
 }

--- a/src/main/java/org/sopt/bofit/domain/post/service/PostImageWriter.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/PostImageWriter.java
@@ -1,14 +1,15 @@
 package org.sopt.bofit.domain.post.service;
 
 import jakarta.transaction.Transactional;
-import java.util.List;
-import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.sopt.bofit.domain.post.entity.Post;
 import org.sopt.bofit.domain.post.entity.PostImage;
 import org.sopt.bofit.domain.post.repository.PostImageRepository;
 import org.sopt.bofit.global.file.dto.request.UpdateImageRequest;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/org/sopt/bofit/domain/post/service/PostImageWriter.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/PostImageWriter.java
@@ -34,7 +34,7 @@ public class PostImageWriter {
     ){
         updatedImages.forEach(image -> {
             if(image.id() == null){
-                create(post, image.imageUrl(), image.sequence());
+                create(post, image.imageKey(), image.sequence());
             } else {
                 currentImages.get(image.id()).updateSequence(image.sequence());
             }

--- a/src/main/java/org/sopt/bofit/domain/post/service/PostImageWriter.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/PostImageWriter.java
@@ -6,6 +6,7 @@ import org.sopt.bofit.domain.post.entity.Post;
 import org.sopt.bofit.domain.post.entity.PostImage;
 import org.sopt.bofit.domain.post.repository.PostImageRepository;
 import org.sopt.bofit.global.file.dto.request.UpdateImageRequest;
+import org.sopt.bofit.global.file.util.CloudFrontUrlCreator;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -17,9 +18,11 @@ public class PostImageWriter {
 
     private final PostImageReader postImageReader;
     private final PostImageRepository postImageRepository;
+    private final CloudFrontUrlCreator cloudFrontUrlCreator;
 
-    public PostImage create(Post post, String url, Integer sequence) {
-        PostImage postImage = PostImage.create(url, post, sequence);
+    public PostImage create(Post post, String imageKey, Integer sequence) {
+        String cloudFrontUrl = cloudFrontUrlCreator.createCloudFrontUrl(imageKey);
+        PostImage postImage = PostImage.create(cloudFrontUrl, post, sequence);
         return postImageRepository.save(postImage);
     }
 

--- a/src/main/java/org/sopt/bofit/domain/post/service/PostService.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/PostService.java
@@ -1,18 +1,7 @@
 package org.sopt.bofit.domain.post.service;
 
-import static org.sopt.bofit.global.exception.constant.PostErrorCode.POST_UNAUTHORIZED;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
-import org.sopt.bofit.domain.post.dto.response.PostCreateResponse;
-import org.sopt.bofit.domain.post.dto.response.PostDetailResponse;
-import org.sopt.bofit.domain.post.dto.response.PostSearchResponse;
-import org.sopt.bofit.domain.post.dto.response.PostSummaryResponse;
-import org.sopt.bofit.domain.post.dto.response.TrendingPostsResponses;
+import org.sopt.bofit.domain.post.dto.response.*;
 import org.sopt.bofit.domain.post.entity.Post;
 import org.sopt.bofit.domain.post.entity.PostImage;
 import org.sopt.bofit.domain.post.entity.TrendPost;
@@ -29,6 +18,14 @@ import org.sopt.bofit.global.file.dto.request.UpdateImageRequest;
 import org.sopt.bofit.global.file.util.ImageValidator;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.IntStream;
+
+import static org.sopt.bofit.global.exception.constant.PostErrorCode.POST_UNAUTHORIZED;
 
 @Service
 @RequiredArgsConstructor
@@ -55,9 +52,9 @@ public class PostService {
 
         Post post = postWriter.createPost(userId, command.title(), command.content(), command.category());
 
-        IntStream.range(0, command.imageUrls().size())
+        IntStream.range(0, command.imageKeys().size())
                 .forEach(sequence -> postImageWriter
-                        .create(post, command.imageUrls().get(sequence), sequence));
+                        .create(post, command.imageKeys().get(sequence), sequence));
 
         return PostCreateResponse.from(post.getId());
     }

--- a/src/main/java/org/sopt/bofit/domain/post/service/dto/request/PostCreateCommand.java
+++ b/src/main/java/org/sopt/bofit/domain/post/service/dto/request/PostCreateCommand.java
@@ -6,6 +6,6 @@ public record PostCreateCommand(
         String title,
         String content,
         String category,
-        List<String> imageUrls
+        List<String> imageKeys
 ) {
 }

--- a/src/main/java/org/sopt/bofit/global/config/SqsConfig.java
+++ b/src/main/java/org/sopt/bofit/global/config/SqsConfig.java
@@ -1,13 +1,8 @@
 package org.sopt.bofit.global.config;
 
-import static org.sopt.bofit.global.config.ThreadPoolConfig.MESSAGE_CONSUMER_POOL;
-import static org.sopt.bofit.global.config.ThreadPoolConfig.MESSAGE_PROVIDER_POOL;
-
 import io.awspring.cloud.sqs.config.SqsMessageListenerContainerFactory;
 import io.awspring.cloud.sqs.listener.acknowledgement.handler.AcknowledgementMode;
 import io.awspring.cloud.sqs.operations.SqsTemplate;
-import java.time.Duration;
-import java.util.concurrent.Executor;
 import org.sopt.bofit.global.config.properties.AWSProperties;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
@@ -17,7 +12,14 @@ import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.core.client.config.SdkAdvancedAsyncClientOption;
+import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.sqs.SqsAsyncClient;
+
+import java.time.Duration;
+import java.util.concurrent.Executor;
+
+import static org.sopt.bofit.global.config.ThreadPoolConfig.MESSAGE_CONSUMER_POOL;
+import static org.sopt.bofit.global.config.ThreadPoolConfig.MESSAGE_PROVIDER_POOL;
 
 @Configuration
 public class SqsConfig {
@@ -31,6 +33,7 @@ public class SqsConfig {
             AwsBasicCredentials.create(awsProperties.credentials().accessKey(), awsProperties.credentials().secretKey())
         );
         return SqsAsyncClient.builder()
+                .region(Region.of(awsProperties.region().value()))
             .credentialsProvider(myCredentialsProvider)
             .asyncConfiguration(
                 config -> config.advancedOption(

--- a/src/main/java/org/sopt/bofit/global/config/properties/AWSProperties.java
+++ b/src/main/java/org/sopt/bofit/global/config/properties/AWSProperties.java
@@ -7,9 +7,11 @@ import org.springframework.boot.context.properties.bind.Name;
 public record AWSProperties(
         Credentials credentials,
         Region region,
-        S3 s3
+        S3 s3,
+        CloudFront cloudFront
 ) {
     public record Credentials(String accessKey, String secretKey) {}
     public record Region(@Name("static") String value) {}
     public record S3(String bucket) {}
+    public record CloudFront(String domain) {}
 }

--- a/src/main/java/org/sopt/bofit/global/file/dto/request/UpdateImageRequest.java
+++ b/src/main/java/org/sopt/bofit/global/file/dto/request/UpdateImageRequest.java
@@ -1,10 +1,10 @@
 package org.sopt.bofit.global.file.dto.request;
 
-import static org.sopt.bofit.global.file.constant.ImageConstant.MAX_IMAGE_URL_LENGTH;
-
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.PositiveOrZero;
 import org.hibernate.validator.constraints.Length;
+
+import static org.sopt.bofit.global.file.constant.ImageConstant.MAX_IMAGE_URL_LENGTH;
 
 public record UpdateImageRequest(
         @Schema(description = "이미지 ID")
@@ -12,7 +12,7 @@ public record UpdateImageRequest(
 
         @Length(max = MAX_IMAGE_URL_LENGTH, message = "이미지 url 의 최대 길이 ({max}) 를 초과했습니다.")
         @Schema(description = "새 이미지 URL (변경 없으면 null)")
-        String imageUrl,
+        String imageKey,
 
         @Schema(description = "순서, 0부터 시작")
         @PositiveOrZero

--- a/src/main/java/org/sopt/bofit/global/file/dto/response/PresignedUrlDto.java
+++ b/src/main/java/org/sopt/bofit/global/file/dto/response/PresignedUrlDto.java
@@ -1,0 +1,11 @@
+package org.sopt.bofit.global.file.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record PresignedUrlDto(
+        @Schema(description = "presigned URL")
+        String presignedUrl,
+
+        @Schema(description = "key 값")
+        String key
+) {}

--- a/src/main/java/org/sopt/bofit/global/file/dto/response/PresignedUrlResponse.java
+++ b/src/main/java/org/sopt/bofit/global/file/dto/response/PresignedUrlResponse.java
@@ -3,9 +3,9 @@ package org.sopt.bofit.global.file.dto.response;
 import java.util.List;
 
 public record PresignedUrlResponse(
-        List<String> presignedUrls
+        List<PresignedUrlDto> presignedUrlDtos
 ) {
-    public static PresignedUrlResponse of(List<String> urls){
-        return new PresignedUrlResponse(urls);
+    public static PresignedUrlResponse of(List<PresignedUrlDto> presignedUrlDtos) {
+        return new PresignedUrlResponse(presignedUrlDtos);
     }
 }

--- a/src/main/java/org/sopt/bofit/global/file/service/FileService.java
+++ b/src/main/java/org/sopt/bofit/global/file/service/FileService.java
@@ -1,13 +1,15 @@
 package org.sopt.bofit.global.file.service;
 
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.sopt.bofit.global.file.constant.ContentTypeConstants;
+import org.sopt.bofit.global.file.dto.response.PresignedUrlDto;
 import org.sopt.bofit.global.file.dto.response.PresignedUrlResponse;
 import org.sopt.bofit.global.file.util.ContentTypeUtil;
 import org.sopt.bofit.global.file.util.KeyGenerator;
 import org.sopt.bofit.global.file.util.PresignedUrlCreator;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -19,13 +21,14 @@ public class FileService {
 
     public PresignedUrlResponse generatePresignedUrls(List<String> contentTypes) {
 
-        List<String> urls = contentTypes.stream()
+        List<PresignedUrlDto> urls = contentTypes.stream()
                 .map(ct -> {
                     ContentTypeConstants category = ContentTypeConstants.from(ct);
                     ContentTypeUtil.validateContentType(ct);
                     String ext = ContentTypeUtil.extensionOf(ct);
                     String key = keyGenerator.generate(category, ext);
-                    return presignedUrlCreator.createPutUrl(key, ct);
+                    String presignedUrl = presignedUrlCreator.createPutUrl(key, ct);
+                    return new PresignedUrlDto(presignedUrl, key);
                 })
                 .toList();
 

--- a/src/main/java/org/sopt/bofit/global/file/util/CloudFrontUrlCreator.java
+++ b/src/main/java/org/sopt/bofit/global/file/util/CloudFrontUrlCreator.java
@@ -1,0 +1,18 @@
+package org.sopt.bofit.global.file.util;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.bofit.global.config.properties.AWSProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CloudFrontUrlCreator {
+
+    private final AWSProperties awsProperties;
+
+    public String createCloudFrontUrl(String key) {
+        String cloudFrontDomain = awsProperties.cloudFront().domain();
+        return cloudFrontDomain + "/" + key;
+    }
+
+}

--- a/src/main/java/org/sopt/bofit/global/file/util/KeyGenerator.java
+++ b/src/main/java/org/sopt/bofit/global/file/util/KeyGenerator.java
@@ -1,8 +1,9 @@
 package org.sopt.bofit.global.file.util;
 
-import java.util.UUID;
 import org.sopt.bofit.global.file.constant.ContentTypeConstants;
 import org.springframework.stereotype.Component;
+
+import java.util.UUID;
 
 @Component
 public class KeyGenerator {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,6 +19,8 @@ cloud:
       static: ap-northeast-2
     s3:
       bucket: bofit-bucket
+    cloudfront:
+      domain: ${CLOUDFRONT_DOMAIN_NAME}
     stack:
       auto: false
 spring:


### PR DESCRIPTION
## Related issue 🛠
- closed #214
  


## Work Description 📝
- 커뮤니티에서 이미지가 있는 게시글 조회 시에 이미지가 버벅거리면서 응답에 지연이 발생하였고, 이를 해결하기 위해 AWS에서 제공하는 CDN인 CloudFront를 활용하였습니다.
- 기존에는 Browser -> S3로 바로 요청을 보냈지만, 이제는 Browser -> CloudFront -> S3의 형태로 요청이 전달되어 사용자의 위치에서 가장 가까운 엣지 서버로부터 리소스를 받아와 응답 속도가 개선됩니다.
- 이를 활용하기 위해 기존에 presigned URL을 발급하고 클라이언트가 업로드 요청을 보낸 뒤, 그 URL을 DB에 저장하던 로직에서 URL의 prefix 부분을 S3 버킷 url이 아닌 CloudFront 도메인의 url로 저장해야 하기 때문에 게시글 생성/수정, 댓글 생성/수정, 대댓글 생성/수정 요청 DTO를 imageUrl이 아닌 key 값으로 변경하고, presigned URL 발급 응답에 key 값을 추가했습니다.
- 추가로, `build.gradle`에 AWS 관련 의존성 버전이 섞여있어 이를 통일했고, `SqsConfig`에 region 설정을 추가했습니다.

